### PR TITLE
fix(i18n): disable locale detection to prevent en being forced on nav…

### DIFF
--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -4,4 +4,5 @@ export const routing = defineRouting({
   locales: ['he', 'en'],
   defaultLocale: 'he',
   localePrefix: 'as-needed',
+  localeDetection: false,
 });


### PR DESCRIPTION
…igation

With localeDetection enabled, the middleware was redirecting URL-prefix-less requests (Hebrew) to /en/ based on the stale NEXT_LOCALE cookie or Accept-Language header. Disabling it makes locale determined solely by the URL, which the LanguageSwitcher already handles correctly.