### PR TITLE
Add refresh button to guest interactions card; fix RTL pagination

### DIFF
--- a/features/schedules/components/guest-interactions-table.tsx
+++ b/features/schedules/components/guest-interactions-table.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useLocale } from 'next-intl';
 import { IconCheck, IconChevronLeft, IconChevronRight, IconEye, IconX } from '@tabler/icons-react';
 
 import { Button } from '@/components/ui/button';
@@ -68,6 +69,7 @@ interface GuestInteractionsTableProps {
 
 export function GuestInteractionsTable({ guests, labels }: GuestInteractionsTableProps) {
   const [page, setPage] = useState(0);
+  const isRTL = useLocale() === 'he';
   const totalPages = Math.ceil(guests.length / PAGE_SIZE);
   const slice = guests.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
@@ -112,7 +114,7 @@ export function GuestInteractionsTable({ guests, labels }: GuestInteractionsTabl
         <TableFooter>
           <TableRow>
             <TableCell colSpan={4}>
-              <div className="flex items-center justify-end gap-2">
+              <div className="flex items-center justify-end gap-2 rtl:justify-start">
                 <span className="text-muted-foreground text-xs">{page + 1} / {totalPages}</span>
                 <Button
                   variant="outline"
@@ -121,7 +123,7 @@ export function GuestInteractionsTable({ guests, labels }: GuestInteractionsTabl
                   onClick={() => setPage((p) => p - 1)}
                   disabled={page === 0}
                 >
-                  <IconChevronLeft size={14} />
+                  {isRTL ? <IconChevronRight size={14} /> : <IconChevronLeft size={14} />}
                 </Button>
                 <Button
                   variant="outline"
@@ -130,7 +132,7 @@ export function GuestInteractionsTable({ guests, labels }: GuestInteractionsTabl
                   onClick={() => setPage((p) => p + 1)}
                   disabled={page === totalPages - 1}
                 >
-                  <IconChevronRight size={14} />
+                  {isRTL ? <IconChevronLeft size={14} /> : <IconChevronRight size={14} />}
                 </Button>
               </div>
             </TableCell>

--- a/features/schedules/components/interactions-refresh-button.tsx
+++ b/features/schedules/components/interactions-refresh-button.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from '@/i18n/navigation';
+import { useTranslations } from 'next-intl';
+import { IconRefresh } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function InteractionsRefreshButton() {
+  const router = useRouter();
+  const t = useTranslations('schedules.interactions');
+  const [isPending, startTransition] = useTransition();
+
+  const handleRefresh = () => {
+    startTransition(() => {
+      router.refresh();
+    });
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7 text-muted-foreground hover:text-foreground"
+      onClick={handleRefresh}
+      disabled={isPending}
+      aria-label={t('refresh')}
+    >
+      <IconRefresh
+        size={15}
+        className={cn(isPending && 'animate-spin')}
+      />
+    </Button>
+  );
+}

--- a/features/schedules/components/schedule-interactions-card.tsx
+++ b/features/schedules/components/schedule-interactions-card.tsx
@@ -8,10 +8,11 @@ import {
 } from '@tabler/icons-react';
 
 import { cn } from '@/lib/utils';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 import { getScheduleInteractionData } from '../queries/guest-interactions';
 import { GuestInteractionsTable } from './guest-interactions-table';
+import { InteractionsRefreshButton } from './interactions-refresh-button';
 
 interface ScheduleInteractionsCardProps {
   scheduleId: string;
@@ -54,6 +55,9 @@ export async function ScheduleInteractionsCard({ scheduleId }: ScheduleInteracti
           </div>
           {t('cardTitle')}
         </CardTitle>
+        <CardAction>
+          <InteractionsRefreshButton />
+        </CardAction>
       </CardHeader>
       <CardContent>
         {isEmpty ? (

--- a/messages/en.json
+++ b/messages/en.json
@@ -806,7 +806,8 @@
       "columnDate": "Date",
       "responseConfirmed": "Confirmed",
       "responseDeclined": "Declined",
-      "responsePending": "No response"
+      "responsePending": "No response",
+      "refresh": "Refresh"
     },
     "status": {
       "cardTitle": "Status",

--- a/messages/he.json
+++ b/messages/he.json
@@ -807,7 +807,8 @@
       "columnDate": "תאריך",
       "responseConfirmed": "אישר",
       "responseDeclined": "סירב",
-      "responsePending": "לא הגיב"
+      "responsePending": "לא הגיב",
+      "refresh": "רענן"
     },
     "status": {
       "cardTitle": "סטטוס",


### PR DESCRIPTION
## Summary

- Adds a refresh button to the Guests Activity card header — clicking it calls `router.refresh()` inside a `useTransition`, spinning the icon while the server component re-fetches
- Fixes table footer pagination alignment in RTL: `justify-end` was placing buttons on the visual left in Hebrew; `rtl:justify-start` keeps them right-aligned
- Fixes chevron icon direction in RTL pagination — prev/next arrows now point in the correct spatial direction per locale

## Test plan

- [ ] Open a schedule's results tab in Hebrew (`/he/app/.../schedules/...`) — refresh button appears top-right of the Guests Activity card, spins on click, and data reloads
- [ ] Pagination footer (when > 10 guests) is right-aligned in Hebrew and left-aligned in English
- [ ] Prev/next chevrons point the correct direction in both locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)