### PR TITLE
Improve guests page density to show more table rows

### DIFF
--- a/components/feature-layout/feature-layout-header.tsx
+++ b/components/feature-layout/feature-layout-header.tsx
@@ -17,7 +17,7 @@ export function FeatureLayoutHeader() {
   }
 
   return (
-    <CardHeader className="px-0 pb-4">
+    <CardHeader className="px-0 pb-2">
       <div className={cn('flex w-full items-start justify-between gap-4', containerClass)}>
         <div className="grid gap-1.5">
           <CardTitle className="text-2xl font-bold">{title}</CardTitle>

--- a/components/ui/stats-cards.tsx
+++ b/components/ui/stats-cards.tsx
@@ -44,28 +44,27 @@ export function StatsCards({ stats, selectedStatuses = [], onStatClick, columns 
               }
             }}
             className={cn(
-              'flex flex-col gap-3 rounded-xl border p-4 shadow-sm transition-colors',
+              'flex flex-col gap-2 rounded-xl border p-3 shadow-sm transition-colors',
               isActive ? activeRing : 'bg-card',
               isClickable && 'cursor-pointer',
             )}
           >
-            {/* Header: title + icon */}
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-semibold">{label}</span>
-              <div className="[&>svg]:size-5">{icon}</div>
-            </div>
-
-            {/* Large number */}
-            <p className="text-3xl font-bold leading-none tracking-tight">
-              {value.toLocaleString()}
-              {breakdown && secondaryText && (
-                <span className="ml-2 text-base font-normal text-muted-foreground">{secondaryText}</span>
-              )}
-            </p>
-
-            {/* Progress bar + stats row */}
             {breakdown ? (
               <>
+                {/* Header: title + icon */}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold">{label}</span>
+                  <div className="[&>svg]:size-5">{icon}</div>
+                </div>
+
+                {/* Large number */}
+                <p className="text-3xl font-bold leading-none tracking-tight">
+                  {value.toLocaleString()}
+                  {secondaryText && (
+                    <span className="ml-2 text-base font-normal text-muted-foreground">{secondaryText}</span>
+                  )}
+                </p>
+
                 <div className="flex h-1.5 w-full gap-0.5 overflow-hidden rounded-full bg-gray-100">
                   {breakdown.map((item) => {
                     const width = breakdownTotal > 0 ? (item.value / breakdownTotal) * 100 : 0;
@@ -89,18 +88,37 @@ export function StatsCards({ stats, selectedStatuses = [], onStatClick, columns 
                 </div>
               </>
             ) : (
-              <div className="space-y-1.5">
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
-                  <div
-                    className={cn('h-full rounded-full transition-all duration-700', barColor)}
-                    style={{ width: `${pct}%` }}
-                  />
+              /* Compact horizontal layout */
+              <>
+                <div className="flex items-center gap-3">
+                  {/* Icon chip */}
+                  <div className={cn('flex size-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 [&>svg]:size-4', isActive && 'bg-white/60')}>
+                    {icon}
+                  </div>
+                  {/* Label + value */}
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-medium text-muted-foreground leading-none mb-1">{label}</p>
+                    <div className="flex items-baseline gap-1.5">
+                      <span className="text-2xl font-bold leading-none tracking-tight">
+                        {value.toLocaleString()}
+                      </span>
+                      {secondaryText && (
+                        <span className="text-xs text-muted-foreground">{secondaryText}</span>
+                      )}
+                    </div>
+                  </div>
                 </div>
-                <div className="text-muted-foreground flex items-center justify-between text-xs">
-                  {secondaryText && <span>{secondaryText}</span>}
-                  <span>{pct}%</span>
+                {/* Progress bar + percentage */}
+                <div className="flex items-center gap-2">
+                  <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+                    <div
+                      className={cn('h-full rounded-full transition-all duration-700', barColor)}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <span className="text-xs text-muted-foreground w-8 text-right shrink-0">{pct}%</span>
                 </div>
-              </div>
+              </>
             )}
           </div>
         );

--- a/features/guests/components/filters/group-filter.tsx
+++ b/features/guests/components/filters/group-filter.tsx
@@ -45,6 +45,7 @@ export function GroupFilter({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
+          size="sm"
           className={cn(
             'w-[180px] justify-between',
             isActive && 'border-primary/50 bg-primary/8 text-primary font-medium hover:bg-primary/15 hover:text-primary',

--- a/features/guests/components/filters/rsvp-status-filter.tsx
+++ b/features/guests/components/filters/rsvp-status-filter.tsx
@@ -47,6 +47,7 @@ export function RsvpStatusFilter({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
+          size="sm"
           className={cn(
             'w-[180px] justify-between',
             isActive && 'border-primary/50 bg-primary/8 text-primary font-medium hover:bg-primary/15 hover:text-primary',

--- a/features/guests/components/filters/side-filter.tsx
+++ b/features/guests/components/filters/side-filter.tsx
@@ -42,6 +42,7 @@ export function SideFilter({
       <PopoverTrigger asChild>
         <Button
           variant="outline"
+          size="sm"
           className={cn(
             'w-[180px] justify-between',
             isActive && 'border-primary/50 bg-primary/8 text-primary font-medium hover:bg-primary/15 hover:text-primary',

--- a/features/guests/components/guest-directory.tsx
+++ b/features/guests/components/guest-directory.tsx
@@ -121,6 +121,7 @@ export function GuestDirectory({
             <GuestSearch searchTerm={searchTerm} onSearchChange={setSearchTerm} />
             <Button
               variant="outline"
+              size="sm"
               onClick={() => setImportDialogOpen(true)}
               className="gap-2"
             >
@@ -148,6 +149,7 @@ export function GuestDirectory({
             />
             <Button
               variant="outline"
+              size="sm"
               onClick={toggleNoPhoneOnly}
               className={cn('gap-2', noPhoneOnly && 'border-primary/50 bg-primary/8 text-primary font-medium hover:bg-primary/15 hover:text-primary')}
             >

--- a/features/guests/components/guests-page.tsx
+++ b/features/guests/components/guests-page.tsx
@@ -245,7 +245,7 @@ export function GuestsPage({
   return (
     <>
       <Tabs defaultValue="guests" onValueChange={handleTabsChange} dir={locale === 'he' ? 'rtl' : 'ltr'}>
-        <TabsList className="border-border mb-6 h-10 w-full justify-start gap-4 rounded-none border-b bg-transparent p-0">
+        <TabsList className="border-border mb-4 h-10 w-full justify-start gap-4 rounded-none border-b bg-transparent p-0">
           <TabsTrigger
             value="guests"
             className="data-[state=active]:text-primary data-[state=active]:after:bg-primary relative h-full flex-none rounded-none border-none bg-transparent px-1 pb-3 text-sm shadow-none after:absolute after:right-0 after:bottom-0 after:left-0 after:h-0.5 after:bg-transparent data-[state=active]:bg-transparent data-[state=active]:shadow-none"
@@ -266,7 +266,7 @@ export function GuestsPage({
           selectedStatuses={selectedStatuses}
           onStatClick={handleStatCardClick}
         />
-        <TabsContent value="guests" className="mt-6">
+        <TabsContent value="guests" className="mt-0">
           <GuestDirectory
             guests={guests}
             groups={groups}

--- a/features/guests/components/table/guests-table.tsx
+++ b/features/guests/components/table/guests-table.tsx
@@ -171,7 +171,7 @@ export function GuestsTable({
                       <TableCell
                         key={cell.id}
                         className={
-                          isNameColumn ? 'px-4 py-2 font-medium' : 'py-2'
+                          isNameColumn ? 'px-4 py-1 font-medium' : 'py-1'
                         }
                       >
                         {flexRender(

--- a/hooks/use-dynamic-page-size.ts
+++ b/hooks/use-dynamic-page-size.ts
@@ -2,8 +2,8 @@
 
 import { useState, useEffect, useCallback, RefObject } from 'react';
 
-const TABLE_ROW_HEIGHT = 49; // Height of each table row in pixels (py-2 padding + content)
-const TABLE_HEADER_HEIGHT = 48; // Height of table header
+const TABLE_ROW_HEIGHT = 41; // Height of each table row in pixels (py-1 padding + content)
+const TABLE_HEADER_HEIGHT = 40; // Height of table header (h-10)
 const PAGINATION_HEIGHT = 40; // Height of pagination controls
 const BUFFER = 48; // Extra buffer space for margins, borders, and layout shifts
 


### PR DESCRIPTION
- Compact stat cards to horizontal layout (~128px → ~70px)
- Reduce table cell padding py-2 → py-1 and update row height constant
- Tighten spacing: tabs mb-6→mb-4, remove mt above table, header pb-4→pb-2
- Switch toolbar buttons to size sm