### PR TITLE
Fix view interactions never recording due to partial index mismatch

### DIFF
--- a/features/confirmation/actions/index.ts
+++ b/features/confirmation/actions/index.ts
@@ -123,10 +123,12 @@ export async function recordViewInteraction(
   scheduleId: string,
 ): Promise<void> {
   const supabase = createServiceClient();
-  await supabase
+  const { error } = await supabase
     .from('guest_interactions')
-    .upsert(
-      { guest_id: guestId, schedule_id: scheduleId, interaction_type: 'view', created_at: new Date().toISOString() },
-      { onConflict: 'guest_id,schedule_id', ignoreDuplicates: false },
-    );
+    .insert({ guest_id: guestId, schedule_id: scheduleId, interaction_type: 'view' });
+
+  // 23505 = unique_violation: guest already viewed this schedule, ignore
+  if (error && error.code !== '23505') {
+    console.error('Error recording view interaction:', error);
+  }
 }

--- a/features/schedules/actions/whatsapp.ts
+++ b/features/schedules/actions/whatsapp.ts
@@ -92,13 +92,13 @@ export async function sendWhatsAppTemplateMessage(params: {
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      console.error('WhatsApp API error:', {
+      console.error('WhatsApp API error:', JSON.stringify({
         status: response.status,
         statusText: response.statusText,
         error: errorData,
         to: params.to,
         template: params.templateName,
-      });
+      }, null, 2));
 
       const metaErrorCode =
         typeof errorData?.error?.code === 'number'


### PR DESCRIPTION
upsert with onConflict:'guest_id,schedule_id' silently failed because the only unique constraint on those columns is a partial index (WHERE interaction_type='view'). PostgreSQL rejects ON CONFLICT targets that don't match a non-partial constraint, so no view rows were ever inserted. Switch to insert + ignore 23505 to handle duplicates correctly.