### PR TITLE
refactor(schedules): replace target_filter JSONB with target_status enum

### DIFF
--- a/features/events/actions/duplicate-event.ts
+++ b/features/events/actions/duplicate-event.ts
@@ -120,7 +120,7 @@ export async function duplicateEvent(
       }
     }
 
-    // Copy schedules with remapped group IDs in target_filter, reset status
+    // Copy schedules and reset status to draft
     const { data: originalSchedules } = await supabase
       .from('schedules')
       .select('*')
@@ -132,24 +132,9 @@ export async function duplicateEvent(
         const { id, created_at, updated_at, sent_at, ...scheduleFields } =
           schedule;
 
-        // Remap group_ids inside target_filter
-        let targetFilter = schedule.target_filter as Record<
-          string,
-          unknown
-        > | null;
-        if (targetFilter?.group_ids && Array.isArray(targetFilter.group_ids)) {
-          targetFilter = {
-            ...targetFilter,
-            group_ids: (targetFilter.group_ids as string[])
-              .map((gid) => groupIdMap.get(gid))
-              .filter(Boolean),
-          };
-        }
-
         return {
           ...scheduleFields,
           event_id: newEvent.id,
-          target_filter: targetFilter,
           status: 'draft' as const,
           sent_at: null,
         };

--- a/features/schedules/actions/execute-schedule.ts
+++ b/features/schedules/actions/execute-schedule.ts
@@ -124,7 +124,7 @@ export async function executeSchedule(
     // 7. Apply target filter
     const targetedGuests = filterGuestsByTarget(
       allGuests,
-      schedule.targetFilter,
+      schedule.targetStatus,
     );
 
     if (targetedGuests.length === 0) {

--- a/features/schedules/actions/schedules.ts
+++ b/features/schedules/actions/schedules.ts
@@ -210,6 +210,7 @@ export async function createDefaultSchedules(
       ),
       status: 'draft' as const,
       delivery_method: 'whatsapp' as const,
+      target_status: schedule.targetStatus ?? null,
     }));
 
     const { error: insertError } = await supabase

--- a/features/schedules/components/message-content-card.tsx
+++ b/features/schedules/components/message-content-card.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { ImageIcon, Send } from 'lucide-react';
+import { ImageIcon, Send, TriangleAlert } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
-  CardAction,
   CardContent,
+  CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
@@ -16,9 +15,13 @@ import {
 
 import { type EventApp } from '@/features/events/schemas';
 import { sendWhatsAppTestMessage } from '../actions';
-import type { DeliveryMethod, WhatsAppTemplateApp } from '../schemas';
+import type { WhatsAppTemplateApp } from '../schemas';
+import { resolveTemplateBodyForPreview } from '../utils/parameter-resolvers';
 
-function resolveSourcePath(source: string, event: EventApp | null): string | null {
+function resolveSourcePath(
+  source: string,
+  event: EventApp | null,
+): string | null {
   if (!event) return null;
   const context: Record<string, unknown> = { event };
   const parts = source.split('.');
@@ -30,11 +33,6 @@ function resolveSourcePath(source: string, event: EventApp | null): string | nul
   return typeof current === 'string' ? current : null;
 }
 
-const DELIVERY_METHOD_LABELS: Record<DeliveryMethod, string> = {
-  whatsapp: 'WhatsApp',
-  sms: 'SMS',
-};
-
 const chatBgStyle: React.CSSProperties = {
   backgroundColor: '#E5DDD5',
   backgroundImage: `url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='10' cy='10' r='1' fill='%23C9BBAD' fill-opacity='0.4'/%3E%3C/svg%3E")`,
@@ -42,11 +40,17 @@ const chatBgStyle: React.CSSProperties = {
 
 interface MessageContentCardProps {
   template: WhatsAppTemplateApp | null;
-  deliveryMethod?: DeliveryMethod;
   event: EventApp | null;
 }
 
-export function MessageContentCard({ template, deliveryMethod, event }: MessageContentCardProps) {
+export function MessageContentCard({
+  template,
+  event,
+}: MessageContentCardProps) {
+  const { resolvedBody, hasMissingFields } = template
+    ? resolveTemplateBodyForPreview(template, event)
+    : { resolvedBody: '', hasMissingFields: false };
+
   const headerPlaceholder = template?.parameters?.headerPlaceholders?.[0];
   const imageUrl = headerPlaceholder?.source
     ? resolveSourcePath(headerPlaceholder.source, event)
@@ -61,8 +65,7 @@ export function MessageContentCard({ template, deliveryMethod, event }: MessageC
     toast.promise(promise, {
       loading: 'Sending test message...',
       success: (data) => data.message,
-      error: (err) =>
-        err instanceof Error ? err.message : 'Failed to send.',
+      error: (err) => (err instanceof Error ? err.message : 'Failed to send.'),
     });
   };
 
@@ -70,15 +73,18 @@ export function MessageContentCard({ template, deliveryMethod, event }: MessageC
     <Card>
       <CardHeader>
         <CardTitle>Message Preview</CardTitle>
-        <CardAction>
-          <Badge variant="outline">{deliveryMethod ? DELIVERY_METHOD_LABELS[deliveryMethod] : 'N/A'}</Badge>
-        </CardAction>
+        <CardDescription>
+          The message guests will receive for this schedule.
+        </CardDescription>
       </CardHeader>
       <CardContent>
         {/* WhatsApp phone mockup */}
         <div className="overflow-hidden rounded-xl border border-zinc-200 shadow-sm">
           {/* Chat area */}
-          <div className="flex min-h-[180px] flex-col gap-1 px-3 py-4" style={chatBgStyle}>
+          <div
+            className="flex min-h-[180px] flex-col gap-1 px-3 py-4"
+            style={chatBgStyle}
+          >
             {template === null ? (
               <div className="flex min-h-[140px] flex-1 items-center justify-center">
                 <p className="rounded-lg bg-white/80 px-3 py-1.5 text-xs text-zinc-500">
@@ -88,37 +94,49 @@ export function MessageContentCard({ template, deliveryMethod, event }: MessageC
             ) : (
               <>
                 {/* Message bubble */}
-                <div className="relative self-end max-w-[85%]">
+                <div className="relative max-w-[85%] self-end">
                   {/* Bubble tail */}
                   <div
-                    className="absolute -right-[7px] top-0 h-0 w-0"
+                    className="absolute top-0 -right-[7px] h-0 w-0"
                     style={{
                       borderLeft: '8px solid #DCF8C6',
                       borderBottom: '8px solid transparent',
                     }}
                   />
-                  <div className="overflow-hidden rounded-l-xl rounded-br-xl shadow-sm" style={{ backgroundColor: '#DCF8C6' }}>
+                  <div
+                    className="overflow-hidden rounded-l-xl rounded-br-xl shadow-sm"
+                    style={{ backgroundColor: '#DCF8C6' }}
+                  >
                     {/* Image header */}
-                    {template.headerType?.toUpperCase() === 'IMAGE' && (
-                      imageUrl ? (
+                    {template.headerType?.toUpperCase() === 'IMAGE' &&
+                      (imageUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element
-                        <img src={imageUrl} alt="Header" className="w-full object-contain" style={{ maxHeight: 120 }} />
+                        <img
+                          src={imageUrl}
+                          alt="Header"
+                          className="w-full object-contain"
+                          style={{ maxHeight: 120 }}
+                        />
                       ) : (
                         <div className="flex h-28 w-full flex-col items-center justify-center gap-1 bg-zinc-300/60">
                           <ImageIcon className="h-7 w-7 text-zinc-400" />
-                          <span className="text-[10px] text-zinc-400">Image</span>
+                          <span className="text-[10px] text-zinc-400">
+                            Image
+                          </span>
                         </div>
-                      )
-                    )}
+                      ))}
                     {/* Text content */}
                     <div className="px-3 py-2">
                       {template.headerText && (
-                        <p className="mb-1 text-sm font-semibold leading-tight text-zinc-800">
+                        <p className="mb-1 text-sm leading-tight font-semibold text-zinc-800">
                           {template.headerText}
                         </p>
                       )}
-                      <p className="text-sm leading-relaxed text-zinc-800 whitespace-pre-wrap" dir="rtl">
-                        {template.bodyText}
+                      <p
+                        className="text-sm leading-relaxed whitespace-pre-wrap text-zinc-800"
+                        dir="rtl"
+                      >
+                        {resolvedBody}
                       </p>
                     </div>
                   </div>
@@ -126,15 +144,23 @@ export function MessageContentCard({ template, deliveryMethod, event }: MessageC
 
                 {/* Footer text */}
                 {template.footerText && (
-                  <p className="self-end max-w-[85%] pr-1 text-[11px] italic text-zinc-500">
+                  <p className="max-w-[85%] self-end pr-1 text-[11px] text-zinc-500 italic">
                     {template.footerText}
                   </p>
                 )}
               </>
             )}
           </div>
-
         </div>
+        {hasMissingFields && (
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+            <span>
+              Some event data is missing. Update your event details to see the
+              full preview.
+            </span>
+          </div>
+        )}
       </CardContent>
       <CardFooter>
         <Button variant="outline" onClick={handleSendTest}>

--- a/features/schedules/components/schedule-tab-content.tsx
+++ b/features/schedules/components/schedule-tab-content.tsx
@@ -3,6 +3,7 @@ import { type ScheduleApp, type WhatsAppTemplateApp } from '../schemas';
 import { MessageContentCard } from './message-content-card';
 import { ScheduleDetailsCard } from './schedule-details-card';
 import { ScheduleStatusCard } from './schedule-status-card';
+import { TargetAudienceCard } from './target-audience-card';
 
 interface ScheduleTabContentProps {
   schedule: ScheduleApp;
@@ -22,10 +23,10 @@ export function ScheduleTabContent({
       <div className="flex flex-col gap-4">
         <ScheduleStatusCard schedule={schedule} />
         <ScheduleDetailsCard schedule={schedule} eventDate={eventDate} />
+        <TargetAudienceCard targetStatus={schedule.targetStatus} />
       </div>
       <MessageContentCard
         template={template}
-        deliveryMethod={schedule.deliveryMethod}
         event={event}
       />
     </div>

--- a/features/schedules/components/target-audience-card.tsx
+++ b/features/schedules/components/target-audience-card.tsx
@@ -1,0 +1,55 @@
+import { Users } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+interface TargetAudienceCardProps {
+  targetStatus?: 'pending' | 'confirmed' | null;
+}
+
+export function TargetAudienceCard({ targetStatus }: TargetAudienceCardProps) {
+  const config =
+    targetStatus === 'confirmed'
+      ? {
+          label: 'Confirmed Guests',
+          description: 'Only guests who have confirmed their attendance.',
+          className: 'bg-green-100 text-green-800 border-green-200',
+        }
+      : targetStatus === 'pending'
+        ? {
+            label: 'Pending Guests',
+            description: 'Only guests who have not yet responded.',
+            className: 'bg-amber-100 text-amber-800 border-amber-200',
+          }
+        : {
+            label: 'All Guests',
+            description: 'All guests on the guest list will receive this message.',
+            className: '',
+          };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5 text-primary" />
+          Target Audience
+        </CardTitle>
+        <CardDescription>Who will receive this message</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-3">
+          <Badge variant="secondary" className={config.className}>
+            {config.label}
+          </Badge>
+          <p className="text-sm text-muted-foreground">{config.description}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/schedules/constants/index.ts
+++ b/features/schedules/constants/index.ts
@@ -5,6 +5,7 @@ export type DefaultScheduleConfig = {
   messageType: MessageType;      // UI category (not stored in DB)
   daysOffset: number;            // Negative = before event, positive = after
   defaultTime: string;           // HH:MM format
+  targetStatus?: 'pending' | 'confirmed';
 };
 
 // Default schedules for wedding events
@@ -15,12 +16,14 @@ export const WEDDING_DEFAULT_SCHEDULES: DefaultScheduleConfig[] = [
     messageType: 'initial_invitation',
     daysOffset: -90,
     defaultTime: '10:00',
+    targetStatus: 'pending',
   },
   {
     templateId: '99adcc20-9e1b-4b6d-afe9-bd6b387a4cd9',
     messageType: 'confirmation_casual_v1_he',
     daysOffset: -14,
     defaultTime: '10:00',
+    targetStatus: 'pending',
   },
   // Add more schedules as needed:
   // { templateId: 'uuid-2', messageType: 'first_confirmation', daysOffset: -45, defaultTime: '10:00' },

--- a/features/schedules/index.ts
+++ b/features/schedules/index.ts
@@ -34,8 +34,6 @@ export {
   filterGuestsByTarget,
   validatePhoneNumber,
   formatPhoneE164,
-  buildTemplateParameters,
-  type TemplateParameter,
 } from './utils';
 
 // Schemas/Types

--- a/features/schedules/schemas/index.ts
+++ b/features/schedules/schemas/index.ts
@@ -194,15 +194,6 @@ export const MessageTemplateAppToDbSchema =
 // SCHEDULES
 // =====================================================
 
-// Target filter schema for schedule targeting
-export const TargetFilterSchema = z.object({
-  guestStatus: z.array(z.enum(['pending', 'confirmed', 'declined'])).optional(),
-  tags: z.array(z.string()).optional(),
-  groupIds: z.array(z.uuid()).optional(),
-});
-
-export type TargetFilter = z.infer<typeof TargetFilterSchema>;
-
 // Custom content override schema
 export const CustomContentSchema = z.object({
   subject: z.string().optional(),
@@ -221,7 +212,7 @@ export const ScheduleAppSchema = z.object({
   scheduledDate: z.string(),
   status: z.enum(SCHEDULE_STATUSES).default('draft'),
   sentAt: z.string().nullable().optional(),
-  targetFilter: TargetFilterSchema.optional(),
+  targetStatus: z.enum(['pending', 'confirmed']).nullable().optional(),
   templateId: z.uuid().nullable().optional(),
   deliveryMethod: z.enum(DELIVERY_METHODS).default('whatsapp'),
   allowDisable: z.boolean().default(false),
@@ -232,14 +223,13 @@ export const ScheduleAppSchema = z.object({
 export type ScheduleApp = z.infer<typeof ScheduleAppSchema>;
 
 // --- DB-Level Schema (snake_case) ---
-// Note: target_filter is JSONB in Supabase
 export const ScheduleDbSchema = z.object({
   id: z.uuid(),
   event_id: z.uuid(),
   scheduled_date: z.string(),
   status: z.enum(SCHEDULE_STATUSES).default('draft'),
   sent_at: z.string().nullable(),
-  target_filter: z.record(z.string(), z.unknown()).nullable(),
+  target_status: z.enum(['pending', 'confirmed']).nullable(),
   template_id: z.uuid().nullable(),
   delivery_method: z.enum(DELIVERY_METHODS).default('whatsapp'),
   allow_disable: z.boolean().default(false),
@@ -256,13 +246,7 @@ export const ScheduleDbToAppSchema = ScheduleDbSchema.transform((db) => ({
   scheduledDate: db.scheduled_date,
   status: db.status,
   sentAt: db.sent_at ?? undefined,
-  targetFilter: db.target_filter
-    ? TargetFilterSchema.parse({
-      guestStatus: db.target_filter.guest_status,
-      tags: db.target_filter.tags,
-      groupIds: db.target_filter.group_ids,
-    })
-    : undefined,
+  targetStatus: db.target_status ?? null,
   templateId: db.template_id ?? undefined,
   deliveryMethod: db.delivery_method,
   allowDisable: db.allow_disable,
@@ -276,7 +260,7 @@ export const ScheduleUpsertSchema = z.object({
   eventId: z.uuid(),
   scheduledDate: z.string(),
   status: z.enum(SCHEDULE_STATUSES).optional(),
-  targetFilter: TargetFilterSchema.optional(),
+  targetStatus: z.enum(['pending', 'confirmed']).nullable().optional(),
   templateId: z.uuid().nullable().optional(),
   deliveryMethod: z.enum(DELIVERY_METHODS).optional(),
   allowDisable: z.boolean().optional(),
@@ -292,13 +276,7 @@ export const ScheduleAppToDbSchema = ScheduleUpsertSchema.transform((app) => {
   dbData.event_id = app.eventId;
   dbData.scheduled_date = app.scheduledDate;
   if (app.status !== undefined) dbData.status = app.status;
-  if (app.targetFilter !== undefined) {
-    dbData.target_filter = {
-      guest_status: app.targetFilter.guestStatus,
-      tags: app.targetFilter.tags,
-      group_ids: app.targetFilter.groupIds,
-    };
-  }
+  if (app.targetStatus !== undefined) dbData.target_status = app.targetStatus;
   if (app.templateId !== undefined) dbData.template_id = app.templateId ?? null;
   if (app.deliveryMethod !== undefined)
     dbData.delivery_method = app.deliveryMethod;

--- a/features/schedules/utils/index.ts
+++ b/features/schedules/utils/index.ts
@@ -1,5 +1,4 @@
 import type { GuestApp } from '@/features/guests/schemas';
-import type { TargetFilter } from '../schemas';
 
 // Re-export parameter resolution utilities
 export {
@@ -46,36 +45,15 @@ export function calculateScheduledDate(
  * Filters guests based on targeting criteria.
  *
  * @param guests - Array of guests to filter
- * @param targetFilter - Optional targeting criteria (RSVP status, group IDs)
+ * @param targetStatus - Optional RSVP status to filter by (null means all guests)
  * @returns Filtered array of guests
  */
 export function filterGuestsByTarget(
   guests: GuestApp[],
-  targetFilter?: TargetFilter,
+  targetStatus?: 'pending' | 'confirmed' | null,
 ): GuestApp[] {
-  if (!targetFilter) {
-    return guests;
-  }
-
-  let filtered = guests;
-
-  // Filter by RSVP status
-  if (targetFilter.guestStatus && targetFilter.guestStatus.length > 0) {
-    filtered = filtered.filter((guest) =>
-      targetFilter.guestStatus!.includes(guest.rsvpStatus),
-    );
-  }
-
-  // Filter by group IDs
-  if (targetFilter.groupIds && targetFilter.groupIds.length > 0) {
-    filtered = filtered.filter(
-      (guest) => guest.groupId && targetFilter.groupIds!.includes(guest.groupId),
-    );
-  }
-
-  // Tags filtering not implemented yet (future enhancement)
-
-  return filtered;
+  if (!targetStatus) return guests;
+  return guests.filter((guest) => guest.rsvpStatus === targetStatus);
 }
 
 /**
@@ -136,70 +114,3 @@ export function formatPhoneE164(phone: string): string {
   return '+972' + cleaned;
 }
 
-/**
- * Template parameter type for WhatsApp messages.
- * Supports text and media types (image, video, document).
- */
-export type MediaParameter =
-  | { type: 'text'; text: string }
-  | { type: 'image'; image: { link: string } }
-  | { type: 'video'; video: { link: string } }
-  | { type: 'document'; document: { link: string; filename?: string } };
-
-export type TemplateParameter = MediaParameter;
-
-/**
- * Builds template parameters by replacing placeholders with actual values.
- * Supports common placeholders: {{guest_name}}, {{event_title}}, {{event_date}}
- *
- * @param bodyText - Template body text with placeholders
- * @param eventTitle - Event title
- * @param eventDate - Event date (ISO string)
- * @param guestName - Guest name
- * @returns Array of template parameters for WhatsApp API
- */
-export function buildTemplateParameters(
-  bodyText: string,
-  eventTitle: string,
-  eventDate: string,
-  guestName: string,
-): TemplateParameter[] {
-  const parameters: TemplateParameter[] = [];
-
-  // Extract placeholders using regex
-  const placeholderRegex = /\{\{(\w+)\}\}/g;
-  let match;
-
-  while ((match = placeholderRegex.exec(bodyText)) !== null) {
-    const placeholder = match[1];
-    let value = '';
-
-    switch (placeholder) {
-      case 'guest_name':
-        value = guestName;
-        break;
-      case 'event_title':
-        value = eventTitle;
-        break;
-      case 'event_date':
-        // Format date to readable format
-        value = new Date(eventDate).toLocaleDateString('en-US', {
-          weekday: 'long',
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        });
-        break;
-      default:
-        // Unknown placeholder - use empty string
-        value = '';
-    }
-
-    parameters.push({
-      type: 'text',
-      text: value,
-    });
-  }
-
-  return parameters;
-}

--- a/features/schedules/utils/index.ts
+++ b/features/schedules/utils/index.ts
@@ -6,6 +6,7 @@ export {
   buildDynamicHeaderParameters,
   buildDynamicButtonParameters,
   extractPlaceholders,
+  type MediaParameter,
   type ParameterResolutionContext,
   type ButtonComponent,
 } from './parameter-resolvers';

--- a/features/schedules/utils/parameter-resolvers.ts
+++ b/features/schedules/utils/parameter-resolvers.ts
@@ -1,6 +1,7 @@
 import type { GuestApp } from '@/features/guests/schemas';
 import type { GroupApp } from '@/features/guests/schemas';
-import type { ScheduleApp } from '@/features/schedules/schemas';
+import type { EventApp } from '@/features/events/schemas';
+import type { ScheduleApp, WhatsAppTemplateApp } from '@/features/schedules/schemas';
 import type {
   PlaceholderConfig,
   HeaderPlaceholderConfig,
@@ -313,4 +314,53 @@ export function buildDynamicButtonParameters(
       return { type: 'text' as const, text: resolved };
     }),
   }));
+}
+
+/**
+ * Resolve a template body for preview purposes.
+ *
+ * Guest/group placeholders are shown as labelled tokens (e.g. `[Name]`) because
+ * no specific guest is selected at preview time. Event placeholders are resolved
+ * against the provided event.
+ */
+export function resolveTemplateBodyForPreview(
+  template: WhatsAppTemplateApp,
+  event: EventApp | null,
+): { resolvedBody: string; hasMissingFields: boolean } {
+  const placeholders = template.parameters?.placeholders;
+
+  if (!placeholders || Object.keys(placeholders).length === 0) {
+    return { resolvedBody: template.bodyText, hasMissingFields: false };
+  }
+
+  let hasMissingFields = false;
+  const resolvedValues: string[] = [];
+  const mockContext = { event: event ?? {}, guest: {} } as unknown as ParameterResolutionContext;
+
+  for (const [name, config] of Object.entries(placeholders)) {
+    const source = config.source ?? name;
+
+    if (source.startsWith('guest.') || source.startsWith('group.')) {
+      const fieldName = source.split('.').pop() ?? source;
+      const label = fieldName.charAt(0).toUpperCase() + fieldName.slice(1);
+      resolvedValues.push(`[${label}]`);
+    } else {
+      const rawValue = event ? getValueByPath({ event }, source) : undefined;
+
+      if ((rawValue === null || rawValue === undefined) && !config.fallback) {
+        hasMissingFields = true;
+        resolvedValues.push('…');
+      } else {
+        const resolved = resolvePlaceholder(name, config, mockContext);
+        resolvedValues.push(resolved || '…');
+      }
+    }
+  }
+
+  let resolvedBody = template.bodyText;
+  resolvedValues.forEach((value, index) => {
+    resolvedBody = resolvedBody.replaceAll(`{{${index + 1}}}`, value);
+  });
+
+  return { resolvedBody, hasMissingFields };
 }

--- a/features/schedules/utils/parameter-resolvers.ts
+++ b/features/schedules/utils/parameter-resolvers.ts
@@ -10,7 +10,11 @@ import type {
   DateFormatOptions,
   CurrencyOptions,
 } from '@/features/schedules/schemas/template-parameters';
-import type { MediaParameter } from '@/features/schedules/utils';
+export type MediaParameter =
+  | { type: 'text'; text: string }
+  | { type: 'image'; image: { link: string } }
+  | { type: 'video'; video: { link: string } }
+  | { type: 'document'; document: { link: string; filename?: string } };
 
 /**
  * Context available for resolving template parameters

--- a/lib/services/message-processor.ts
+++ b/lib/services/message-processor.ts
@@ -187,7 +187,7 @@ async function processSingleSchedule(
   );
 
   // 6. Apply target filter and validate phone numbers
-  const targetedGuests = filterGuestsByTarget(allGuests, schedule.targetFilter);
+  const targetedGuests = filterGuestsByTarget(allGuests, schedule.targetStatus);
 
   if (targetedGuests.length === 0) {
     await revertOrCancel(supabase, schedule.id, rawScheduleWithEvent.scheduled_date);


### PR DESCRIPTION
Simplify schedule targeting from a flexible JSONB target_filter (with guestStatus, tags, groupIds) down to a single target_status enum column ('pending' | 'confirmed' | null). Adds a TargetAudienceCard component to display targeting info, and resolves template body placeholders for message preview. Removes dead buildTemplateParameters utility.