### PR TITLE
Add admin trigger-schedule action and UI polish

### DIFF
--- a/app/[locale]/admin/events/[eventId]/page.tsx
+++ b/app/[locale]/admin/events/[eventId]/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { IconChevronLeft } from '@tabler/icons-react';
 import { getAdminEvent, getAdminEventSchedules } from '@/features/admin/queries/event-detail';
 import { ManualSendCard } from '@/features/admin/components/manual-send-card';
+import { TriggerScheduleCard } from '@/features/admin/components/trigger-schedule-card';
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline'> = {
   published: 'default',
@@ -62,6 +63,7 @@ export default async function AdminEventDetailPage({
         <h2 className="text-lg font-semibold mb-3">Quick Actions</h2>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
           <ManualSendCard eventId={eventId} schedules={schedules} />
+          <TriggerScheduleCard schedules={schedules} />
         </div>
       </div>
     </div>

--- a/features/admin/actions/trigger-schedule.ts
+++ b/features/admin/actions/trigger-schedule.ts
@@ -1,0 +1,179 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { getTemplateByKey } from '@/features/schedules/config/whatsapp-templates';
+import {
+  filterGuestsByTarget,
+  validatePhoneNumber,
+  sendInChunks,
+  buildDeliveryRecord,
+  generateConfirmationToken,
+} from '@/features/schedules/utils';
+import type { ParameterResolutionContext } from '@/features/schedules/utils/parameter-resolvers';
+import { ScheduleDbToAppSchema } from '@/features/schedules/schemas';
+import { DbToAppTransformerSchema } from '@/features/guests/schemas';
+import type { GroupApp } from '@/features/guests/schemas';
+
+export type TriggerScheduleResult = {
+  success: boolean;
+  message: string;
+  sentCount?: number;
+  failedCount?: number;
+};
+
+export async function triggerScheduleAdmin(scheduleId: string): Promise<TriggerScheduleResult> {
+  const tag = `[trigger-schedule-admin] schedule=${scheduleId}`;
+  console.log(`${tag} start`);
+
+  try {
+    await assertAdmin();
+    const supabase = createServiceClient();
+
+    const { data: scheduleRow, error: scheduleError } = await supabase
+      .from('schedules')
+      .select(`*, events (id, user_id, title, event_date, location, host_details, invitations)`)
+      .eq('id', scheduleId)
+      .single();
+
+    if (scheduleError || !scheduleRow || !scheduleRow.events) {
+      console.error(`${tag} schedule fetch failed`, scheduleError);
+      return { success: false, message: 'Schedule not found' };
+    }
+
+    if (scheduleRow.status === 'sent' || scheduleRow.status === 'cancelled') {
+      return { success: false, message: `Cannot trigger a schedule with status: ${scheduleRow.status}` };
+    }
+
+    if (!scheduleRow.template_key) {
+      return { success: false, message: 'No template assigned to this schedule' };
+    }
+
+    const templateConfig = getTemplateByKey(scheduleRow.template_key);
+    if (!templateConfig?.whatsapp?.parameters) {
+      return { success: false, message: 'Template not found or missing parameter config' };
+    }
+
+    const template = templateConfig.whatsapp;
+    const eventRow = scheduleRow.events;
+    const schedule = ScheduleDbToAppSchema.parse(scheduleRow);
+
+    const eventContext = {
+      id: eventRow.id,
+      userId: eventRow.user_id,
+      title: eventRow.title,
+      eventDate: eventRow.event_date,
+      location: eventRow.location ?? undefined,
+      hostDetails: eventRow.host_details ?? undefined,
+      invitations: eventRow.invitations ? { imageUrl: eventRow.invitations.image_url } : undefined,
+    };
+
+    const { data: guestRows, error: guestError } = await supabase
+      .from('guests')
+      .select('*')
+      .eq('event_id', eventRow.id);
+
+    if (guestError || !guestRows) {
+      console.error(`${tag} guest fetch failed`, guestError);
+      return { success: false, message: 'Failed to fetch guests' };
+    }
+
+    const allGuests = guestRows.map((g) => DbToAppTransformerSchema.parse(g));
+
+    const targeted = filterGuestsByTarget(
+      allGuests,
+      schedule.targetStatus,
+      schedule.actionType ?? undefined,
+    );
+
+    const guests = targeted.filter((g) => validatePhoneNumber(g.phone));
+
+    if (guests.length === 0) {
+      return { success: false, message: 'No eligible guests with valid phone numbers' };
+    }
+
+    const uniqueGroupIds = [...new Set(guests.map((g) => g.groupId).filter((id): id is string => !!id))];
+    const groupsMap = new Map<string, GroupApp>();
+    if (uniqueGroupIds.length > 0) {
+      const { data: groupRows } = await supabase.from('groups').select('*').in('id', uniqueGroupIds);
+      for (const row of groupRows ?? []) {
+        groupsMap.set(row.id, {
+          id: row.id,
+          eventId: row.event_id,
+          name: row.name,
+          description: row.description ?? null,
+          icon: row.icon ?? null,
+          side: (row.side ?? null) as 'bride' | 'groom' | null,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        });
+      }
+    }
+
+    console.log(`${tag} sending to ${guests.length} guests…`);
+
+    const sendResults = await sendInChunks(guests, (guest) => {
+      const confirmationToken = generateConfirmationToken();
+      const context: ParameterResolutionContext = {
+        guest,
+        event: eventContext,
+        group: guest.groupId ? (groupsMap.get(guest.groupId) ?? null) : null,
+        schedule,
+        confirmationToken,
+      };
+      return { context, template, confirmationToken };
+    });
+
+    const deliveryRecords: Record<string, unknown>[] = [];
+    let sentCount = 0;
+    let failedCount = 0;
+
+    for (const settled of sendResults) {
+      if (settled.status === 'fulfilled') {
+        const r = settled.value;
+        deliveryRecords.push(buildDeliveryRecord(scheduleId, r, 'manual'));
+        if (r.success) sentCount++;
+        else {
+          failedCount++;
+          console.warn(`${tag} failed guestId=${r.guest.id} code=${r.errorCode ?? 'none'} msg=${r.message}`);
+        }
+      } else {
+        failedCount++;
+        console.error(`${tag} send promise rejected`, settled.reason);
+      }
+    }
+
+    if (deliveryRecords.length > 0) {
+      const { error: insertError } = await supabase.from('message_deliveries').insert(deliveryRecords);
+      if (insertError) console.error(`${tag} delivery record insert failed`, insertError);
+    }
+
+    if (sentCount > 0) {
+      const { error: updateError } = await supabase
+        .from('schedules')
+        .update({ status: 'sent', sent_at: new Date().toISOString() })
+        .eq('id', scheduleId);
+      if (updateError) console.error(`${tag} schedule status update failed`, updateError);
+    }
+
+    revalidatePath('/app');
+    revalidatePath(`/admin/events/${eventRow.id}`);
+
+    if (sentCount === 0) {
+      return { success: false, message: 'All messages failed to send', sentCount: 0, failedCount };
+    }
+
+    const result = {
+      success: true,
+      message: `Sent ${sentCount} message${sentCount !== 1 ? 's' : ''}${failedCount > 0 ? `, ${failedCount} failed` : ''}`,
+      sentCount,
+      failedCount,
+    };
+    console.log(`${tag} done`, result.message);
+    return result;
+  } catch (error) {
+    console.error(`${tag} unexpected error`, error);
+    return { success: false, message: 'Failed to trigger schedule' };
+  }
+}

--- a/features/admin/components/trigger-schedule-card.tsx
+++ b/features/admin/components/trigger-schedule-card.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+import { IconBolt, IconLoader2 } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ACTION_TYPE_LABELS } from '@/features/schedules/schemas';
+import type { ScheduleApp } from '@/features/schedules/schemas';
+import { triggerScheduleAdmin } from '../actions/trigger-schedule';
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function TriggerScheduleCard({
+  schedules,
+}: {
+  schedules: ScheduleApp[];
+}) {
+  const unsentSchedules = schedules.filter(
+    (s) => s.status !== 'sent' && s.status !== 'cancelled',
+  );
+
+  const [open, setOpen] = useState(false);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<string>('');
+  const [isSending, startSending] = useTransition();
+
+  function handleTrigger() {
+    if (!selectedScheduleId) return;
+    startSending(async () => {
+      const promise = triggerScheduleAdmin(selectedScheduleId).then((result) => {
+        if (!result.success) throw new Error(result.message);
+        return result;
+      });
+      toast.promise(promise, {
+        loading: 'Triggering schedule…',
+        success: (data) => {
+          setOpen(false);
+          setSelectedScheduleId('');
+          return data.message ?? 'Schedule triggered';
+        },
+        error: (err) => (err instanceof Error ? err.message : 'Failed to trigger schedule'),
+      });
+      await promise.catch(() => {});
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button className="group flex flex-col gap-3 rounded-xl border bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-50 text-amber-600 transition-colors group-hover:bg-amber-100">
+            <IconBolt className="h-5 w-5" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-foreground">Trigger Schedule</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Run a schedule for all eligible guests
+            </p>
+          </div>
+        </button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Trigger Schedule</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {unsentSchedules.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No unsent schedules for this event
+            </p>
+          ) : (
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Schedule</label>
+              <Select value={selectedScheduleId} onValueChange={setSelectedScheduleId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a schedule…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {unsentSchedules.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      <span>
+                        {s.actionType ? ACTION_TYPE_LABELS[s.actionType] : 'Schedule'}
+                        <span className="ml-2 text-muted-foreground">
+                          · {formatDate(s.scheduledDate)}
+                        </span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleTrigger}
+              disabled={!selectedScheduleId || isSending || unsentSchedules.length === 0}
+            >
+              {isSending && <IconLoader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+              Trigger
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/guests/components/guest-directory.tsx
+++ b/features/guests/components/guest-directory.tsx
@@ -111,48 +111,52 @@ export function GuestDirectory({
     onSelectGuest(null);
   };
 
+  const isEmpty = guests.length === 0;
+
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <GuestSearch searchTerm={searchTerm} onSearchChange={setSearchTerm} />
-          <Button
-            variant="outline"
-            onClick={() => setImportDialogOpen(true)}
-            className="gap-2"
-          >
-            <IconUpload size={16} />
-            {t('directory.importCsv')}
-          </Button>
-        </div>
-        <div className="flex items-center gap-2">
-          <RsvpStatusFilter
-            selectedStatuses={selectedStatuses}
-            onStatusToggle={handleStatusToggle}
-          />
-          <GroupFilter
-            groups={groups}
-            selectedGroupIds={selectedGroupIds}
-            onGroupToggle={handleGroupToggle}
-            onSelectAll={handleSelectAllGroups}
-            isAllSelected={isAllSelected}
-          />
-          <SideFilter
-            selectedSides={selectedSides}
-            onSideToggle={handleSideToggle}
-            onSelectAll={handleSelectAllSides}
-            isAllSelected={isAllSidesSelected}
-          />
-          <Button
-            variant="outline"
-            onClick={toggleNoPhoneOnly}
-            className={cn('gap-2', noPhoneOnly && 'border-primary/50 bg-primary/8 text-primary font-medium hover:bg-primary/15 hover:text-primary')}
-          >
-            <IconPhoneOff size={16} />
-            {t('filters.noPhone')}
-          </Button>
-        </div>
-      </CardHeader>
+      {!isEmpty && (
+        <CardHeader className="flex flex-row items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <GuestSearch searchTerm={searchTerm} onSearchChange={setSearchTerm} />
+            <Button
+              variant="outline"
+              onClick={() => setImportDialogOpen(true)}
+              className="gap-2"
+            >
+              <IconUpload size={16} />
+              {t('directory.importCsv')}
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
+            <RsvpStatusFilter
+              selectedStatuses={selectedStatuses}
+              onStatusToggle={handleStatusToggle}
+            />
+            <GroupFilter
+              groups={groups}
+              selectedGroupIds={selectedGroupIds}
+              onGroupToggle={handleGroupToggle}
+              onSelectAll={handleSelectAllGroups}
+              isAllSelected={isAllSelected}
+            />
+            <SideFilter
+              selectedSides={selectedSides}
+              onSideToggle={handleSideToggle}
+              onSelectAll={handleSelectAllSides}
+              isAllSelected={isAllSidesSelected}
+            />
+            <Button
+              variant="outline"
+              onClick={toggleNoPhoneOnly}
+              className={cn('gap-2', noPhoneOnly && 'border-primary/50 bg-primary/8 text-primary font-medium hover:bg-primary/15 hover:text-primary')}
+            >
+              <IconPhoneOff size={16} />
+              {t('filters.noPhone')}
+            </Button>
+          </div>
+        </CardHeader>
+      )}
       <CardContent ref={tableContainerRef}>
         {isCalculated ? (
           <GuestsTable

--- a/features/schedules/components/message-content-card.tsx
+++ b/features/schedules/components/message-content-card.tsx
@@ -72,7 +72,7 @@ export function MessageContentCard({
   const buttons = template?.parameters?.buttonPlaceholders ?? [];
 
   return (
-    <Card className="h-full flex flex-col">
+    <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <div className="bg-primary/10 rounded-md p-1.5">
@@ -84,12 +84,12 @@ export function MessageContentCard({
           {t('cardDescription')}
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col flex-1 min-h-0">
+      <CardContent>
         {/* WhatsApp phone mockup */}
-        <div className="flex flex-col overflow-hidden rounded-xl border border-zinc-200 shadow-sm flex-1 min-h-0">
+        <div className="overflow-hidden rounded-xl border border-zinc-200 shadow-sm">
           {/* Chat area */}
           <div
-            className="flex flex-1 flex-col gap-1 px-3 py-4"
+            className="flex flex-col gap-1 px-3 py-4"
             style={chatBgStyle}
           >
             {template === null ? (

--- a/features/schedules/config/whatsapp-templates.ts
+++ b/features/schedules/config/whatsapp-templates.ts
@@ -41,15 +41,20 @@ export const WHATSAPP_TEMPLATES: Record<string, TemplateConfig> = {
   confirmation_casual_v1_he: {
     whatsapp: {
       templateKey: 'confirmation_casual_v1_he',
-      templateName: 'confirmation_casual_v1_he',
+      templateName: 'confirmation_initial_with_header_casual',
       bodyText:
-        'היי, \nהוזמנת לחתונתם של {{1}} ו{{2}}\nשתתקיים בתאריך {{3}} ב{{4}}\nמחכים לדעת אם נזכה לראות אותך באירוע.\nלאישור הגעה ופרטים נוספים, לחצו על הכפתור למטה',
+        'היי אורחים יקרים\nהחתונה של {{1}} ו{{2}} מתקרבת, נשמח לדעת אם תגיעו.\n\n📅 {{3}}\n📍 {{4}}\n\nמחכים לחגוג איתכם ❤️\nלאישור הגעה, לחצו על הכפתור 👇🏼',
       languageCode: 'he',
-      headerType: null,
+      headerType: 'IMAGE',
       headerText: null,
       footerText: null,
       parameters: {
-        headerPlaceholders: [],
+        headerPlaceholders: [
+          {
+            type: 'image',
+            source: 'event.invitations.imageUrl',
+          },
+        ],
         placeholders: {
           'host.bride.name': {
             source: 'event.hostDetails.bride.name',


### PR DESCRIPTION
- Add TriggerScheduleCard for manually triggering schedules from the admin event detail page
- Reuse DbToAppTransformerSchema instead of manual guest row mapping
- Update confirmation_casual_v1_he WhatsApp template (name, body, IMAGE header)
- Hide guest directory header when guest list is empty
- Remove flex-stretch layout from message-content-card