### PR TITLE
feat(event-details): simplify card headers and update primary color t…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,8 +52,8 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.645 0.246 16.439);
-  --primary-foreground: oklch(0.969 0.015 12.422);
+  --primary: oklch(0.55 0.14 185);
+  --primary-foreground: oklch(0.98 0.01 185);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
@@ -65,7 +65,7 @@
   --success-foreground: oklch(0.98 0.01 150);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.645 0.246 16.439);
+  --ring: oklch(0.55 0.14 185);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -73,12 +73,12 @@
   --chart-5: oklch(0.769 0.188 70.08);
   --sidebar: oklch(1 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.645 0.246 16.439);
-  --sidebar-primary-foreground: oklch(0.969 0.015 12.422);
+  --sidebar-primary: oklch(0.55 0.14 185);
+  --sidebar-primary-foreground: oklch(0.98 0.01 185);
   --sidebar-accent: oklch(0.967 0.001 286.375);
   --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
   --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.645 0.246 16.439);
+  --sidebar-ring: oklch(0.55 0.14 185);
   --header-height: 3.5rem;
 }
 
@@ -89,8 +89,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.21 0.006 285.885);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.645 0.246 16.439);
-  --primary-foreground: oklch(0.969 0.015 12.422);
+  --primary: oklch(0.65 0.14 185);
+  --primary-foreground: oklch(0.15 0.03 185);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.274 0.006 286.033);
@@ -102,7 +102,7 @@
   --success-foreground: oklch(0.98 0.01 150);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.645 0.246 16.439);
+  --ring: oklch(0.65 0.14 185);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -110,12 +110,12 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.645 0.246 16.439);
-  --sidebar-primary-foreground: oklch(0.969 0.015 12.422);
+  --sidebar-primary: oklch(0.65 0.14 185);
+  --sidebar-primary-foreground: oklch(0.15 0.03 185);
   --sidebar-accent: oklch(0.274 0.006 286.033);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.645 0.246 16.439);
+  --sidebar-ring: oklch(0.65 0.14 185);
 }
 
 /* Flat design: zero out Tailwind's shadow composition variables.

--- a/features/events/components/event-details/couple-card.tsx
+++ b/features/events/components/event-details/couple-card.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useFormContext } from 'react-hook-form';
-import { IconUsers } from '@tabler/icons-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { cardHover } from '@/lib/utils';
@@ -22,12 +21,7 @@ export function CoupleCard() {
   return (
     <Card className={cardHover}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-lg">
-          <div className="rounded-md bg-primary/10 p-1.5">
-            <IconUsers size={16} className="text-primary" />
-          </div>
-          The Couple
-        </CardTitle>
+        <CardTitle className="text-xl font-bold">The Couple</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         <div className="space-y-4">

--- a/features/events/components/event-details/date-time-card.tsx
+++ b/features/events/components/event-details/date-time-card.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useFormContext } from 'react-hook-form';
-import { IconCalendarEvent } from '@tabler/icons-react';
 import {
   Card,
   CardContent,
@@ -43,12 +42,7 @@ export function DateTimeCard() {
   return (
     <Card className={cardHover}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-lg">
-          <div className="rounded-md bg-primary/10 p-1.5">
-            <IconCalendarEvent size={16} className="text-primary" />
-          </div>
-          Date & Time
-        </CardTitle>
+        <CardTitle className="text-xl font-bold">Date & Time</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 gap-8">

--- a/features/events/components/event-details/digital-gift-card.tsx
+++ b/features/events/components/event-details/digital-gift-card.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useFormContext } from 'react-hook-form';
-import { IconGift } from '@tabler/icons-react';
 import { Switch } from '@/components/ui/switch';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -24,12 +23,7 @@ export function DigitalGiftCard() {
   return (
     <Card className={cardHover}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-lg">
-          <div className="rounded-md bg-primary/10 p-1.5">
-            <IconGift size={16} className="text-primary" />
-          </div>
-          Digital Gift
-        </CardTitle>
+        <CardTitle className="text-xl font-bold">Digital Gift</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="space-y-2">

--- a/features/events/components/event-details/event-details-wrapper.tsx
+++ b/features/events/components/event-details/event-details-wrapper.tsx
@@ -120,7 +120,7 @@ export function EventDetailsWrapper({ event }: EventDetailsWrapperProps) {
 
   return (
     <Form {...form}>
-      <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
+      <form id={formId} onSubmit={form.handleSubmit(onSubmit)} className="mx-auto max-w-5xl">
         <EventDetailsHeader
           formId={formId}
           isDirty={isDirty}

--- a/features/events/components/event-details/event-invitation-card.tsx
+++ b/features/events/components/event-details/event-invitation-card.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import {
   IconLoader2,
-  IconMail,
   IconPhoto,
   IconUpload,
   IconX,
@@ -120,12 +119,7 @@ export function EventInvitationCard({
   return (
     <Card className={cardHover}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-lg">
-          <div className="bg-primary/10 rounded-md p-1.5">
-            <IconMail size={16} className="text-primary" />
-          </div>
-          Event Invitation
-        </CardTitle>
+        <CardTitle className="text-xl font-bold">Event Invitation</CardTitle>
         <CardDescription>
           This image will be sent to guests as the first message they receive
           when invited to your event.

--- a/features/events/components/event-details/guest-experience-card.tsx
+++ b/features/events/components/event-details/guest-experience-card.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useFormContext } from 'react-hook-form';
-import { IconToolsKitchen2 } from '@tabler/icons-react';
 import { Switch } from '@/components/ui/switch';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cardHover } from '@/lib/utils';
@@ -19,12 +18,7 @@ export function GuestExperienceCard() {
   return (
     <Card className={cardHover}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-lg">
-          <div className="rounded-md bg-primary/10 p-1.5">
-            <IconToolsKitchen2 size={16} className="text-primary" />
-          </div>
-          Guest Experience
-        </CardTitle>
+        <CardTitle className="text-xl font-bold">Guest Experience</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="flex flex-row items-center justify-between space-y-0">

--- a/features/events/components/event-details/location-card.tsx
+++ b/features/events/components/event-details/location-card.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useFormContext } from 'react-hook-form';
-import { IconMapPin } from '@tabler/icons-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { LocationInput } from '@/components/ui/location-input';
 import { cardHover } from '@/lib/utils';
@@ -34,12 +33,7 @@ export function LocationCard() {
   return (
     <Card className={cardHover}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-lg">
-          <div className="rounded-md bg-primary/10 p-1.5">
-            <IconMapPin size={16} className="text-primary" />
-          </div>
-          Location
-        </CardTitle>
+        <CardTitle className="text-xl font-bold">Location</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <FormField


### PR DESCRIPTION
…heme

Remove icon decorators from all event detail card headers in favor of plain bold titles. Constrain the details form to max-w-5xl centered layout. Update primary color from orange/red to teal across light and dark mode CSS variables.