### PR TITLE
feat: delay profile creation to first onboarding step

### DIFF
--- a/features/collaborate/actions/respond.ts
+++ b/features/collaborate/actions/respond.ts
@@ -14,6 +14,12 @@ export async function acceptInvitation(token: string): Promise<ActionState> {
 
     const supabase = await createClient();
 
+    // Profile rows are no longer created at signup, so ensure one exists
+    // before inserting into event_collaborators (which FKs to profiles.id).
+    await supabase
+      .from('profiles')
+      .upsert({ id: currentUser.id, email: currentUser.email }, { onConflict: 'id' });
+
     // Call the SECURITY DEFINER function that handles the entire accept flow
     // (insert collaborator, copy scope, update invitation, audit log)
     // bypassing RLS since the invitee isn't a collaborator yet.

--- a/supabase/migrations/20260512000000_delay_profile_creation.sql
+++ b/supabase/migrations/20260512000000_delay_profile_creation.sql
@@ -1,0 +1,7 @@
+-- Profiles are now created on first onboarding step (PersonalInfoStep) via upsert
+-- from the application, rather than automatically at signup. Code paths that
+-- depend on profile data already fall back to auth.users metadata when the row
+-- is missing; invitation acceptance upserts a minimal profile to satisfy the
+-- event_collaborators FK.
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+DROP FUNCTION IF EXISTS public.handle_new_user();


### PR DESCRIPTION
Drop the auth.users trigger that auto-created a profile row at signup. Profiles are now created when the user completes/skips the personal info step via the existing upsert in updateUserProfile. The invitation acceptance flow upserts a minimal profile first to satisfy the event_collaborators FK.