### PR TITLE
Add SMS as a delivery method for confirmation schedules

### DIFF
--- a/features/schedules/actions/execute-schedule.ts
+++ b/features/schedules/actions/execute-schedule.ts
@@ -10,9 +10,11 @@ import {
   filterGuestsByTarget,
   validatePhoneNumber,
   sendInChunks,
+  sendSmsToGuest,
   buildDeliveryRecord,
   generateConfirmationToken,
   type ParameterResolutionContext,
+  type GuestSendResult,
 } from '../utils';
 import type { GroupApp } from '@/features/guests/schemas';
 
@@ -146,45 +148,64 @@ export async function executeSchedule(
 
     const skippedCount = targetedGuests.length - guestsWithPhones.length;
 
-    // 9. Validate template has parameters configuration
-    if (!template.parameters) {
-      return {
-        success: false,
-        message: 'Template missing parameter configuration',
-      };
+    // 9-11. Send messages — dispatched by delivery method
+    let sendResults: PromiseSettledResult<GuestSendResult>[];
+
+    if (schedule.deliveryMethod === 'sms') {
+      sendResults = await Promise.allSettled(
+        guestsWithPhones.map((guest) => {
+          const confirmationToken = generateConfirmationToken();
+          const context: ParameterResolutionContext = {
+            guest,
+            event: schedule.event,
+            group: null,
+            schedule,
+            confirmationToken,
+          };
+          return sendSmsToGuest({ guest, context, confirmationToken });
+        }),
+      );
+    } else {
+      // 9. Validate template has parameters configuration
+      if (!template.parameters) {
+        return {
+          success: false,
+          message: 'Template missing parameter configuration',
+        };
+      }
+
+      // 10. Batch fetch all needed groups for performance
+      const uniqueGroupIds = [
+        ...new Set(
+          guestsWithPhones
+            .map((guest) => guest.groupId)
+            .filter((id): id is string => !!id),
+        ),
+      ];
+
+      const groupsMap = new Map<string, GroupApp>();
+      await Promise.all(
+        uniqueGroupIds.map(async (groupId) => {
+          const group = await getGroupById(groupId);
+          if (group) {
+            groupsMap.set(groupId, group);
+          }
+        }),
+      );
+
+      // 11. Send messages in rate-limited chunks
+      sendResults = await sendInChunks(guestsWithPhones, (guest) => {
+        const confirmationToken = generateConfirmationToken();
+        const context: ParameterResolutionContext = {
+          guest,
+          event: schedule.event,
+          group: guest.groupId ? groupsMap.get(guest.groupId) : null,
+          schedule,
+          confirmationToken,
+        };
+        return { context, template, confirmationToken };
+      });
     }
-
-    // 10. Batch fetch all needed groups for performance
-    const uniqueGroupIds = [
-      ...new Set(
-        guestsWithPhones
-          .map((guest) => guest.groupId)
-          .filter((id): id is string => !!id),
-      ),
-    ];
-
-    const groupsMap = new Map<string, GroupApp>();
-    await Promise.all(
-      uniqueGroupIds.map(async (groupId) => {
-        const group = await getGroupById(groupId);
-        if (group) {
-          groupsMap.set(groupId, group);
-        }
-      }),
-    );
-
-    // 11. Send messages in rate-limited chunks
-    const sendResults = await sendInChunks(guestsWithPhones, (guest) => {
-      const confirmationToken = generateConfirmationToken();
-      const context: ParameterResolutionContext = {
-        guest,
-        event: schedule.event,
-        group: guest.groupId ? groupsMap.get(guest.groupId) : null,
-        schedule,
-        confirmationToken,
-      };
-      return { context, template, confirmationToken };
-    });
 
     // 12. Process results and create delivery records
     const deliveryRecords = [];

--- a/features/schedules/actions/schedules.ts
+++ b/features/schedules/actions/schedules.ts
@@ -223,7 +223,7 @@ export async function createDefaultSchedules(
         template_key: schedule.templateKey,
         scheduled_date,
         scheduled_time,
-        delivery_method: 'whatsapp' as const,
+        delivery_method: (schedule.deliveryMethod ?? 'whatsapp') as 'whatsapp' | 'sms',
         target_status: schedule.targetStatus ?? null,
         action_type: schedule.actionType,
       };
@@ -330,7 +330,7 @@ export async function createSchedulesFromSelection(
       template_key: s.templateKey,
       scheduled_date: s.scheduledDate,
       scheduled_time: s.scheduledTime,
-      delivery_method: 'whatsapp' as const,
+      delivery_method: (s.deliveryMethod ?? 'whatsapp') as 'whatsapp' | 'sms',
       target_status: s.targetStatus,
       action_type: s.actionType,
       status: s.status,

--- a/features/schedules/components/schedule-setup-wizard.tsx
+++ b/features/schedules/components/schedule-setup-wizard.tsx
@@ -77,6 +77,7 @@ export function ScheduleSetupWizard({
           enabled: true,
           date: new Date(s.scheduledDate),
           time: s.defaultTime,
+          deliveryMethod: s.deliveryMethod,
         })),
     [suggestedSchedules],
   );
@@ -122,6 +123,7 @@ export function ScheduleSetupWizard({
         scheduledTime: invitationSuggestion.defaultTime,
         targetStatus: invitationSuggestion.targetStatus,
         status: invitationDecision === 'send' ? null : 'cancelled',
+        deliveryMethod: invitationSuggestion.deliveryMethod,
       });
     }
 
@@ -133,6 +135,7 @@ export function ScheduleSetupWizard({
         scheduledTime: row.time,
         targetStatus: row.targetStatus,
         status: row.enabled ? null : 'cancelled',
+        deliveryMethod: row.deliveryMethod,
       });
     }
 

--- a/features/schedules/components/wizard/wizard-timeline-step.tsx
+++ b/features/schedules/components/wizard/wizard-timeline-step.tsx
@@ -25,6 +25,7 @@ export type TimelineRow = {
   enabled: boolean;
   date: Date;
   time: string;
+  deliveryMethod: 'whatsapp' | 'sms';
 };
 
 interface WizardTimelineStepProps {

--- a/features/schedules/config/sms-bodies.ts
+++ b/features/schedules/config/sms-bodies.ts
@@ -1,0 +1,35 @@
+import type { ParameterResolutionContext } from '../utils/parameter-resolvers';
+import { buildDynamicTemplateParameters } from '../utils/parameter-resolvers';
+import { getTemplateByKey } from './whatsapp-templates';
+
+function resolveSiteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_VERCEL_URL ||
+    'http://localhost:3000'
+  );
+}
+
+const SMS_CONFIRMATION_BODY =
+  'היי אורחים יקרים\nהחתונה של {{1}} ו{{2}} מתקרבת, נשמח לדעת אם תגיעו.\n\n📅 {{3}}\n📍 {{4}}\n\nמחכים לחגוג איתכם ❤️\nלאישור הגעה, לחצו על הקישור 👇🏼';
+
+export function buildSmsConfirmationBody(
+  context: ParameterResolutionContext,
+  confirmationToken: string,
+): string {
+  const siteUrl = resolveSiteUrl();
+  const rsvpLink = `${siteUrl}/confirm/${confirmationToken}`;
+
+  const placeholders = getTemplateByKey('confirmation_casual_v1_he')?.whatsapp.parameters?.placeholders;
+  if (!placeholders) {
+    console.error('[SMS] Failed to resolve placeholders for confirmation_casual_v1_he');
+    throw new Error('SMS template resolution failed');
+  }
+
+  const params = buildDynamicTemplateParameters(placeholders, context);
+  let body = SMS_CONFIRMATION_BODY;
+  params.forEach((param, i) => {
+    body = body.replace(`{{${i + 1}}}`, param.text);
+  });
+  return `${body}\n${rsvpLink}`;
+}

--- a/features/schedules/constants/index.ts
+++ b/features/schedules/constants/index.ts
@@ -6,6 +6,7 @@ export type DefaultScheduleConfig = {
   daysOffset: number; // Negative = before event, positive = after
   defaultTime: string; // HH:MM format
   targetStatus?: 'pending' | 'confirmed';
+  deliveryMethod?: 'whatsapp' | 'sms';
 };
 
 // Default schedules for wedding events
@@ -24,6 +25,14 @@ export const WEDDING_DEFAULT_SCHEDULES: DefaultScheduleConfig[] = [
     daysOffset: -21,
     defaultTime: '10:00',
     targetStatus: 'pending',
+  },
+  {
+    templateKey: 'confirmation_casual_v1_he',
+    actionType: 'confirmation',
+    daysOffset: -17,
+    defaultTime: '10:00',
+    targetStatus: 'pending',
+    deliveryMethod: 'sms',
   },
   {
     templateKey: 'confirmation_casual_v1_he',

--- a/features/schedules/schemas/index.ts
+++ b/features/schedules/schemas/index.ts
@@ -155,6 +155,7 @@ export const ScheduleSelectionItemSchema = z.object({
   targetStatus: z.enum(['pending', 'confirmed']).nullable(),
   // null = active; 'cancelled' = created but disabled (user opted out in the wizard)
   status: z.enum(SCHEDULE_STATUSES).nullable(),
+  deliveryMethod: z.enum(DELIVERY_METHODS).default('whatsapp'),
 });
 
 export type ScheduleSelectionItem = z.infer<typeof ScheduleSelectionItemSchema>;

--- a/features/schedules/utils/index.ts
+++ b/features/schedules/utils/index.ts
@@ -15,6 +15,7 @@ export {
 export {
   categoriseWhatsAppError,
   sendToGuest,
+  sendSmsToGuest,
   sendInChunks,
   buildDeliveryRecord,
   generateConfirmationToken,

--- a/features/schedules/utils/send-helpers.ts
+++ b/features/schedules/utils/send-helpers.ts
@@ -4,6 +4,7 @@ import type { DeliveryMethod } from '../schemas';
 import type { WhatsAppTemplateApp } from '../schemas/whatsapp-templates';
 import { sendWhatsAppTemplateMessage } from '../actions/whatsapp';
 import { sendSmsMessage, buildSmsFallbackBody } from '../actions/sms';
+import { buildSmsConfirmationBody } from '../config/sms-bodies';
 import {
   buildDynamicTemplateParameters,
   buildDynamicButtonParameters,
@@ -129,6 +130,28 @@ export async function sendToGuest(params: {
     message: waResult.message,
     channel: 'whatsapp',
     errorCode: waResult.errorCode,
+    confirmationToken,
+  };
+}
+
+// ─── SMS primary send ─────────────────────────────────────────────────────────
+
+export async function sendSmsToGuest(params: {
+  guest: GuestApp;
+  context: ParameterResolutionContext;
+  confirmationToken: string;
+}): Promise<GuestSendResult> {
+  const { guest, context, confirmationToken } = params;
+  const phoneE164 = formatPhoneE164(guest.phone!);
+  const body = buildSmsConfirmationBody(context, confirmationToken);
+  const result = await sendSmsMessage({ to: phoneE164, body });
+
+  return {
+    guest,
+    success: result.success,
+    messageId: result.messageId,
+    message: result.message,
+    channel: 'sms',
     confirmationToken,
   };
 }

--- a/features/schedules/utils/suggested-schedules.ts
+++ b/features/schedules/utils/suggested-schedules.ts
@@ -9,6 +9,7 @@ export type SuggestedSchedule = {
   defaultTime: string;
   targetStatus: 'pending' | 'confirmed' | null;
   scheduledDate: string; // concrete ISO date derived from the event date
+  deliveryMethod: 'whatsapp' | 'sms';
 };
 
 /**
@@ -34,5 +35,6 @@ export function buildSuggestedSchedules(
       config.daysOffset,
       config.defaultTime,
     ),
+    deliveryMethod: config.deliveryMethod ?? 'whatsapp',
   }));
 }

--- a/lib/services/message-processor.ts
+++ b/lib/services/message-processor.ts
@@ -9,6 +9,7 @@ import {
   filterGuestsByTarget,
   validatePhoneNumber,
   sendInChunks,
+  sendSmsToGuest,
   buildDeliveryRecord,
   generateConfirmationToken,
   type ParameterResolutionContext,
@@ -216,6 +217,59 @@ async function processSingleSchedule(
       `[cron] Schedule ${schedule.id}: all eligible guests already delivered`,
     );
     return { sentCount: 0, failedCount: 0 };
+  }
+
+  // SMS schedules: send via ActiveTrail and return early (no WhatsApp template needed)
+  if (schedule.deliveryMethod === 'sms') {
+    let sentCount = 0;
+    let failedCount = 0;
+
+    const results = await Promise.allSettled(
+      pendingGuests.map((guest) => {
+        const confirmationToken = generateConfirmationToken();
+        const context: ParameterResolutionContext = {
+          guest,
+          event,
+          group: null,
+          schedule,
+          confirmationToken,
+        };
+        return sendSmsToGuest({ guest, context, confirmationToken });
+      }),
+    );
+
+    const deliveryRecords = [];
+    for (const settled of results) {
+      if (settled.status === 'fulfilled') {
+        const r = settled.value;
+        deliveryRecords.push(buildDeliveryRecord(schedule.id, r));
+        if (r.success) {
+          sentCount++;
+        } else {
+          failedCount++;
+          console.error(`[cron] SMS failed to send to ${r.guest.name}:`, r.message);
+        }
+      } else {
+        failedCount++;
+        console.error('[cron] SMS send promise rejected:', settled.reason);
+      }
+    }
+
+    if (deliveryRecords.length > 0) {
+      const { error: upsertError } = await supabase
+        .from('message_deliveries')
+        .upsert(deliveryRecords, { onConflict: 'schedule_id,guest_id' });
+      if (upsertError) {
+        console.error('[cron] Error upserting SMS delivery records:', upsertError);
+      }
+    }
+
+    if (sentCount === 0) {
+      await revertOrCancel(supabase, schedule.id, rawScheduleWithEvent.scheduled_date);
+    }
+
+    console.log(`[cron] Schedule ${schedule.id} (SMS): sent=${sentCount}, failed=${failedCount}`);
+    return { sentCount, failedCount };
   }
 
   // 7. Validate template has parameters configuration


### PR DESCRIPTION
Wire deliveryMethod through wizard → schema → suggested schedules → create actions → execute action and cron processor. New sendSmsToGuest helper builds the body via sms-bodies config and dispatches via ActiveTrail. Default schedule config gains an SMS confirmation at -17d.