### PR TITLE
Add admin phone calls feature for RSVP tracking

### DIFF
--- a/app/[locale]/admin/events/[eventId]/calls/page.tsx
+++ b/app/[locale]/admin/events/[eventId]/calls/page.tsx
@@ -1,0 +1,13 @@
+import { getCallRounds } from '@/features/admin/queries/calls';
+import { PhoneCallsView } from '@/features/admin/components/phone-calls-view';
+
+export default async function AdminEventCallsPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId } = await params;
+  const rounds = await getCallRounds(eventId);
+
+  return <PhoneCallsView eventId={eventId} initialRounds={rounds} />;
+}

--- a/app/[locale]/admin/events/[eventId]/layout.tsx
+++ b/app/[locale]/admin/events/[eventId]/layout.tsx
@@ -1,0 +1,70 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { IconChevronLeft } from '@tabler/icons-react';
+import { getAdminEvent } from '@/features/admin/queries/event-detail';
+import { EventDetailTabs } from '@/features/admin/components/event-detail-tabs';
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline'> = {
+  published: 'default',
+  draft: 'secondary',
+  archived: 'outline',
+};
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export default async function AdminEventLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId } = await params;
+  const event = await getAdminEvent(eventId);
+
+  if (!event) notFound();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/admin/events">
+            <IconChevronLeft className="mr-1 h-4 w-4" />
+            Events
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{event.title}</h1>
+          <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+            <span>{formatDate(event.eventDate)}</span>
+            <Badge variant={STATUS_VARIANT[event.status] ?? 'outline'}>{event.status}</Badge>
+            <Link href={`/admin/users/${event.ownerId}`} className="text-blue-600 hover:underline">
+              {event.ownerEmail}
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <EventDetailTabs eventId={eventId} />
+
+      <Card>
+        <CardContent>
+          {children}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/[locale]/admin/events/[eventId]/page.tsx
+++ b/app/[locale]/admin/events/[eventId]/page.tsx
@@ -1,26 +1,6 @@
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { IconChevronLeft } from '@tabler/icons-react';
-import { getAdminEvent, getAdminEventSchedules } from '@/features/admin/queries/event-detail';
+import { getAdminEventSchedules } from '@/features/admin/queries/event-detail';
 import { ManualSendCard } from '@/features/admin/components/manual-send-card';
 import { TriggerScheduleCard } from '@/features/admin/components/trigger-schedule-card';
-
-const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline'> = {
-  published: 'default',
-  draft: 'secondary',
-  archived: 'outline',
-};
-
-function formatDate(dateStr: string | null) {
-  if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleDateString('en-GB', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  });
-}
 
 export default async function AdminEventDetailPage({
   params,
@@ -28,43 +8,14 @@ export default async function AdminEventDetailPage({
   params: Promise<{ eventId: string }>;
 }) {
   const { eventId } = await params;
-  const [event, schedules] = await Promise.all([
-    getAdminEvent(eventId),
-    getAdminEventSchedules(eventId),
-  ]);
-
-  if (!event) notFound();
+  const schedules = await getAdminEventSchedules(eventId);
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Button variant="ghost" size="sm" asChild>
-          <Link href="/admin/events">
-            <IconChevronLeft className="mr-1 h-4 w-4" />
-            Events
-          </Link>
-        </Button>
-      </div>
-
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">{event.title}</h1>
-          <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
-            <span>{formatDate(event.eventDate)}</span>
-            <Badge variant={STATUS_VARIANT[event.status] ?? 'outline'}>{event.status}</Badge>
-            <Link href={`/admin/users/${event.ownerId}`} className="text-blue-600 hover:underline">
-              {event.ownerEmail}
-            </Link>
-          </div>
-        </div>
-      </div>
-
-      <div>
-        <h2 className="text-lg font-semibold mb-3">Quick Actions</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-          <ManualSendCard eventId={eventId} schedules={schedules} />
-          <TriggerScheduleCard eventId={eventId} schedules={schedules} />
-        </div>
+    <div>
+      <h2 className="text-lg font-semibold mb-3">Quick Actions</h2>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <ManualSendCard eventId={eventId} schedules={schedules} />
+        <TriggerScheduleCard eventId={eventId} schedules={schedules} />
       </div>
     </div>
   );

--- a/features/admin/actions/calls.ts
+++ b/features/admin/actions/calls.ts
@@ -1,0 +1,167 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import type { CallOutcome } from '../types';
+
+export type StartCallRoundResult = {
+  success: boolean;
+  message: string;
+  roundId?: string;
+  count?: number;
+  roundNumber?: number;
+};
+
+export async function startCallRound(eventId: string): Promise<StartCallRoundResult> {
+  try {
+    const adminId = await assertAdmin();
+    const supabase = createServiceClient();
+
+    const { data: existingRounds } = await supabase
+      .from('call_rounds')
+      .select('round_number')
+      .eq('event_id', eventId)
+      .order('round_number', { ascending: false })
+      .limit(1);
+
+    const nextRoundNumber = (existingRounds?.[0]?.round_number ?? 0) + 1;
+
+    const { data: round, error: roundError } = await supabase
+      .from('call_rounds')
+      .insert({ event_id: eventId, round_number: nextRoundNumber, started_by: adminId })
+      .select('id')
+      .single();
+
+    if (roundError || !round) {
+      return { success: false, message: 'Failed to create call round' };
+    }
+
+    const { data: pendingGuests } = await supabase
+      .from('guests')
+      .select('id')
+      .eq('event_id', eventId)
+      .eq('rsvp_status', 'pending');
+
+    if (!pendingGuests || pendingGuests.length === 0) {
+      await supabase.from('call_rounds').delete().eq('id', round.id);
+      return { success: false, message: 'No pending guests to call' };
+    }
+
+    const logs = pendingGuests.map((g) => ({ round_id: round.id, guest_id: g.id }));
+    const { error: logsError } = await supabase.from('call_logs').insert(logs);
+
+    if (logsError) {
+      await supabase.from('call_rounds').delete().eq('id', round.id);
+      return { success: false, message: 'Failed to snapshot guests' };
+    }
+
+    revalidatePath(`/admin/events/${eventId}/calls`);
+
+    return {
+      success: true,
+      message: `Round ${nextRoundNumber} started with ${pendingGuests.length} guest${pendingGuests.length !== 1 ? 's' : ''}`,
+      roundId: round.id,
+      count: pendingGuests.length,
+      roundNumber: nextRoundNumber,
+    };
+  } catch {
+    return { success: false, message: 'Failed to start call round' };
+  }
+}
+
+export type DeleteCallRoundResult = {
+  success: boolean;
+  message: string;
+};
+
+export async function deleteCallRound(roundId: string, eventId: string): Promise<DeleteCallRoundResult> {
+  try {
+    await assertAdmin();
+    const supabase = createServiceClient();
+
+    const { error } = await supabase.from('call_rounds').delete().eq('id', roundId);
+
+    if (error) {
+      return { success: false, message: 'Failed to delete round' };
+    }
+
+    revalidatePath(`/admin/events/${eventId}/calls`);
+    return { success: true, message: 'Round deleted' };
+  } catch {
+    return { success: false, message: 'Failed to delete round' };
+  }
+}
+
+export type RecordCallOutcomeResult = {
+  success: boolean;
+  message: string;
+};
+
+export async function recordCallOutcome({
+  logId,
+  guestId,
+  eventId,
+  outcome,
+  notes,
+  amount,
+}: {
+  logId: string;
+  guestId: string;
+  eventId: string;
+  outcome: CallOutcome;
+  notes?: string;
+  amount?: number;
+}): Promise<RecordCallOutcomeResult> {
+  try {
+    const adminId = await assertAdmin();
+    const supabase = createServiceClient();
+
+    const { data: adminProfile } = await supabase
+      .from('profiles')
+      .select('full_name, email')
+      .eq('id', adminId)
+      .single();
+
+    const adminName = adminProfile?.full_name ?? adminProfile?.email ?? 'Admin';
+    const now = new Date().toISOString();
+
+    const { error: logError } = await supabase
+      .from('call_logs')
+      .update({ outcome, notes: notes ?? null, called_by: adminId, called_at: now, updated_at: now })
+      .eq('id', logId);
+
+    if (logError) {
+      return { success: false, message: 'Failed to save outcome' };
+    }
+
+    if (outcome === 'confirmed' || outcome === 'declined') {
+      const guestUpdate: Record<string, unknown> = {
+        rsvp_status: outcome,
+        rsvp_change_source: 'admin_call',
+        rsvp_changed_by: adminId,
+        rsvp_changed_by_name: adminName,
+        rsvp_changed_at: now,
+        updated_at: now,
+      };
+      if (outcome === 'confirmed' && amount !== undefined && amount >= 1) {
+        guestUpdate.amount = amount;
+      }
+
+      const { error: guestError } = await supabase
+        .from('guests')
+        .update(guestUpdate)
+        .eq('id', guestId);
+
+      if (guestError) {
+        return { success: false, message: 'Outcome saved but failed to update RSVP' };
+      }
+    }
+
+    revalidatePath(`/admin/events/${eventId}/calls`);
+
+    return { success: true, message: 'Outcome saved' };
+  } catch {
+    return { success: false, message: 'Failed to record outcome' };
+  }
+}

--- a/features/admin/components/event-detail-tabs.tsx
+++ b/features/admin/components/event-detail-tabs.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+const TABS = [
+  { label: 'Overview', path: '' },
+  { label: 'Phone Calls', path: '/calls' },
+];
+
+export function EventDetailTabs({ eventId }: { eventId: string }) {
+  const pathname = usePathname();
+  const base = `/admin/events/${eventId}`;
+
+  return (
+    <div className="flex gap-0 border-b">
+      {TABS.map(({ label, path }) => {
+        const href = `${base}${path}`;
+        const isActive = path === '/calls' ? pathname.endsWith('/calls') : !pathname.endsWith('/calls');
+        return (
+          <Link
+            key={label}
+            href={href}
+            className={cn(
+              'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+              isActive
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground',
+            )}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/features/admin/components/phone-calls-view.tsx
+++ b/features/admin/components/phone-calls-view.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import { useState, useTransition, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import { IconChevronLeft, IconChevronRight, IconLoader2, IconPhone, IconSearch, IconTrash, IconCheck } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Toggle } from '@/components/ui/toggle';
+import { useDynamicPageSize } from '@/hooks/use-dynamic-page-size';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { cn } from '@/lib/utils';
+import { startCallRound, deleteCallRound } from '../actions/calls';
+import { getCallRounds, getRoundCallLogs } from '../queries/calls';
+import { RoundGuestRow } from './round-guest-row';
+import type { CallRoundSummary, CallLogWithGuest, CallOutcome } from '../types';
+
+type SummaryFilterKey = 'awaiting' | 'confirmed' | 'declined' | 'noAnswer' | 'callBack' | 'wrongNumber';
+
+const SUMMARY_STATS: {
+  key: keyof CallRoundSummary;
+  label: string;
+  color: string;
+}[] = [
+  { key: 'awaiting', label: 'awaiting', color: 'text-slate-600' },
+  { key: 'confirmed', label: 'confirmed', color: 'text-emerald-600' },
+  { key: 'declined', label: 'declined', color: 'text-red-500' },
+  { key: 'noAnswer', label: 'no answer', color: 'text-slate-400' },
+  { key: 'callBack', label: 'call back', color: 'text-blue-500' },
+  { key: 'wrongNumber', label: 'wrong #', color: 'text-amber-500' },
+];
+
+interface PhoneCallsViewProps {
+  eventId: string;
+  initialRounds: CallRoundSummary[];
+}
+
+export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) {
+  const [rounds, setRounds] = useState<CallRoundSummary[]>(initialRounds);
+  const [selectedRoundId, setSelectedRoundId] = useState<string | null>(
+    initialRounds[0]?.id ?? null,
+  );
+  const [logs, setLogs] = useState<CallLogWithGuest[]>([]);
+  const [loadingLogs, setLoadingLogs] = useState(false);
+  const [isStarting, startTransition] = useTransition();
+  const [deletingRoundId, setDeletingRoundId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<SummaryFilterKey | null>(null);
+  const [search, setSearch] = useState('');
+  const [pageIndex, setPageIndex] = useState(0);
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const { pageSize } = useDynamicPageSize({ containerRef: tableContainerRef, rowHeight: 57 });
+
+  useEffect(() => {
+    if (!selectedRoundId) return;
+    setActiveFilter(null);
+    setSearch('');
+    setPageIndex(0);
+    setLoadingLogs(true);
+    getRoundCallLogs(selectedRoundId)
+      .then(setLogs)
+      .finally(() => setLoadingLogs(false));
+  }, [selectedRoundId]);
+
+  async function handleStartRound() {
+    startTransition(async () => {
+      const promise = startCallRound(eventId).then((result) => {
+        if (!result.success) throw new Error(result.message);
+        return result;
+      });
+
+      toast.promise(promise, {
+        loading: 'Starting round…',
+        success: async (data) => {
+          const updated = await getCallRounds(eventId);
+          setRounds(updated);
+          if (data.roundId) setSelectedRoundId(data.roundId);
+          return data.message;
+        },
+        error: (err) => (err instanceof Error ? err.message : 'Failed to start round'),
+      });
+
+      await promise.catch(() => {});
+    });
+  }
+
+  async function handleDeleteRound(roundId: string) {
+    setDeletingRoundId(roundId);
+    const promise = deleteCallRound(roundId, eventId).then((result) => {
+      if (!result.success) throw new Error(result.message);
+      return result;
+    });
+
+    toast.promise(promise, {
+      loading: 'Deleting round…',
+      success: async () => {
+        const updated = await getCallRounds(eventId);
+        setRounds(updated);
+        if (selectedRoundId === roundId) {
+          setSelectedRoundId(updated[0]?.id ?? null);
+          setLogs([]);
+        }
+        return 'Round deleted';
+      },
+      error: (err) => (err instanceof Error ? err.message : 'Failed to delete round'),
+    });
+
+    await promise.catch(() => {});
+    setDeletingRoundId(null);
+  }
+
+  async function handleOutcomeChange(logId: string, outcome: CallOutcome) {
+    setLogs((prev) => prev.map((l) => (l.id === logId ? { ...l, outcome } : l)));
+    const updated = await getCallRounds(eventId);
+    setRounds(updated);
+  }
+
+  const selectedRound = rounds.find((r) => r.id === selectedRoundId);
+
+  const sortedLogs = [...logs].sort((a, b) => {
+    if (!a.outcome && b.outcome) return -1;
+    if (a.outcome && !b.outcome) return 1;
+    return 0;
+  });
+
+  const FILTER_PREDICATES: Record<SummaryFilterKey, (log: CallLogWithGuest) => boolean> = {
+    awaiting: (log) => log.outcome === null,
+    confirmed: (log) => log.outcome === 'confirmed',
+    declined: (log) => log.outcome === 'declined',
+    noAnswer: (log) => log.outcome === 'no_answer',
+    callBack: (log) => log.outcome === 'call_back',
+    wrongNumber: (log) => log.outcome === 'wrong_number',
+  };
+
+  const searchQuery = search.trim().toLowerCase();
+  const searchedLogs = searchQuery
+    ? sortedLogs.filter(
+        (l) =>
+          l.name.toLowerCase().includes(searchQuery) ||
+          (l.phone ?? '').includes(searchQuery),
+      )
+    : sortedLogs;
+
+  const filteredLogs = activeFilter
+    ? searchedLogs.filter(FILTER_PREDICATES[activeFilter])
+    : searchedLogs;
+
+  const pageCount = Math.ceil(filteredLogs.length / pageSize);
+  const displayedLogs = filteredLogs.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize);
+
+  function handleSearchChange(value: string) {
+    setSearch(value);
+    setPageIndex(0);
+  }
+
+  function handleFilterChange(key: SummaryFilterKey | null) {
+    setActiveFilter(key);
+    setPageIndex(0);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Round selector */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-1 flex-1">
+          {rounds.map((round) => {
+            const isSelected = selectedRoundId === round.id;
+            const isDeleting = deletingRoundId === round.id;
+            const isComplete = round.awaiting === 0 && round.total > 0;
+            return (
+              <div key={round.id} className="group relative">
+                <button
+                  onClick={() => setSelectedRoundId(round.id)}
+                  className={cn(
+                    'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
+                    isSelected
+                      ? 'bg-foreground text-background font-medium'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  <span>Round {round.roundNumber}</span>
+                  <span
+                    className={cn(
+                      'text-xs tabular-nums',
+                      isSelected ? 'text-background/50' : 'text-muted-foreground/50',
+                    )}
+                  >
+                    {round.awaiting}/{round.total}
+                  </span>
+                  {isComplete && (
+                    <IconCheck
+                      className={cn(
+                        'h-3 w-3',
+                        isSelected ? 'text-background/60' : 'text-emerald-500',
+                      )}
+                    />
+                  )}
+                </button>
+                <button
+                  onClick={() => setConfirmDeleteId(round.id)}
+                  disabled={isDeleting}
+                  title="Delete round"
+                  className="absolute -top-1.5 -right-1.5 hidden h-4 w-4 items-center justify-center rounded-full bg-muted text-muted-foreground shadow-sm hover:bg-destructive/10 hover:text-destructive group-hover:flex disabled:pointer-events-none"
+                >
+                  {isDeleting ? (
+                    <IconLoader2 className="h-2.5 w-2.5 animate-spin" />
+                  ) : (
+                    <IconTrash className="h-2.5 w-2.5" />
+                  )}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <Button size="sm" variant="outline" onClick={handleStartRound} disabled={isStarting}>
+          {isStarting ? (
+            <IconLoader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <IconPhone className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          New round
+        </Button>
+      </div>
+
+      {rounds.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed py-16 text-center">
+          <IconPhone className="mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">No call rounds yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Start a round to load pending guests and begin tracking calls
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Search + filters */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative">
+              <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+              <Input
+                value={search}
+                onChange={(e) => handleSearchChange(e.target.value)}
+                placeholder="Search guests…"
+                className="h-7 pl-8 pr-3 text-xs w-44"
+              />
+            </div>
+            {selectedRound && (
+              <div className="flex flex-wrap items-center gap-1 text-xs">
+              {SUMMARY_STATS.filter(({ key }) => (selectedRound[key] as number) > 0).map(
+                ({ key, label, color }) => (
+                  <Toggle
+                    key={key}
+                    size="sm"
+                    pressed={activeFilter === key}
+                    onPressedChange={(pressed) =>
+                      handleFilterChange(pressed ? (key as SummaryFilterKey) : null)
+                    }
+                    className="h-auto px-2 py-1 gap-1 rounded-full data-[state=on]:bg-muted data-[state=on]:ring-1 data-[state=on]:ring-border"
+                  >
+                    <span className={cn('font-semibold tabular-nums', color)}>
+                      {selectedRound[key] as number}
+                    </span>
+                    <span className="text-muted-foreground">{label}</span>
+                  </Toggle>
+                ),
+              )}
+            </div>
+            )}
+          </div>
+
+          {/* Table */}
+          <div ref={tableContainerRef} className="rounded-lg border overflow-hidden">
+            {loadingLogs ? (
+              <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading…
+              </div>
+            ) : displayedLogs.length === 0 ? (
+              <div className="flex h-20 items-center justify-center text-sm text-muted-foreground">
+                {search || activeFilter ? 'No guests match' : 'No guests in this round'}
+              </div>
+            ) : (
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="px-4 py-2.5 text-left text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Guest
+                    </th>
+                    <th className="px-4 py-2.5 text-left text-[11px] font-medium uppercase tracking-wide text-muted-foreground w-32">
+                      Phone
+                    </th>
+                    <th className="px-4 py-2.5 text-left text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Outcome
+                    </th>
+                    <th className="px-4 py-2.5 text-left text-[11px] font-medium uppercase tracking-wide text-muted-foreground w-44">
+                      Notes
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {displayedLogs.map((log) => (
+                    <RoundGuestRow
+                      key={log.id}
+                      log={log}
+                      eventId={eventId}
+                      onOutcomeChange={handleOutcomeChange}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {pageCount > 1 && (
+            <div className="flex items-center justify-between px-1">
+              <p className="text-xs text-muted-foreground">
+                {pageIndex * pageSize + 1}-{Math.min((pageIndex + 1) * pageSize, filteredLogs.length)} of {filteredLogs.length}
+              </p>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="size-7"
+                  onClick={() => setPageIndex((p) => p - 1)}
+                  disabled={pageIndex === 0}
+                >
+                  <IconChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="size-7"
+                  onClick={() => setPageIndex((p) => p + 1)}
+                  disabled={pageIndex >= pageCount - 1}
+                >
+                  <IconChevronRight className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      <AlertDialog
+        open={!!confirmDeleteId}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDeleteId(null);
+        }}
+      >
+        <AlertDialogContent dir="ltr">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete round?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the round and all its call logs. This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (confirmDeleteId) {
+                  handleDeleteRound(confirmDeleteId);
+                  setConfirmDeleteId(null);
+                }
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/features/admin/components/round-guest-row.tsx
+++ b/features/admin/components/round-guest-row.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+import { IconLoader2 } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { recordCallOutcome } from '../actions/calls';
+import type { CallLogWithGuest, CallOutcome } from '../types';
+
+const OUTCOME_CONFIG: Record<
+  CallOutcome,
+  { label: string; buttonClass: string; badgeClass: string }
+> = {
+  no_answer: {
+    label: 'No answer',
+    buttonClass: 'hover:bg-slate-100 hover:text-slate-700 hover:border-slate-300',
+    badgeClass: 'bg-slate-100 text-slate-600',
+  },
+  confirmed: {
+    label: 'Confirmed',
+    buttonClass: 'hover:bg-emerald-50 hover:text-emerald-700 hover:border-emerald-300',
+    badgeClass: 'bg-emerald-100 text-emerald-700',
+  },
+  declined: {
+    label: 'Declined',
+    buttonClass: 'hover:bg-red-50 hover:text-red-600 hover:border-red-300',
+    badgeClass: 'bg-red-100 text-red-600',
+  },
+  call_back: {
+    label: 'Call back',
+    buttonClass: 'hover:bg-blue-50 hover:text-blue-700 hover:border-blue-300',
+    badgeClass: 'bg-blue-100 text-blue-700',
+  },
+  wrong_number: {
+    label: 'Wrong #',
+    buttonClass: 'hover:bg-amber-50 hover:text-amber-700 hover:border-amber-300',
+    badgeClass: 'bg-amber-100 text-amber-700',
+  },
+};
+
+const OUTCOMES: CallOutcome[] = ['no_answer', 'confirmed', 'declined', 'call_back', 'wrong_number'];
+
+interface RoundGuestRowProps {
+  log: CallLogWithGuest;
+  eventId: string;
+  onOutcomeChange: (logId: string, outcome: CallOutcome) => void;
+}
+
+export function RoundGuestRow({ log, eventId, onOutcomeChange }: RoundGuestRowProps) {
+  const [outcome, setOutcome] = useState<CallOutcome | null>(log.outcome);
+  const [pendingOutcome, setPendingOutcome] = useState<CallOutcome | null>(null);
+  const [amount, setAmount] = useState<number>(log.amount);
+  const [notes, setNotes] = useState<string>(log.notes ?? '');
+  const [showNotes, setShowNotes] = useState(!!log.notes);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const isResolved = outcome !== null;
+
+  function save(selectedOutcome: CallOutcome, amt?: number) {
+    startTransition(async () => {
+      const promise = recordCallOutcome({
+        logId: log.id,
+        guestId: log.guestId,
+        eventId,
+        outcome: selectedOutcome,
+        notes: notes.trim() || undefined,
+        amount: selectedOutcome === 'confirmed' ? (amt ?? amount) : undefined,
+      }).then((result) => {
+        if (!result.success) throw new Error(result.message);
+        return result;
+      });
+
+      toast.promise(promise, {
+        loading: 'Saving…',
+        success: () => {
+          setOutcome(selectedOutcome);
+          setPendingOutcome(null);
+          setIsEditing(false);
+          onOutcomeChange(log.id, selectedOutcome);
+          return 'Outcome saved';
+        },
+        error: (err) => (err instanceof Error ? err.message : 'Failed to save'),
+      });
+
+      await promise.catch(() => {});
+    });
+  }
+
+  function handleOutcomeClick(o: CallOutcome) {
+    if (o === 'confirmed') {
+      setPendingOutcome('confirmed');
+    } else {
+      save(o);
+    }
+  }
+
+  function handleConfirmSave() {
+    save('confirmed', amount);
+  }
+
+  const sideLabel = log.side === 'bride' ? 'Bride' : log.side === 'groom' ? 'Groom' : null;
+
+  return (
+    <tr
+      className={cn(
+        'group transition-colors hover:bg-muted/20',
+        isResolved && !isEditing && 'opacity-50',
+      )}
+    >
+      {/* Guest */}
+      <td className="px-4 py-3 align-middle">
+        <div className="flex items-baseline gap-2">
+          <span
+            className={cn(
+              'text-sm font-medium',
+              isResolved && !isEditing && 'line-through text-muted-foreground',
+            )}
+          >
+            {log.name}
+          </span>
+          {sideLabel && (
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50">
+              {sideLabel}
+            </span>
+          )}
+        </div>
+        {log.groupName && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{log.groupName}</p>
+        )}
+      </td>
+
+      {/* Phone */}
+      <td className="px-4 py-3 align-middle w-32">
+        {log.phone ? (
+          <a
+            href={`tel:${log.phone}`}
+            className="text-xs text-blue-600 tabular-nums hover:underline transition-colors"
+          >
+            {log.phone}
+          </a>
+        ) : (
+          <span className="text-xs text-muted-foreground/40">—</span>
+        )}
+      </td>
+
+      {/* Outcome */}
+      <td className="px-4 py-3 align-middle">
+        {isResolved && !isEditing ? (
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                OUTCOME_CONFIG[outcome!].badgeClass,
+              )}
+            >
+              {OUTCOME_CONFIG[outcome!].label}
+              {outcome === 'confirmed' && amount > 1 && (
+                <span className="ml-1 opacity-70">×{amount}</span>
+              )}
+            </span>
+            <button
+              onClick={() => setIsEditing(true)}
+              className="text-xs text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground"
+            >
+              Edit
+            </button>
+          </div>
+        ) : pendingOutcome !== 'confirmed' ? (
+          <div className="flex flex-wrap gap-1">
+            {OUTCOMES.map((o) => (
+              <button
+                key={o}
+                disabled={isPending}
+                onClick={() => handleOutcomeClick(o)}
+                className={cn(
+                  'rounded border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition-all disabled:opacity-50',
+                  OUTCOME_CONFIG[o].buttonClass,
+                  outcome === o && 'bg-foreground/10 border-foreground/30 text-foreground',
+                )}
+              >
+                {isPending ? (
+                  <IconLoader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  OUTCOME_CONFIG[o].label
+                )}
+              </button>
+            ))}
+            {isEditing && (
+              <button
+                onClick={() => {
+                  setIsEditing(false);
+                  setPendingOutcome(null);
+                }}
+                className="px-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <label className="text-xs font-medium text-muted-foreground">Guests</label>
+            <input
+              type="number"
+              min={1}
+              value={amount}
+              onChange={(e) => setAmount(Math.max(1, Number(e.target.value)))}
+              className="w-14 rounded border px-2 py-1 text-xs bg-background"
+            />
+            <Button size="sm" className="h-7 text-xs" onClick={handleConfirmSave} disabled={isPending}>
+              {isPending && <IconLoader2 className="mr-1 h-3 w-3 animate-spin" />}
+              Save
+            </Button>
+            <button
+              onClick={() => setPendingOutcome(null)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </td>
+
+      {/* Notes */}
+      <td className="px-4 py-3 align-middle w-44">
+        {isResolved && !isEditing ? (
+          <span className="text-xs text-muted-foreground italic">
+            {notes || '—'}
+          </span>
+        ) : showNotes ? (
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Notes…"
+            rows={2}
+            className="w-full rounded border px-2 py-1 text-xs resize-none bg-background"
+          />
+        ) : (
+          <button
+            onClick={() => setShowNotes(true)}
+            className="text-xs text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+          >
+            + Add note
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/features/admin/queries/calls.ts
+++ b/features/admin/queries/calls.ts
@@ -1,0 +1,91 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import type { CallRoundSummary, CallLogWithGuest, CallOutcome } from '../types';
+
+export async function getCallRounds(eventId: string): Promise<CallRoundSummary[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const { data: rounds, error } = await supabase
+    .from('call_rounds')
+    .select('id, round_number, created_at')
+    .eq('event_id', eventId)
+    .order('round_number', { ascending: false });
+
+  if (error || !rounds || rounds.length === 0) return [];
+
+  const roundIds = rounds.map((r) => r.id);
+
+  const { data: logs } = await supabase
+    .from('call_logs')
+    .select('round_id, outcome')
+    .in('round_id', roundIds);
+
+  const logsByRound = new Map<string, { outcome: string | null }[]>();
+  for (const log of logs ?? []) {
+    const arr = logsByRound.get(log.round_id) ?? [];
+    arr.push({ outcome: log.outcome ?? null });
+    logsByRound.set(log.round_id, arr);
+  }
+
+  return rounds.map((round) => {
+    const roundLogs = logsByRound.get(round.id) ?? [];
+    const total = roundLogs.length;
+    const awaiting = roundLogs.filter((l) => !l.outcome).length;
+    const confirmed = roundLogs.filter((l) => l.outcome === 'confirmed').length;
+    const declined = roundLogs.filter((l) => l.outcome === 'declined').length;
+    const noAnswer = roundLogs.filter((l) => l.outcome === 'no_answer').length;
+    const callBack = roundLogs.filter((l) => l.outcome === 'call_back').length;
+    const wrongNumber = roundLogs.filter((l) => l.outcome === 'wrong_number').length;
+
+    return {
+      id: round.id,
+      roundNumber: round.round_number,
+      createdAt: round.created_at,
+      total,
+      awaiting,
+      confirmed,
+      declined,
+      noAnswer,
+      callBack,
+      wrongNumber,
+    };
+  });
+}
+
+export async function getRoundCallLogs(roundId: string): Promise<CallLogWithGuest[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from('call_logs')
+    .select(
+      'id, guest_id, outcome, notes, called_at, guests(id, name, phone_number, amount, side, rsvp_status, group_id, groups(name))',
+    )
+    .eq('round_id', roundId)
+    .order('created_at', { ascending: true });
+
+  if (error || !data) return [];
+
+  return data.map((log) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const guest = log.guests as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const group = guest?.groups as any;
+    return {
+      id: log.id,
+      guestId: log.guest_id,
+      name: guest?.name ?? '',
+      phone: guest?.phone_number ?? null,
+      amount: guest?.amount ?? 1,
+      side: (guest?.side ?? null) as 'bride' | 'groom' | null,
+      groupName: group?.name ?? null,
+      currentRsvpStatus: (guest?.rsvp_status ?? 'pending') as 'pending' | 'confirmed' | 'declined',
+      outcome: (log.outcome ?? null) as CallOutcome | null,
+      notes: log.notes ?? null,
+      calledAt: log.called_at ?? null,
+    };
+  });
+}

--- a/features/admin/types.ts
+++ b/features/admin/types.ts
@@ -1,3 +1,32 @@
+export type CallOutcome = 'no_answer' | 'confirmed' | 'declined' | 'call_back' | 'wrong_number';
+
+export type CallRoundSummary = {
+  id: string;
+  roundNumber: number;
+  createdAt: string;
+  total: number;
+  awaiting: number;
+  confirmed: number;
+  declined: number;
+  noAnswer: number;
+  callBack: number;
+  wrongNumber: number;
+};
+
+export type CallLogWithGuest = {
+  id: string;
+  guestId: string;
+  name: string;
+  phone: string | null;
+  amount: number;
+  side: 'bride' | 'groom' | null;
+  groupName: string | null;
+  currentRsvpStatus: 'pending' | 'confirmed' | 'declined';
+  outcome: CallOutcome | null;
+  notes: string | null;
+  calledAt: string | null;
+};
+
 export type AdminUser = {
   id: string;
   email: string;

--- a/features/guests/components/guests-page.tsx
+++ b/features/guests/components/guests-page.tsx
@@ -21,14 +21,13 @@ import {
   SheetFooter,
 } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
-import { IconClock, IconPlus, IconProgressHelp, IconTrash, IconUserPlus, IconUsers, IconUsersGroup } from '@tabler/icons-react';
+import { IconClock, IconPlus, IconTrash, IconUserPlus, IconUsers, IconUsersGroup } from '@tabler/icons-react';
 import { GuestWithGroupApp, GroupWithGuestsApp } from '../schemas';
 import { useFeatureHeader } from '@/components/feature-layout';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
   GroupsDirectory,
   CreateGroupDialog,
-  GroupIcon,
 } from '@/features/guests/components/groups';
 import { upsertGroup, UpsertGroupState, UpsertGroupErrorCode } from '../actions/groups';
 import { deleteGuest } from '@/features/guests/actions';
@@ -326,44 +325,6 @@ export function GuestsPage({
 
                 {/* Labeled data badges */}
                 <div className="flex flex-col gap-1.5 items-start">
-                  {/* Status */}
-                  <span className="inline-flex items-stretch w-fit rounded-full border bg-muted/40 text-sm overflow-hidden">
-                    <span className="px-2.5 py-1 flex items-center gap-1.5 text-muted-foreground">
-                      <IconProgressHelp size={12} className="shrink-0" />
-                      {t('form.rsvpStatus')}
-                    </span>
-                    <span className="w-px bg-border" />
-                    <span className="px-2.5 py-1 flex items-center gap-1.5 text-foreground">
-                      <span className={`size-1.5 rounded-full shrink-0 ${RSVP_DOT_STYLES[rsvpStatus]}`} />
-                      {t(`rsvp.${rsvpStatus}` as 'rsvp.pending' | 'rsvp.confirmed' | 'rsvp.declined')}
-                    </span>
-                  </span>
-
-                  {/* Guests */}
-                  <span className="inline-flex items-stretch w-fit rounded-full border bg-muted/40 text-sm overflow-hidden">
-                    <span className="px-2.5 py-1 flex items-center gap-1.5 text-muted-foreground">
-                      <IconUsers size={12} className="shrink-0" />
-                      {t('sheet.people')}
-                    </span>
-                    <span className="w-px bg-border" />
-                    <span className="px-2.5 py-1 text-foreground">
-                      {selectedGuest.amount}{' '}
-                      {selectedGuest.amount === 1 ? t('form.person') : t('form.people')}
-                    </span>
-                  </span>
-
-                  {/* Group */}
-                  {guestGroup && (
-                    <span className="inline-flex items-stretch w-fit rounded-full border bg-muted/40 text-sm overflow-hidden">
-                      <span className="px-2.5 py-1 flex items-center gap-1.5 text-muted-foreground">
-                        <GroupIcon iconName={guestGroup.icon} size="sm" className="shrink-0" />
-                        {t('form.group')}
-                      </span>
-                      <span className="w-px bg-border" />
-                      <span className="px-2.5 py-1 text-foreground">{guestGroup.name}</span>
-                    </span>
-                  )}
-
                   {/* RSVP Updated */}
                   {selectedGuest.rsvpChangedAt && (
                     <span className="inline-flex items-stretch w-fit rounded-full border bg-muted/40 text-sm overflow-hidden">
@@ -375,7 +336,9 @@ export function GuestsPage({
                       <span className="px-2.5 py-1 text-muted-foreground">
                         {selectedGuest.rsvpChangeSource === 'guest'
                           ? `${t('sheet.viaGuest')} · ${format(new Date(selectedGuest.rsvpChangedAt), 'd/M/yy · HH:mm')}`
-                          : `${selectedGuest.rsvpChangedBy === currentUserId ? t('sheet.viaYou') : (selectedGuest.rsvpChangedByName ?? t('sheet.viaOrganizer'))} · ${format(new Date(selectedGuest.rsvpChangedAt), 'd/M/yy · HH:mm')}`}
+                          : selectedGuest.rsvpChangeSource === 'admin_call'
+                            ? `${t('sheet.viaAdmin')} · ${format(new Date(selectedGuest.rsvpChangedAt), 'd/M/yy · HH:mm')}`
+                            : `${selectedGuest.rsvpChangedBy === currentUserId ? t('sheet.viaYou') : (selectedGuest.rsvpChangedByName ?? t('sheet.viaOrganizer'))} · ${format(new Date(selectedGuest.rsvpChangedAt), 'd/M/yy · HH:mm')}`}
                       </span>
                     </span>
                   )}

--- a/features/guests/schemas/index.ts
+++ b/features/guests/schemas/index.ts
@@ -113,7 +113,7 @@ export const GuestDbSchema = z.object({
   rsvp_changed_by: z.uuid().nullable().optional(),
   rsvp_changed_by_name: z.string().max(255).nullable().optional(),
   rsvp_changed_at: z.string().nullable().optional(),
-  rsvp_change_source: z.enum(['manual', 'guest']).nullable().optional(),
+  rsvp_change_source: z.enum(['manual', 'guest', 'admin_call']).nullable().optional(),
   is_offline_rsvp: z.boolean().default(false),
 });
 

--- a/features/guests/schemas/index.ts
+++ b/features/guests/schemas/index.ts
@@ -60,7 +60,7 @@ export const GuestAppSchema = z.object({
   rsvpChangedBy: z.uuid().nullable().optional(),
   rsvpChangedByName: z.string().nullable().optional(),
   rsvpChangedAt: z.string().nullable().optional(),
-  rsvpChangeSource: z.enum(['manual', 'guest']).nullable().optional(),
+  rsvpChangeSource: z.enum(['manual', 'guest', 'admin_call']).nullable().optional(),
   isOfflineRsvp: z.boolean().default(false),
 });
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -372,6 +372,7 @@
       "viaGuest": "via guest",
       "viaYou": "via you",
       "viaOrganizer": "via organizer",
+      "viaAdmin": "via admin",
       "deleteGuest": "Delete Guest",
       "updateGuest": "Update Guest",
       "actionsSection": "Actions",

--- a/messages/he.json
+++ b/messages/he.json
@@ -373,6 +373,7 @@
       "viaGuest": "על ידי האורח",
       "viaYou": "על ידך",
       "viaOrganizer": "על ידי המארגן",
+      "viaAdmin": "על ידי אדמין",
       "deleteGuest": "מחק אורח",
       "updateGuest": "עדכן אורח",
       "actionsSection": "פעולות",

--- a/supabase/migrations/20260530000001_add_call_rounds_and_logs.sql
+++ b/supabase/migrations/20260530000001_add_call_rounds_and_logs.sql
@@ -1,0 +1,49 @@
+create type call_outcome as enum ('no_answer', 'confirmed', 'declined', 'call_back', 'wrong_number');
+
+create table call_rounds (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references events(id) on delete cascade,
+  round_number int not null,
+  started_by uuid references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (event_id, round_number)
+);
+
+create table call_logs (
+  id uuid primary key default gen_random_uuid(),
+  round_id uuid not null references call_rounds(id) on delete cascade,
+  guest_id uuid not null references guests(id) on delete cascade,
+  outcome call_outcome,
+  notes text,
+  called_by uuid references auth.users(id),
+  called_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (round_id, guest_id)
+);
+
+alter table call_rounds enable row level security;
+alter table call_logs enable row level security;
+
+create policy "Admins can manage call_rounds"
+  on call_rounds
+  for all
+  to authenticated
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid() and profiles.is_admin = true
+    )
+  );
+
+create policy "Admins can manage call_logs"
+  on call_logs
+  for all
+  to authenticated
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid() and profiles.is_admin = true
+    )
+  );

--- a/supabase/migrations/20260530000002_add_admin_call_rsvp_source.sql
+++ b/supabase/migrations/20260530000002_add_admin_call_rsvp_source.sql
@@ -1,0 +1,5 @@
+alter table "public"."guests" drop constraint "guests_rsvp_change_source_check";
+
+alter table "public"."guests" add constraint "guests_rsvp_change_source_check" CHECK (((rsvp_change_source)::text = ANY ((ARRAY['manual'::character varying, 'guest'::character varying, 'admin_call'::character varying])::text[]))) not valid;
+
+alter table "public"."guests" validate constraint "guests_rsvp_change_source_check";


### PR DESCRIPTION
Adds call_rounds and call_logs tables so admins can snapshot pending guests into a call round, record outcomes (confirmed/declined/no answer/ call back/wrong number), and have RSVP changes attributed to admin_call. Includes search, outcome filters, and dynamic pagination in the calls view.