### PR TITLE
feat: add contact picker import for phone contacts

### DIFF
--- a/features/guests/components/contact-picker-dialog.tsx
+++ b/features/guests/components/contact-picker-dialog.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { IconCheck, IconX } from '@tabler/icons-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { importGuests } from '@/features/guests/actions/guests';
+import { ImportGuestSchema } from '@/features/guests/schemas';
+
+export interface ContactInfo {
+  name?: string[];
+  tel?: string[];
+}
+
+interface ProcessedContact {
+  name: string;
+  phone: string | null;
+  valid: boolean;
+  skipReason?: 'noPhone' | 'invalidPhone' | 'duplicatePhone' | 'noName';
+}
+
+interface ContactPickerDialogProps {
+  rawContacts: ContactInfo[];
+  eventId: string;
+  existingPhones: Set<string>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function processContacts(
+  rawContacts: ContactInfo[],
+  existingPhones: Set<string>,
+): ProcessedContact[] {
+  const seenPhones = new Set<string>();
+
+  return rawContacts.map((contact) => {
+    const name = contact.name?.[0]?.trim() || '';
+    const phones = contact.tel ?? [];
+
+    if (phones.length === 0) {
+      return { name, phone: null, valid: false, skipReason: 'noPhone' as const };
+    }
+
+    for (const rawPhone of phones) {
+      const result = ImportGuestSchema.safeParse({ name: name || 'x', phone: rawPhone, amount: 1 });
+      if (result.success) {
+        const normalized = rawPhone.trim();
+        if (name.length < 2) {
+          return { name, phone: normalized, valid: false, skipReason: 'noName' as const };
+        }
+        if (existingPhones.has(normalized) || seenPhones.has(normalized)) {
+          return { name, phone: normalized, valid: false, skipReason: 'duplicatePhone' as const };
+        }
+        seenPhones.add(normalized);
+        return { name, phone: normalized, valid: true };
+      }
+    }
+
+    return { name, phone: phones[0].trim(), valid: false, skipReason: 'invalidPhone' as const };
+  });
+}
+
+export function ContactPickerDialog({
+  rawContacts,
+  eventId,
+  existingPhones,
+  open,
+  onOpenChange,
+}: ContactPickerDialogProps) {
+  const t = useTranslations('guests.contactPicker');
+  const [isImporting, setIsImporting] = useState(false);
+
+  const processed = useMemo(
+    () => processContacts(rawContacts, existingPhones),
+    [rawContacts, existingPhones],
+  );
+
+  const valid = processed.filter((c) => c.valid);
+  const skipped = processed.filter((c) => !c.valid);
+
+  const handleImport = async () => {
+    setIsImporting(true);
+    const guests = valid.map((c) => ({
+      name: c.name,
+      phone: c.phone!,
+      amount: 1,
+    }));
+
+    const promise = importGuests(eventId, guests).then((result) => {
+      if (!result.success) throw new Error(result.message);
+      return result;
+    });
+
+    toast.promise(promise, {
+      loading: t('importing'),
+      success: (data) => data.message || t('importSuccess', { count: valid.length }),
+      error: (err) => (err instanceof Error ? err.message : t('importError')),
+    });
+
+    try {
+      await promise;
+      onOpenChange(false);
+    } catch {
+      // error shown by toast
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('dialogTitle')}</DialogTitle>
+          <DialogDescription>{t('dialogDescription')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1 text-sm">
+          {valid.length > 0 && (
+            <p className="text-muted-foreground">{t('willImport', { count: valid.length })}</p>
+          )}
+          {skipped.length > 0 && (
+            <p className="text-muted-foreground">{t('willSkip', { count: skipped.length })}</p>
+          )}
+        </div>
+
+        <div className="max-h-72 overflow-y-auto">
+          <ul className="space-y-2 pr-1">
+            {processed.map((contact, i) => (
+              <li key={i} className="flex items-center gap-3">
+                <span
+                  className={`flex size-5 shrink-0 items-center justify-center rounded-full ${
+                    contact.valid ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-500'
+                  }`}
+                >
+                  {contact.valid ? <IconCheck size={12} /> : <IconX size={12} />}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className={`truncate text-sm font-medium ${!contact.valid ? 'text-muted-foreground' : ''}`}>
+                    {contact.name || <span className="italic">{t('unnamed')}</span>}
+                  </p>
+                  {contact.phone && (
+                    <p className="truncate text-xs text-muted-foreground">{contact.phone}</p>
+                  )}
+                </div>
+                {!contact.valid && contact.skipReason && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {t(contact.skipReason)}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t('cancel')}
+          </Button>
+          <Button onClick={handleImport} disabled={valid.length === 0 || isImporting}>
+            {t('import', { count: valid.length })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/guests/components/guest-directory.tsx
+++ b/features/guests/components/guest-directory.tsx
@@ -7,12 +7,17 @@ import { GuestSearch } from './guest-search';
 import { GuestsTable } from '@/features/guests/components/table';
 import { GroupFilter, RsvpStatusFilter } from '@/features/guests/components/filters';
 import { ImportGuestsDialog } from '@/features/guests/components/groups';
+import { ContactPickerDialog, type ContactInfo } from './contact-picker-dialog';
 import { GuestWithGroupApp, GroupInfo } from '@/features/guests/schemas';
 import { useGuestFilters, useDynamicPageSize } from '@/features/guests/hooks';
 import { deleteGuest, type DeleteGuestState } from '@/features/guests/actions';
-import { IconUpload } from '@tabler/icons-react';
+import { IconAddressBook, IconUpload } from '@tabler/icons-react';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+
+interface ContactManager {
+  select(props: string[], opts?: { multiple?: boolean }): Promise<ContactInfo[]>;
+}
 
 interface GuestDirectoryProps {
   guests: GuestWithGroupApp[];
@@ -37,6 +42,8 @@ export function GuestDirectory({
 }: GuestDirectoryProps) {
   const t = useTranslations('guests');
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [contactDialogOpen, setContactDialogOpen] = useState(false);
+  const [pickedContacts, setPickedContacts] = useState<ContactInfo[]>([]);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const { pageSize, isCalculated } = useDynamicPageSize({
     containerRef: tableContainerRef,
@@ -100,6 +107,15 @@ export function GuestDirectory({
     onSelectGuest(null);
   };
 
+  const handleImportFromContacts = async () => {
+    const contacts = await (navigator as unknown as { contacts: ContactManager }).contacts
+      .select(['name', 'tel'], { multiple: true });
+    if (contacts.length > 0) {
+      setPickedContacts(contacts);
+      setContactDialogOpen(true);
+    }
+  };
+
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between gap-2">
@@ -113,6 +129,16 @@ export function GuestDirectory({
             <IconUpload size={16} />
             {t('directory.importCsv')}
           </Button>
+          {'contacts' in navigator && (
+            <Button
+              variant="outline"
+              onClick={handleImportFromContacts}
+              className="gap-2"
+            >
+              <IconAddressBook size={16} />
+              {t('directory.importFromContacts')}
+            </Button>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <RsvpStatusFilter
@@ -150,6 +176,14 @@ export function GuestDirectory({
         onOpenChange={setImportDialogOpen}
         eventId={eventId}
         existingPhones={existingPhones}
+      />
+
+      <ContactPickerDialog
+        rawContacts={pickedContacts}
+        eventId={eventId}
+        existingPhones={existingPhones}
+        open={contactDialogOpen}
+        onOpenChange={setContactDialogOpen}
       />
     </Card>
   );

--- a/messages/en.json
+++ b/messages/en.json
@@ -335,9 +335,26 @@
     },
     "directory": {
       "importCsv": "Import File",
+      "importFromContacts": "Import from Contacts",
       "deletingGuest": "Deleting {name}...",
       "guestDeleted": "Guest deleted successfully.",
       "guestDeleteFailed": "Failed to delete guest. Please try again."
+    },
+    "contactPicker": {
+      "dialogTitle": "Import from Phone Contacts",
+      "dialogDescription": "Contacts with invalid or duplicate phone numbers will be skipped.",
+      "willImport": "{count} contacts will be imported",
+      "willSkip": "{count} will be skipped",
+      "import": "Import {count} contacts",
+      "cancel": "Cancel",
+      "noPhone": "No valid phone",
+      "noName": "No name",
+      "duplicatePhone": "Already in list",
+      "invalidPhone": "Invalid phone",
+      "unnamed": "Unnamed",
+      "importing": "Importing contacts...",
+      "importSuccess": "{count} contacts imported successfully",
+      "importError": "Failed to import contacts. Please try again."
     },
     "filters": {
       "filterByStatus": "Filter by status",

--- a/messages/he.json
+++ b/messages/he.json
@@ -335,9 +335,26 @@
     },
     "directory": {
       "importCsv": "ייבוא קובץ",
+      "importFromContacts": "ייבוא מאנשי קשר",
       "deletingGuest": "מוחק את {name}...",
       "guestDeleted": "האורח נמחק בהצלחה.",
       "guestDeleteFailed": "מחיקת האורח נכשלה. נסה שנית."
+    },
+    "contactPicker": {
+      "dialogTitle": "ייבוא מאנשי קשר בטלפון",
+      "dialogDescription": "אנשי קשר עם מספר טלפון לא תקין או כפול יידלגו.",
+      "willImport": "{count} אנשי קשר יוטענו",
+      "willSkip": "{count} יידלגו",
+      "import": "ייבא {count} אנשי קשר",
+      "cancel": "ביטול",
+      "noPhone": "אין טלפון תקין",
+      "noName": "ללא שם",
+      "duplicatePhone": "כבר ברשימה",
+      "invalidPhone": "טלפון לא תקין",
+      "unnamed": "ללא שם",
+      "importing": "מייבא אנשי קשר...",
+      "importSuccess": "{count} אנשי קשר יובאו בהצלחה",
+      "importError": "ייבוא אנשי הקשר נכשל. נסה שנית."
     },
     "filters": {
       "filterByStatus": "סנן לפי סטטוס",


### PR DESCRIPTION
Adds a new "Import from Contacts" button (Contact Picker API, mobile only) that lets users select phone contacts and previews which will be imported vs skipped before confirming.

Contacts are skipped when they have no phone, an invalid phone, a duplicate phone, or no name (which would fail server-side validation silently). Both Hebrew and English translations included.