### PR TITLE
Add back-office admin UI with user impersonation

### DIFF
--- a/app/[locale]/admin/events/[eventId]/page.tsx
+++ b/app/[locale]/admin/events/[eventId]/page.tsx
@@ -1,0 +1,69 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { IconChevronLeft } from '@tabler/icons-react';
+import { getAdminEvent, getAdminEventSchedules } from '@/features/admin/queries/event-detail';
+import { ManualSendCard } from '@/features/admin/components/manual-send-card';
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline'> = {
+  published: 'default',
+  draft: 'secondary',
+  archived: 'outline',
+};
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '—';
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export default async function AdminEventDetailPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId } = await params;
+  const [event, schedules] = await Promise.all([
+    getAdminEvent(eventId),
+    getAdminEventSchedules(eventId),
+  ]);
+
+  if (!event) notFound();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/admin/events">
+            <IconChevronLeft className="mr-1 h-4 w-4" />
+            Events
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{event.title}</h1>
+          <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+            <span>{formatDate(event.eventDate)}</span>
+            <Badge variant={STATUS_VARIANT[event.status] ?? 'outline'}>{event.status}</Badge>
+            <Link href={`/admin/users/${event.ownerId}`} className="text-blue-600 hover:underline">
+              {event.ownerEmail}
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Quick Actions</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <ManualSendCard eventId={eventId} schedules={schedules} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/admin/events/page.tsx
+++ b/app/[locale]/admin/events/page.tsx
@@ -1,0 +1,18 @@
+import { listAllEvents } from '@/features/admin/queries';
+import { EventsTable } from '@/features/admin/components/events-table';
+
+export default async function AdminEventsPage() {
+  const events = await listAllEvents();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Events</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          {events.length} event{events.length !== 1 ? 's' : ''} across all users
+        </p>
+      </div>
+      <EventsTable events={events} />
+    </div>
+  );
+}

--- a/app/[locale]/admin/layout.tsx
+++ b/app/[locale]/admin/layout.tsx
@@ -1,0 +1,28 @@
+import { assertAdmin } from '@/lib/supabase/admin';
+import { AdminSidebar } from '@/features/admin/components/admin-sidebar';
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
+import { setRequestLocale } from 'next-intl/server';
+
+export default async function AdminLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  await assertAdmin();
+
+  return (
+    <div dir="ltr">
+      <SidebarProvider className="!bg-[#F4F4F6]">
+        <AdminSidebar />
+        <SidebarInset className="!bg-[#F4F4F6]">
+          <div className="p-6">{children}</div>
+        </SidebarInset>
+      </SidebarProvider>
+    </div>
+  );
+}

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function AdminPage() {
+  redirect('/admin/events');
+}

--- a/app/[locale]/admin/users/[userId]/page.tsx
+++ b/app/[locale]/admin/users/[userId]/page.tsx
@@ -1,0 +1,112 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { getUserById, listAllEvents } from '@/features/admin/queries';
+import { startImpersonation } from '@/features/admin/actions/impersonation';
+import { EventsTable } from '@/features/admin/components/events-table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { IconChevronLeft } from '@tabler/icons-react';
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export default async function AdminUserDetailPage({
+  params,
+}: {
+  params: Promise<{ userId: string }>;
+}) {
+  const { userId } = await params;
+  const [user, events] = await Promise.all([
+    getUserById(userId),
+    listAllEvents(userId),
+  ]);
+
+  if (!user) notFound();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/admin/users">
+            <IconChevronLeft className="mr-1 h-4 w-4" />
+            Users
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">
+            {user.fullName || user.email}
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">{user.email}</p>
+        </div>
+        <form action={startImpersonation.bind(null, userId)}>
+          <Button type="submit" variant="outline">
+            View as user
+          </Button>
+        </form>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Plan
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Badge variant={user.plan === 'pro' ? 'default' : 'secondary'}>
+              {user.plan}
+            </Badge>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Signed up
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-sm font-medium">{formatDate(user.signupDate)}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Events
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <span className="text-2xl font-bold">{user.eventCount}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Role
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {user.isAdmin ? (
+              <Badge variant="destructive">Admin</Badge>
+            ) : (
+              <span className="text-sm text-muted-foreground">User</span>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div>
+        <h2 className="text-lg font-semibold mb-4">Events</h2>
+        <EventsTable events={events} />
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -1,0 +1,18 @@
+import { listUsers } from '@/features/admin/queries';
+import { UsersTable } from '@/features/admin/components/users-table';
+
+export default async function AdminUsersPage() {
+  const users = await listUsers();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Users</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          {users.length} registered user{users.length !== 1 ? 's' : ''}
+        </p>
+      </div>
+      <UsersTable users={users} />
+    </div>
+  );
+}

--- a/app/[locale]/app/layout.tsx
+++ b/app/[locale]/app/layout.tsx
@@ -4,8 +4,10 @@ import { redirect } from '@/i18n/navigation';
 import { setRequestLocale } from 'next-intl/server';
 import { createClient } from '@/lib/supabase/server';
 import { getAllUserEvents } from '@/features/events/queries';
+import { getEffectiveUser } from '@/features/auth/queries';
 import { AiChatButton } from '@/features/ai-chat/components/ai-chat-button';
 import { LayoutContentWrapper } from '@/components/layout-content-wrapper';
+import { ImpersonationBanner } from '@/features/admin/components/impersonation-banner';
 
 export default async function Layout({
   children,
@@ -24,25 +26,16 @@ export default async function Layout({
     return redirect({ href: '/login', locale });
   }
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('full_name, avatar_url, phone_number')
-    .eq('id', data.user.id)
-    .single();
+  const effectiveUser = await getEffectiveUser();
 
   const user = {
-    name:
-      profile?.full_name ||
-      data.user.user_metadata?.name ||
-      data.user.email ||
-      data.user.phone ||
-      '',
-    email: data.user.email,
-    phone: profile?.phone_number || data.user.phone,
-    avatar: profile?.avatar_url || data.user.user_metadata?.avatar_url,
+    name: effectiveUser?.displayName || '',
+    email: effectiveUser?.email,
+    phone: effectiveUser?.phone,
+    avatar: effectiveUser?.avatar,
   };
 
-  // Fetch user events
+  // Fetch events for the effective user (impersonation-aware)
   const events = await getAllUserEvents();
 
   return (
@@ -50,10 +43,11 @@ export default async function Layout({
       <AppSidebar
         variant="floating"
         events={events}
-        currentUserId={data.user.id}
+        currentUserId={effectiveUser?.id ?? data.user.id}
         user={user}
       />
       <SidebarInset className="!bg-[#F4F4F6]">
+        <ImpersonationBanner />
         <LayoutContentWrapper>{children}</LayoutContentWrapper>
         {process.env.ENABLE_AI_CHAT === 'true' && <AiChatButton />}
       </SidebarInset>

--- a/features/admin/actions/impersonation.ts
+++ b/features/admin/actions/impersonation.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { assertAdmin } from '@/lib/supabase/admin';
+
+export async function startImpersonation(userId: string) {
+  await assertAdmin();
+  const cookieStore = await cookies();
+  cookieStore.set('impersonate_user_id', userId, {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+  });
+  redirect('/app');
+}
+
+export async function stopImpersonation(returnUserId?: string) {
+  await assertAdmin();
+  const cookieStore = await cookies();
+  cookieStore.delete('impersonate_user_id');
+  redirect(returnUserId ? `/admin/users/${returnUserId}` : '/admin/users');
+}

--- a/features/admin/actions/index.ts
+++ b/features/admin/actions/index.ts
@@ -1,0 +1,3 @@
+export { startImpersonation, stopImpersonation } from './impersonation';
+export { sendManualMessages } from './send-manual';
+export type { ManualSendResult } from './send-manual';

--- a/features/admin/actions/send-manual.ts
+++ b/features/admin/actions/send-manual.ts
@@ -1,0 +1,225 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { getTemplateByKey } from '@/features/schedules/config/whatsapp-templates';
+import {
+  sendInChunks,
+  buildDeliveryRecord,
+  generateConfirmationToken,
+} from '@/features/schedules/utils/send-helpers';
+import { validatePhoneNumber } from '@/features/schedules/utils';
+import type { ParameterResolutionContext } from '@/features/schedules/utils/parameter-resolvers';
+import type { GuestApp } from '@/features/guests/schemas';
+import type { GroupApp } from '@/features/guests/schemas';
+import { ScheduleDbToAppSchema } from '@/features/schedules/schemas';
+
+export type ManualSendResult = {
+  success: boolean;
+  message: string;
+  sentCount?: number;
+  failedCount?: number;
+};
+
+export async function sendManualMessages(
+  scheduleId: string,
+  guestIds: string[],
+): Promise<ManualSendResult> {
+  if (guestIds.length === 0) {
+    return { success: false, message: 'No guests selected' };
+  }
+
+  const tag = `[manual-send] schedule=${scheduleId} guests=${guestIds.length}`;
+  console.log(`${tag} start`);
+
+  try {
+    await assertAdmin();
+    const supabase = createServiceClient();
+
+    // Fetch schedule + event via service client (bypasses RLS)
+    const { data: scheduleRow, error: scheduleError } = await supabase
+      .from('schedules')
+      .select(`*, events (id, user_id, title, event_date, location, host_details, invitations)`)
+      .eq('id', scheduleId)
+      .single();
+
+    if (scheduleError || !scheduleRow || !scheduleRow.events) {
+      console.error(`${tag} schedule fetch failed`, scheduleError);
+      return { success: false, message: 'Schedule not found' };
+    }
+
+    if (!scheduleRow.template_key) {
+      console.warn(`${tag} no template_key on schedule`);
+      return { success: false, message: 'No template assigned to this schedule' };
+    }
+
+    const templateConfig = getTemplateByKey(scheduleRow.template_key);
+    if (!templateConfig?.whatsapp?.parameters) {
+      console.warn(`${tag} template not found: ${scheduleRow.template_key}`);
+      return { success: false, message: 'Template not found or missing parameter config' };
+    }
+
+    const template = templateConfig.whatsapp;
+    const eventRow = scheduleRow.events;
+
+    console.log(`${tag} event="${eventRow.title}" template=${scheduleRow.template_key} action=${scheduleRow.action_type}`);
+
+    const eventContext = {
+      id: eventRow.id,
+      userId: eventRow.user_id,
+      title: eventRow.title,
+      eventDate: eventRow.event_date,
+      location: eventRow.location ?? undefined,
+      hostDetails: eventRow.host_details ?? undefined,
+      invitations: eventRow.invitations ? { imageUrl: eventRow.invitations.image_url } : undefined,
+    };
+
+    const schedule = ScheduleDbToAppSchema.parse(scheduleRow);
+
+    // Fetch selected guests
+    const { data: guestRows, error: guestError } = await supabase
+      .from('guests')
+      .select('*')
+      .in('id', guestIds)
+      .eq('event_id', eventRow.id);
+
+    if (guestError || !guestRows) {
+      console.error(`${tag} guest fetch failed`, guestError);
+      return { success: false, message: 'Failed to fetch guests' };
+    }
+
+    // Shape to GuestApp (trusted DB data — skip zod validation)
+    const guests: GuestApp[] = guestRows
+      .filter((g) => validatePhoneNumber(g.phone_number))
+      .map((g) => ({
+        id: g.id,
+        eventId: g.event_id,
+        name: g.name,
+        phone: g.phone_number,
+        groupId: g.group_id ?? undefined,
+        rsvpStatus: (g.rsvp_status ?? 'pending') as 'pending' | 'confirmed' | 'declined',
+        mealChoice: g.meal_choice ?? undefined,
+        amount: g.amount ?? 1,
+        notes: g.notes ?? undefined,
+        side: (g.side ?? null) as 'bride' | 'groom' | null,
+        tableId: g.table_id ?? null,
+        createdAt: g.created_at,
+        updatedAt: g.updated_at,
+        invitationToken: g.invitation_token,
+        rsvpChangedBy: g.rsvp_changed_by ?? null,
+        rsvpChangedByName: g.rsvp_changed_by_name ?? null,
+        rsvpChangedAt: g.rsvp_changed_at ?? null,
+        rsvpChangeSource: (g.rsvp_change_source ?? null) as 'manual' | 'guest' | null,
+        isOfflineRsvp: g.is_offline_rsvp ?? false,
+      }));
+
+    const skipped = guestRows.length - guests.length;
+    console.log(`${tag} guests fetched=${guestRows.length} valid=${guests.length} skipped_no_phone=${skipped}`);
+
+    if (guests.length === 0) {
+      return { success: false, message: 'None of the selected guests have a valid phone number' };
+    }
+
+    // Batch-fetch groups
+    const uniqueGroupIds = [
+      ...new Set(guests.map((g) => g.groupId).filter((id): id is string => !!id)),
+    ];
+    const groupsMap = new Map<string, GroupApp>();
+    if (uniqueGroupIds.length > 0) {
+      const { data: groupRows } = await supabase
+        .from('groups')
+        .select('*')
+        .in('id', uniqueGroupIds);
+      for (const row of groupRows ?? []) {
+        groupsMap.set(row.id, {
+          id: row.id,
+          eventId: row.event_id,
+          name: row.name,
+          description: row.description ?? null,
+          icon: row.icon ?? null,
+          side: (row.side ?? null) as 'bride' | 'groom' | null,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        });
+      }
+      console.log(`${tag} groups fetched=${groupsMap.size}`);
+    }
+
+    console.log(`${tag} sending…`);
+
+    // Send in rate-limited chunks
+    const sendResults = await sendInChunks(
+      guests,
+      (guest) => {
+        const confirmationToken = generateConfirmationToken();
+        const context: ParameterResolutionContext = {
+          guest,
+          event: eventContext,
+          group: guest.groupId ? (groupsMap.get(guest.groupId) ?? null) : null,
+          schedule,
+          confirmationToken,
+        };
+        return { context, template, confirmationToken };
+      },
+      async (chunkResults, chunkIndex, totalChunks) => {
+        const sent = chunkResults.filter(
+          (r) => r.status === 'fulfilled' && r.value.success,
+        ).length;
+        const failed = chunkResults.length - sent;
+        console.log(`${tag} chunk ${chunkIndex + 1}/${totalChunks} sent=${sent} failed=${failed}`);
+      },
+    );
+
+    // Process results and insert delivery records
+    const deliveryRecords: Record<string, unknown>[] = [];
+    let sentCount = 0;
+    let failedCount = 0;
+
+    for (const settled of sendResults) {
+      if (settled.status === 'fulfilled') {
+        const r = settled.value;
+        deliveryRecords.push(buildDeliveryRecord(scheduleId, r));
+        if (r.success) sentCount++;
+        else {
+          failedCount++;
+          console.warn(`${tag} failed guestId=${r.guest.id} code=${r.errorCode ?? 'none'} msg=${r.message}`);
+        }
+      } else {
+        failedCount++;
+        console.error(`${tag} send promise rejected`, settled.reason);
+      }
+    }
+
+    console.log(`${tag} send complete sent=${sentCount} failed=${failedCount}`);
+
+    if (deliveryRecords.length > 0) {
+      const { error: insertError } = await supabase
+        .from('message_deliveries')
+        .insert(deliveryRecords);
+      if (insertError) {
+        console.error(`${tag} delivery record insert failed`, insertError);
+      } else {
+        console.log(`${tag} inserted ${deliveryRecords.length} delivery records`);
+      }
+    }
+
+    revalidatePath('/app');
+
+    if (sentCount === 0) {
+      return { success: false, message: 'All messages failed to send', sentCount: 0, failedCount };
+    }
+
+    const result = {
+      success: true,
+      message: `Sent ${sentCount} message${sentCount !== 1 ? 's' : ''}${failedCount > 0 ? `, ${failedCount} failed` : ''}`,
+      sentCount,
+      failedCount,
+    };
+    console.log(`${tag} done`, result.message);
+    return result;
+  } catch (error) {
+    console.error(`${tag} unexpected error`, error);
+    return { success: false, message: 'Failed to send messages' };
+  }
+}

--- a/features/admin/components/admin-sidebar.tsx
+++ b/features/admin/components/admin-sidebar.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { IconUsers, IconCalendar, IconChevronLeft } from '@tabler/icons-react';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
+import { cn } from '@/lib/utils';
+
+const NAV_ITEMS = [
+  { label: 'Events', href: '/admin/events', icon: IconCalendar },
+  { label: 'Users', href: '/admin/users', icon: IconUsers },
+];
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <Sidebar variant="floating">
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" asChild>
+              <Link href="/admin/events">
+                <span className="font-semibold text-sm">Back Office</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarMenu>
+          {NAV_ITEMS.map(({ label, href, icon: Icon }) => (
+            <SidebarMenuItem key={href}>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.includes(href)}
+              >
+                <Link href={href}>
+                  <Icon />
+                  <span>{label}</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarContent>
+
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild>
+              <Link href="/app" className={cn('text-muted-foreground')}>
+                <IconChevronLeft />
+                <span>Back to App</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/features/admin/components/events-table.tsx
+++ b/features/admin/components/events-table.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import type { AdminEvent } from '../types';
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline'> = {
+  published: 'default',
+  draft: 'secondary',
+  archived: 'outline',
+};
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '—';
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function EventsTable({ events }: { events: AdminEvent[] }) {
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+
+  const filtered = events.filter((e) => {
+    const matchSearch =
+      e.title.toLowerCase().includes(search.toLowerCase()) ||
+      e.ownerEmail.toLowerCase().includes(search.toLowerCase());
+    const matchStatus = statusFilter === 'all' || e.status === statusFilter;
+    return matchSearch && matchStatus;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          placeholder="Search by name or owner…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-sm"
+        />
+        <div className="flex gap-1">
+          {['all', 'draft', 'published', 'archived'].map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                statusFilter === s
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80'
+              }`}
+            >
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Event</TableHead>
+              <TableHead>Owner</TableHead>
+              <TableHead>Date</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Guests</TableHead>
+              <TableHead className="text-right">RSVP %</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                  No events found
+                </TableCell>
+              </TableRow>
+            )}
+            {filtered.map((event) => (
+              <TableRow key={event.id}>
+                <TableCell className="font-medium">
+                  <Link
+                    href={`/admin/events/${event.id}`}
+                    className="hover:underline"
+                  >
+                    {event.title}
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Link
+                    href={`/admin/users/${event.ownerId}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {event.ownerEmail}
+                  </Link>
+                </TableCell>
+                <TableCell>{formatDate(event.eventDate)}</TableCell>
+                <TableCell>
+                  <Badge variant={STATUS_VARIANT[event.status] ?? 'outline'}>
+                    {event.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right">{event.guestCount}</TableCell>
+                <TableCell className="text-right">
+                  {event.guestCount > 0 ? `${event.rsvpPercent}%` : '—'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/features/admin/components/impersonation-banner.tsx
+++ b/features/admin/components/impersonation-banner.tsx
@@ -1,0 +1,37 @@
+import { getImpersonation } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { stopImpersonation } from '@/features/admin/actions/impersonation';
+
+export async function ImpersonationBanner() {
+  const impersonation = await getImpersonation();
+  if (!impersonation) return null;
+
+  const supabase = createServiceClient();
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('email, full_name')
+    .eq('id', impersonation.userId)
+    .single();
+
+  const displayName = profile?.full_name || profile?.email || impersonation.userId;
+
+  return (
+    <div className="sticky top-0 z-50 flex items-center justify-between gap-4 border-b border-amber-300 bg-amber-50 px-5 py-2.5 text-sm text-amber-900">
+      <div className="flex items-center gap-2">
+        <span className="inline-block h-2 w-2 rounded-full bg-amber-400" />
+        <span>
+          Viewing as <span className="font-semibold">{displayName}</span>
+          <span className="ml-2 text-amber-600">· Read-only</span>
+        </span>
+      </div>
+      <form action={stopImpersonation.bind(null, impersonation.userId)}>
+        <button
+          type="submit"
+          className="rounded-md border border-amber-300 bg-white px-3 py-1 text-xs font-medium text-amber-800 shadow-sm transition-colors hover:bg-amber-100"
+        >
+          Exit
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/features/admin/components/manual-send-card.tsx
+++ b/features/admin/components/manual-send-card.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+import { IconSend, IconLoader2 } from '@tabler/icons-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ACTION_TYPE_LABELS } from '@/features/schedules/schemas';
+import type { ScheduleApp } from '@/features/schedules/schemas';
+import { getGuestsForManualSend } from '../queries/event-detail';
+import { sendManualMessages } from '../actions/send-manual';
+import type { GuestWithDeliveryStatus } from '../queries/event-detail';
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function ScheduleLabel({ schedule }: { schedule: ScheduleApp }) {
+  const label = schedule.actionType ? ACTION_TYPE_LABELS[schedule.actionType] : 'Schedule';
+  return (
+    <span>
+      {label}
+      <span className="ml-2 text-muted-foreground">· {formatDate(schedule.scheduledDate)}</span>
+      {schedule.status === 'sent' && (
+        <Badge variant="secondary" className="ml-2 text-xs">
+          Sent
+        </Badge>
+      )}
+    </span>
+  );
+}
+
+export function ManualSendCard({
+  eventId,
+  schedules,
+}: {
+  eventId: string;
+  schedules: ScheduleApp[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<string>('');
+  const [guests, setGuests] = useState<GuestWithDeliveryStatus[]>([]);
+  const [selectedGuestIds, setSelectedGuestIds] = useState<Set<string>>(new Set());
+  const [loadingGuests, setLoadingGuests] = useState(false);
+  const [isSending, startSending] = useTransition();
+
+  async function handleScheduleChange(scheduleId: string) {
+    setSelectedScheduleId(scheduleId);
+    setSelectedGuestIds(new Set());
+    setGuests([]);
+    setLoadingGuests(true);
+    try {
+      const result = await getGuestsForManualSend(eventId, scheduleId);
+      setGuests(result);
+      // Default-select guests with no delivery
+      setSelectedGuestIds(new Set(result.filter((g) => !g.hasDelivery).map((g) => g.id)));
+    } finally {
+      setLoadingGuests(false);
+    }
+  }
+
+  function toggleGuest(id: string) {
+    setSelectedGuestIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    if (selectedGuestIds.size === guests.length) {
+      setSelectedGuestIds(new Set());
+    } else {
+      setSelectedGuestIds(new Set(guests.map((g) => g.id)));
+    }
+  }
+
+  function handleSend() {
+    if (!selectedScheduleId || selectedGuestIds.size === 0) return;
+    startSending(async () => {
+      const promise = sendManualMessages(selectedScheduleId, [...selectedGuestIds]).then(
+        (result) => {
+          if (!result.success) throw new Error(result.message);
+          return result;
+        },
+      );
+      toast.promise(promise, {
+        loading: `Sending to ${selectedGuestIds.size} guest${selectedGuestIds.size !== 1 ? 's' : ''}…`,
+        success: (data) => {
+          setOpen(false);
+          // Refresh guest list to reflect new deliveries
+          handleScheduleChange(selectedScheduleId);
+          return data.message ?? 'Messages sent';
+        },
+        error: (err) => (err instanceof Error ? err.message : 'Failed to send'),
+      });
+      await promise.catch(() => {});
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button className="group flex flex-col gap-3 rounded-xl border bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-colors group-hover:bg-blue-100">
+            <IconSend className="h-5 w-5" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-foreground">Manual Message Send</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Send a schedule message to specific guests
+            </p>
+          </div>
+        </button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Manual Message Send</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">Schedule</label>
+            <Select value={selectedScheduleId} onValueChange={handleScheduleChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a schedule…" />
+              </SelectTrigger>
+              <SelectContent>
+                {schedules.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    <ScheduleLabel schedule={s} />
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {selectedScheduleId && (
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium">
+                  Guests
+                  {guests.length > 0 && (
+                    <span className="ml-1.5 text-muted-foreground">({guests.length})</span>
+                  )}
+                </label>
+                {guests.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={toggleAll}
+                    className="text-xs text-blue-600 hover:underline"
+                  >
+                    {selectedGuestIds.size === guests.length ? 'Deselect all' : 'Select all'}
+                  </button>
+                )}
+              </div>
+
+              {loadingGuests ? (
+                <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                  <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Loading guests…
+                </div>
+              ) : guests.length === 0 ? (
+                <div className="flex h-20 items-center justify-center rounded-lg border border-dashed text-sm text-muted-foreground">
+                  No guests found
+                </div>
+              ) : (
+                <div className="max-h-72 overflow-y-auto rounded-lg border divide-y">
+                  {guests.map((guest) => (
+                    <label
+                      key={guest.id}
+                      className="flex cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-muted/50"
+                    >
+                      <Checkbox
+                        checked={selectedGuestIds.has(guest.id)}
+                        onCheckedChange={() => toggleGuest(guest.id)}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{guest.name}</p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {guest.phone ?? 'No phone'}
+                          <span className="mx-1.5">·</span>
+                          {guest.rsvpStatus}
+                        </p>
+                      </div>
+                      {guest.hasDelivery && (
+                        <Badge variant="secondary" className="shrink-0 text-xs">
+                          Sent
+                        </Badge>
+                      )}
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSend}
+              disabled={!selectedScheduleId || selectedGuestIds.size === 0 || isSending}
+            >
+              {isSending && <IconLoader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+              Send to {selectedGuestIds.size > 0 ? selectedGuestIds.size : '…'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/admin/components/users-table.tsx
+++ b/features/admin/components/users-table.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import type { AdminUser } from '../types';
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function UsersTable({ users }: { users: AdminUser[] }) {
+  const [search, setSearch] = useState('');
+
+  const filtered = users.filter(
+    (u) =>
+      u.email.toLowerCase().includes(search.toLowerCase()) ||
+      u.fullName.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="Search by email or name…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="max-w-sm"
+      />
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Plan</TableHead>
+              <TableHead>Signed up</TableHead>
+              <TableHead className="text-right">Events</TableHead>
+              <TableHead className="text-right"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                  No users found
+                </TableCell>
+              </TableRow>
+            )}
+            {filtered.map((user) => (
+              <TableRow key={user.id}>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {user.email}
+                    {user.isAdmin && (
+                      <Badge variant="destructive" className="text-[10px] px-1 py-0">
+                        admin
+                      </Badge>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>{user.fullName || '—'}</TableCell>
+                <TableCell>
+                  <Badge variant={user.plan === 'pro' ? 'default' : 'secondary'}>
+                    {user.plan}
+                  </Badge>
+                </TableCell>
+                <TableCell>{formatDate(user.signupDate)}</TableCell>
+                <TableCell className="text-right">{user.eventCount}</TableCell>
+                <TableCell className="text-right">
+                  <Button asChild variant="outline" size="sm">
+                    <Link href={`/admin/users/${user.id}`}>View</Link>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/features/admin/index.ts
+++ b/features/admin/index.ts
@@ -1,0 +1,3 @@
+export * from './queries';
+export * from './actions';
+export * from './types';

--- a/features/admin/queries/event-detail.ts
+++ b/features/admin/queries/event-detail.ts
@@ -1,0 +1,104 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { ScheduleDbToAppSchema } from '@/features/schedules/schemas';
+import type { ScheduleApp } from '@/features/schedules/schemas';
+
+export type AdminEventDetail = {
+  id: string;
+  title: string;
+  eventDate: string | null;
+  status: string;
+  ownerEmail: string;
+  ownerId: string;
+};
+
+export type GuestWithDeliveryStatus = {
+  id: string;
+  name: string;
+  phone: string | null;
+  rsvpStatus: 'pending' | 'confirmed' | 'declined';
+  createdAt: string;
+  hasDelivery: boolean;
+};
+
+export async function getAdminEvent(eventId: string): Promise<AdminEventDetail | null> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const { data: event, error } = await supabase
+    .from('events')
+    .select('id, title, event_date, status, user_id')
+    .eq('id', eventId)
+    .single();
+
+  if (error || !event) return null;
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('email')
+    .eq('id', event.user_id)
+    .single();
+
+  return {
+    id: event.id,
+    title: event.title,
+    eventDate: event.event_date,
+    status: event.status ?? 'draft',
+    ownerEmail: profile?.email ?? '',
+    ownerId: event.user_id,
+  };
+}
+
+export async function getAdminEventSchedules(eventId: string): Promise<ScheduleApp[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from('schedules')
+    .select('*')
+    .eq('event_id', eventId)
+    .order('scheduled_date', { ascending: true });
+
+  if (error || !data) return [];
+
+  return data.map((row) => ScheduleDbToAppSchema.parse(row));
+}
+
+export async function getGuestsForManualSend(
+  eventId: string,
+  scheduleId: string,
+): Promise<GuestWithDeliveryStatus[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const [{ data: guests }, { data: deliveries }] = await Promise.all([
+    supabase
+      .from('guests')
+      .select('id, name, phone_number, rsvp_status, created_at')
+      .eq('event_id', eventId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('message_deliveries')
+      .select('guest_id')
+      .eq('schedule_id', scheduleId),
+  ]);
+
+  const deliveredSet = new Set((deliveries ?? []).map((d) => d.guest_id));
+
+  const result: GuestWithDeliveryStatus[] = (guests ?? []).map((g) => ({
+    id: g.id,
+    name: g.name,
+    phone: g.phone_number ?? null,
+    rsvpStatus: g.rsvp_status as 'pending' | 'confirmed' | 'declined',
+    createdAt: g.created_at,
+    hasDelivery: deliveredSet.has(g.id),
+  }));
+
+  // no-delivery guests first, then already-sent; both groups sorted newest first (already from DB)
+  return result.sort((a, b) => {
+    if (a.hasDelivery !== b.hasDelivery) return a.hasDelivery ? 1 : -1;
+    return 0;
+  });
+}

--- a/features/admin/queries/events.ts
+++ b/features/admin/queries/events.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import type { AdminEvent } from '../types';
+
+export async function listAllEvents(userId?: string): Promise<AdminEvent[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  let eventsQuery = supabase
+    .from('events')
+    .select('id, title, user_id, event_date, status')
+    .order('event_date', { ascending: false });
+
+  if (userId) {
+    eventsQuery = eventsQuery.eq('user_id', userId);
+  }
+
+  const { data: events, error } = await eventsQuery;
+
+  if (error || !events || events.length === 0) {
+    if (error) console.error('Error fetching admin events:', error);
+    return [];
+  }
+
+  const eventIds = events.map((e) => e.id);
+  const ownerIds = [...new Set(events.map((e) => e.user_id))];
+
+  // Fetch owner emails from profiles
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, email')
+    .in('id', ownerIds);
+
+  const emailMap = new Map<string, string>(
+    (profiles ?? []).map((p) => [p.id, p.email ?? '']),
+  );
+
+  // Fetch guest counts grouped by event_id and rsvp_status in one query
+  const { data: guestRows } = await supabase
+    .from('guests')
+    .select('event_id, rsvp_status')
+    .in('event_id', eventIds);
+
+  const guestMap = new Map<string, { total: number; confirmed: number }>();
+  for (const row of guestRows ?? []) {
+    const entry = guestMap.get(row.event_id) ?? { total: 0, confirmed: 0 };
+    entry.total++;
+    if (row.rsvp_status === 'confirmed') entry.confirmed++;
+    guestMap.set(row.event_id, entry);
+  }
+
+  return events.map((e) => {
+    const stats = guestMap.get(e.id) ?? { total: 0, confirmed: 0 };
+    return {
+      id: e.id,
+      title: e.title,
+      ownerEmail: emailMap.get(e.user_id) ?? '',
+      ownerId: e.user_id,
+      eventDate: e.event_date,
+      status: e.status ?? 'draft',
+      guestCount: stats.total,
+      confirmedCount: stats.confirmed,
+      rsvpPercent:
+        stats.total > 0 ? Math.round((stats.confirmed / stats.total) * 100) : 0,
+    };
+  });
+}

--- a/features/admin/queries/index.ts
+++ b/features/admin/queries/index.ts
@@ -1,0 +1,4 @@
+export { listUsers, getUserById } from './users';
+export { listAllEvents } from './events';
+export { getAdminEvent, getAdminEventSchedules, getGuestsForManualSend } from './event-detail';
+export type { AdminEventDetail, GuestWithDeliveryStatus } from './event-detail';

--- a/features/admin/queries/users.ts
+++ b/features/admin/queries/users.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import type { AdminUser } from '../types';
+
+export async function listUsers(): Promise<AdminUser[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const { data: profiles, error } = await supabase
+    .from('profiles')
+    .select('id, email, full_name, pricing_plan, created_at, is_admin')
+    .order('created_at', { ascending: false });
+
+  if (error || !profiles) {
+    console.error('Error fetching users:', error);
+    return [];
+  }
+
+  const ids = profiles.map((p) => p.id);
+
+  // Count events per user in one query
+  const { data: eventCounts } = await supabase
+    .from('events')
+    .select('user_id')
+    .in('user_id', ids);
+
+  const countMap = new Map<string, number>();
+  for (const row of eventCounts ?? []) {
+    countMap.set(row.user_id, (countMap.get(row.user_id) ?? 0) + 1);
+  }
+
+  return profiles.map((p) => ({
+    id: p.id,
+    email: p.email ?? '',
+    fullName: p.full_name ?? '',
+    plan: p.pricing_plan ?? 'basic',
+    signupDate: p.created_at,
+    eventCount: countMap.get(p.id) ?? 0,
+    isAdmin: p.is_admin ?? false,
+  }));
+}
+
+export async function getUserById(userId: string): Promise<AdminUser | null> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, email, full_name, pricing_plan, created_at, is_admin')
+    .eq('id', userId)
+    .single();
+
+  if (error || !profile) return null;
+
+  const { count } = await supabase
+    .from('events')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', userId);
+
+  return {
+    id: profile.id,
+    email: profile.email ?? '',
+    fullName: profile.full_name ?? '',
+    plan: profile.pricing_plan ?? 'basic',
+    signupDate: profile.created_at,
+    eventCount: count ?? 0,
+    isAdmin: profile.is_admin ?? false,
+  };
+}

--- a/features/admin/types.ts
+++ b/features/admin/types.ts
@@ -1,0 +1,21 @@
+export type AdminUser = {
+  id: string;
+  email: string;
+  fullName: string;
+  plan: string;
+  signupDate: string;
+  eventCount: number;
+  isAdmin: boolean;
+};
+
+export type AdminEvent = {
+  id: string;
+  title: string;
+  ownerEmail: string;
+  ownerId: string;
+  eventDate: string | null;
+  status: string;
+  guestCount: number;
+  confirmedCount: number;
+  rsvpPercent: number;
+};

--- a/features/auth/queries/auth.ts
+++ b/features/auth/queries/auth.ts
@@ -1,4 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
+import { getImpersonation } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
 import type { User, ProfileData } from '../schemas';
 
 export async function getUserProfile(): Promise<ProfileData | null> {
@@ -34,6 +36,45 @@ export async function getUserProfile(): Promise<ProfileData | null> {
       initialSetupComplete: profile?.initial_setup_complete ?? false,
     };
   } catch {
+    return null;
+  }
+}
+
+export async function getEffectiveUser(): Promise<User | null> {
+  try {
+    const impersonation = await getImpersonation();
+    if (!impersonation) return getCurrentUser();
+
+    const adminSupabase = createServiceClient();
+    const { data } = await adminSupabase.auth.admin.getUserById(impersonation.userId);
+    const authUser = data.user;
+    if (!authUser) return null;
+
+    const { data: profile } = await adminSupabase
+      .from('profiles')
+      .select('full_name, avatar_url, phone_number')
+      .eq('id', impersonation.userId)
+      .single();
+
+    return {
+      id: authUser.id,
+      email: authUser.email || undefined,
+      phone: profile?.phone_number || authUser.phone || undefined,
+      displayName:
+        profile?.full_name ||
+        authUser.user_metadata?.full_name ||
+        authUser.user_metadata?.name ||
+        authUser.email ||
+        authUser.phone ||
+        '',
+      avatar:
+        profile?.avatar_url ||
+        authUser.user_metadata?.avatar_url ||
+        authUser.user_metadata?.picture ||
+        '',
+    };
+  } catch (error) {
+    console.error('Get effective user error:', error);
     return null;
   }
 }

--- a/features/auth/queries/index.ts
+++ b/features/auth/queries/index.ts
@@ -1,1 +1,1 @@
-export { getCurrentUser, getUserProfile } from './auth';
+export { getCurrentUser, getUserProfile, getEffectiveUser } from './auth';

--- a/features/budget/queries/expenses.ts
+++ b/features/budget/queries/expenses.ts
@@ -1,10 +1,10 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import { ExpenseDbToAppTransformerSchema } from '../schemas/expenses';
 import type { ExpenseApp } from '../schemas/expenses';
 
 export async function getEventExpenses(eventId: string): Promise<ExpenseApp[]> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data, error } = await supabase
       .from('expenses')
       .select('*')

--- a/features/budget/queries/gifts.ts
+++ b/features/budget/queries/gifts.ts
@@ -1,9 +1,9 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import type { GiftRow } from '../types';
 
 export async function getEventGifts(eventId: string): Promise<GiftRow[]> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const [{ data: guests }, { data: gifts }] = await Promise.all([
       supabase
         .from('guests')

--- a/features/collaborate/queries/collaborators.ts
+++ b/features/collaborate/queries/collaborators.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import type { CollaboratorApp, CollaboratorRole } from '../schemas';
 
 /**
@@ -11,7 +11,7 @@ export async function getEventCollaborators(
   eventId: string,
 ): Promise<CollaboratorApp[]> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
 
     const { data, error } = await supabase
       .from('event_collaborators')
@@ -94,7 +94,7 @@ export async function getCollaboratorRole(
   eventId: string,
 ): Promise<{ role: CollaboratorRole; isCreator: boolean } | null> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -139,7 +139,7 @@ export async function getCollaboratorScope(
   collaboratorId: string,
 ): Promise<{ guestIds: string[]; groupIds: string[] }> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
 
     const { data, error } = await supabase
       .from('collaborator_guest_scope')

--- a/features/collaborate/queries/invitations.ts
+++ b/features/collaborate/queries/invitations.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import {
   InvitationDbToAppSchema,
   type InvitationApp,
@@ -13,7 +13,7 @@ export async function getEventInvitations(
   eventId: string,
 ): Promise<InvitationApp[]> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
 
     const { data, error } = await supabase
       .from('collaboration_invitations')
@@ -45,7 +45,7 @@ export async function getInvitationByToken(
   token: string,
 ): Promise<(InvitationApp & { eventTitle: string }) | null> {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
 
     const { data, error } = await supabase.rpc('get_invitation_by_token', {
       p_token: token,

--- a/features/dashboard/queries/guest-stats.ts
+++ b/features/dashboard/queries/guest-stats.ts
@@ -1,11 +1,11 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import type { RecentRsvpRow } from '../types';
 
 export async function getRecentRsvpActivity(
   eventId: string,
   limit = 5,
 ): Promise<RecentRsvpRow[]> {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
 
   const { data, error } = await supabase
     .from('guests')

--- a/features/dashboard/queries/onboarding-status.ts
+++ b/features/dashboard/queries/onboarding-status.ts
@@ -1,7 +1,7 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 
 export async function getCollaboratorCount(eventId: string): Promise<number> {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
   const { count } = await supabase
     .from('event_collaborators')
     .select('*', { count: 'exact', head: true })

--- a/features/dashboard/queries/pending-schedules.ts
+++ b/features/dashboard/queries/pending-schedules.ts
@@ -1,7 +1,7 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 
 export async function getPendingSchedulesCount(eventId: string): Promise<number> {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
 
   const { count, error } = await supabase
     .from('schedules')

--- a/features/events/actions/events.ts
+++ b/features/events/actions/events.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { getCurrentUser } from '@/features/auth/queries';
+import { assertNotImpersonating } from '@/lib/supabase/admin';
 import {
   EventDetailsUpdateSchema,
   UpdateEventDetailsState,
@@ -35,6 +36,8 @@ export type SetDefaultEventState = {
  * @returns Result state with success status and new event ID
  */
 export async function createEvent(formData: FormData): Promise<CreateEventState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {
@@ -110,6 +113,8 @@ export async function createEvent(formData: FormData): Promise<CreateEventState>
 export async function createOnboardingEvent(
   formData: FormData,
 ): Promise<CreateOnboardingEventState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {
@@ -237,6 +242,8 @@ function processInvitations(invitations: Invitations): Invitations {
 export async function updateEventDetails(
   formData: FormData,
 ): Promise<UpdateEventDetailsState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {
@@ -376,6 +383,8 @@ export async function updateEventDetails(
 }
 
 export async function deleteEvent(eventId: string): Promise<DeleteEventState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {
@@ -415,6 +424,8 @@ export async function deleteEvent(eventId: string): Promise<DeleteEventState> {
 export async function setDefaultEvent(
   eventId: string,
 ): Promise<SetDefaultEventState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {

--- a/features/events/queries/events.ts
+++ b/features/events/queries/events.ts
@@ -1,10 +1,10 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import { DbToAppTransformerSchema, type EventApp } from '../schemas';
 
 export async function getEventById(eventId: string): Promise<EventApp | null> {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
   const { data: event, error } = await supabase
     .from('events')
     .select('*')
@@ -30,14 +30,19 @@ export async function getEventById(eventId: string): Promise<EventApp | null> {
  */
 export async function getLastUserEvent(): Promise<EventApp | null> {
   try {
-    const supabase = await createClient();
+    const { supabase, impersonation } = await getEffectiveClient();
 
-    const { data: event, error } = await supabase
+    let query = supabase
       .from('events')
       .select('*')
       .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
+      .limit(1);
+
+    if (impersonation) {
+      query = query.eq('user_id', impersonation.userId);
+    }
+
+    const { data: event, error } = await query.maybeSingle();
 
     if (error) {
       console.error('Error fetching last user event:', error);
@@ -58,11 +63,15 @@ export async function getLastUserEvent(): Promise<EventApp | null> {
 }
 
 export async function getAllUserEvents(): Promise<EventApp[]> {
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from('events')
-    .select('*')
-    .order('created_at', { ascending: false });
+  const { supabase, impersonation } = await getEffectiveClient();
+
+  let query = supabase.from('events').select('*').order('created_at', { ascending: false });
+
+  if (impersonation) {
+    query = query.eq('user_id', impersonation.userId);
+  }
+
+  const { data, error } = await query;
   if (error) {
     console.error('Error fetching all user events:', error);
     return [];

--- a/features/guests/actions/guests.ts
+++ b/features/guests/actions/guests.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { getCurrentUser } from '@/features/auth/queries';
+import { assertNotImpersonating } from '@/lib/supabase/admin';
 import {
   GuestUpsertSchema,
   AppToDbTransformerSchema,
@@ -27,6 +28,8 @@ export async function upsertGuest(
   eventId: string,
   formData: FormData,
 ): Promise<UpsertGuestState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {
@@ -127,6 +130,8 @@ export async function upsertGuest(
 }
 
 export async function deleteGuest(guestId: string): Promise<DeleteGuestState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {
@@ -175,6 +180,8 @@ export async function importGuests(
   eventId: string,
   guests: ImportGuestData[],
 ): Promise<ImportGuestsState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const currentUser = await getCurrentUser();
     if (!currentUser) {

--- a/features/guests/queries/groups.ts
+++ b/features/guests/queries/groups.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import {
   GroupDbToAppTransformerSchema,
   GroupApp,
@@ -8,7 +8,7 @@ import {
 
 export const getEventGroups = async (eventId: string): Promise<GroupApp[]> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data: groups, error } = await supabase
       .from('groups')
       .select('*')
@@ -53,7 +53,7 @@ export const getEventGroupsWithGuests = async (
   eventId: string,
 ): Promise<GroupWithGuestsApp[]> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
 
     // Fetch groups with their guests using Supabase's relation syntax
     // This assumes you have set up the foreign key relationship in Supabase
@@ -118,7 +118,7 @@ export const getGroupById = async (
   groupId: string,
 ): Promise<GroupApp | null> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data: group, error } = await supabase
       .from('groups')
       .select('*')

--- a/features/guests/queries/guests.ts
+++ b/features/guests/queries/guests.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import {
   DbToAppTransformerSchema,
   GuestApp,
@@ -8,7 +8,7 @@ import {
 
 export const getEventGuests = async (eventId: string): Promise<GuestApp[]> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data: guests, error } = await supabase
       .from('guests')
       .select('*')
@@ -56,7 +56,7 @@ export const getGuestsWithInitialInvitation = async (
   eventId: string,
 ): Promise<Set<string>> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data } = await supabase
       .from('message_deliveries')
       .select('guest_id, schedules!inner(action_type, event_id)')
@@ -74,7 +74,7 @@ export const getEventGuestPhones = async (
   eventId: string,
 ): Promise<Map<string, string>> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data, error } = await supabase
       .from('guests')
       .select('phone_number, name')
@@ -106,7 +106,7 @@ export const getEventGuestsWithGroups = async (
   eventId: string,
 ): Promise<GuestWithGroupApp[]> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
 
     // Fetch guests with their group using Supabase's relation syntax
     const { data: guests, error } = await supabase

--- a/features/schedules/actions/schedules.ts
+++ b/features/schedules/actions/schedules.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 
 import { createClient } from '@/lib/supabase/server';
+import { assertNotImpersonating } from '@/lib/supabase/admin';
 import { DEFAULT_SCHEDULES_BY_EVENT_TYPE } from '../constants';
 import { getTemplatesByKeys } from '../config/whatsapp-templates';
 import { calculateScheduledDate } from '../utils';
@@ -26,6 +27,8 @@ export async function updateScheduledDate(
   scheduledDate: string,
   scheduledTime: string,
 ): Promise<UpdateScheduledDateState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const supabase = await createClient();
 
@@ -80,6 +83,8 @@ export async function updateScheduleStatus(
   scheduleId: string,
   enabled: boolean,
 ): Promise<UpdateScheduleStatusState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const supabase = await createClient();
 
@@ -139,6 +144,8 @@ export async function createDefaultSchedules(
   eventDate: string,
   eventType: string = 'wedding',
 ): Promise<CreateDefaultSchedulesState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const supabase = await createClient();
 
@@ -267,6 +274,8 @@ export async function createSchedulesFromSelection(
   eventId: string,
   selections: ScheduleSelectionItem[],
 ): Promise<CreateSchedulesFromSelectionState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
   try {
     const parsed = ScheduleSelectionSchema.safeParse(selections);
     if (!parsed.success) {

--- a/features/schedules/queries/message-deliveries.ts
+++ b/features/schedules/queries/message-deliveries.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 
 export type DeliveryMethodStats = {
   whatsapp: { successful: number; failed: number; total: number };
@@ -11,7 +11,7 @@ export type DeliveryMethodStats = {
 export async function getDeliveryMethodStats(
   scheduleId: string,
 ): Promise<DeliveryMethodStats> {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
   const empty: DeliveryMethodStats = {
     whatsapp: { successful: 0, failed: 0, total: 0 },
     sms: { successful: 0, failed: 0, total: 0 },

--- a/features/schedules/queries/schedules.ts
+++ b/features/schedules/queries/schedules.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import { ScheduleDbToAppSchema, type ScheduleApp } from '../schemas';
 
 /**
@@ -10,7 +10,7 @@ import { ScheduleDbToAppSchema, type ScheduleApp } from '../schemas';
 export async function getSchedulesByEventId(
   eventId: string,
 ): Promise<ScheduleApp[]> {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
 
   const { data, error } = await supabase
     .from('schedules')
@@ -54,7 +54,7 @@ export async function getScheduleById(
   })
   | null
 > {
-  const supabase = await createClient();
+  const { supabase } = await getEffectiveClient();
 
   const { data, error } = await supabase
     .from('schedules')

--- a/features/seating/queries/tables.ts
+++ b/features/seating/queries/tables.ts
@@ -1,11 +1,11 @@
-import { createClient } from '@/lib/supabase/server';
+import { getEffectiveClient } from '@/lib/supabase/admin';
 import { TableDbToAppTransformerSchema, type TableApp } from '../schemas';
 import { getEventGuestsWithGroups } from '@/features/guests/queries';
 import type { SeatingPageData, SeatingStatsView, TableWithGuestsApp } from '../types';
 
 export const getEventTables = async (eventId: string): Promise<TableApp[]> => {
   try {
-    const supabase = await createClient();
+    const { supabase } = await getEffectiveClient();
     const { data, error } = await supabase
       .from('tables')
       .select('*')

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,57 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+
+type ImpersonationContext = { userId: string } | null;
+
+// TODO: wrap with React cache() to deduplicate DB calls within a single render
+export async function getImpersonation(): Promise<ImpersonationContext> {
+  const cookieStore = await cookies();
+  const impersonateId = cookieStore.get('impersonate_user_id')?.value;
+  if (!impersonateId) return null;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  return profile?.is_admin ? { userId: impersonateId } : null;
+}
+
+export async function getEffectiveClient() {
+  const impersonation = await getImpersonation();
+  const supabase = impersonation ? createServiceClient() : await createClient();
+  return { supabase, impersonation };
+}
+
+export async function assertAdmin(): Promise<string> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect('/login');
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.is_admin) redirect('/app');
+
+  return user.id;
+}
+
+export async function assertNotImpersonating(): Promise<string | null> {
+  const impersonation = await getImpersonation();
+  return impersonation ? 'Read-only mode (impersonation)' : null;
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -74,6 +74,21 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
+  // Guard /admin routes: require is_admin = true on the user's profile
+  if (user && strippedPath.startsWith('/admin')) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single();
+
+    if (!profile?.is_admin) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/app';
+      return NextResponse.redirect(url);
+    }
+  }
+
   // IMPORTANT: You *must* return the supabaseResponse object as it is.
   // If you're creating a new response object with NextResponse.next() make sure to:
   // 1. Pass the request in it, like so:

--- a/supabase/migrations/20260517000000_add_is_admin_to_profiles.sql
+++ b/supabase/migrations/20260517000000_add_is_admin_to_profiles.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT false;

--- a/supabase/migrations/20260517000001_add_created_at_to_profiles.sql
+++ b/supabase/migrations/20260517000001_add_created_at_to_profiles.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+UPDATE public.profiles p
+SET created_at = u.created_at
+FROM auth.users u
+WHERE u.id = p.id;


### PR DESCRIPTION
- /admin routes with sidebar, users table, and event detail views
- is_admin column on profiles with middleware + layout guards
- Cookie-based impersonation (read-only, secure in production)
- getEffectiveClient() routes all queries through service client when impersonating
- assertNotImpersonating() blocks mutations on events, guests, and schedules
- Manual WhatsApp send action for admin use