### PR TITLE
Add iPlan export with rich scope selector

### DIFF
--- a/app/[locale]/app/[eventId]/guests/page.tsx
+++ b/app/[locale]/app/[eventId]/guests/page.tsx
@@ -30,6 +30,7 @@ export default async function GuestsPage({
     <GuestsPageComponent
       guests={guests}
       eventId={eventId}
+      eventName={event?.title}
       groups={groups}
       existingPhones={existingPhones}
       showDietary={showDietary}

--- a/features/guests/components/guest-directory.tsx
+++ b/features/guests/components/guest-directory.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useActionState, startTransition, useRef } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import { toast } from 'sonner';
 import { GuestSearch } from './guest-search';
 import { GuestsTable } from '@/features/guests/components/table';
@@ -14,15 +14,30 @@ import { ImportGuestsDialog } from '@/features/guests/components/groups';
 import { GuestWithGroupApp, GroupInfo } from '@/features/guests/schemas';
 import { useGuestFilters, useDynamicPageSize } from '@/features/guests/hooks';
 import { deleteGuest, type DeleteGuestState } from '@/features/guests/actions';
-import { IconUpload, IconPhoneOff } from '@tabler/icons-react';
+import { exportGuestsToIplan, type IplanScope } from '@/features/guests/utils';
+import { IconUpload, IconPhoneOff, IconFileSpreadsheet } from '@tabler/icons-react';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+} from '@/components/ui/item';
 import { cn } from '@/lib/utils';
 
 interface GuestDirectoryProps {
   guests: GuestWithGroupApp[];
   groups: GroupInfo[];
   eventId: string;
+  eventName?: string;
   existingPhones: Map<string, string>;
   onSelectGuest: (guest: GuestWithGroupApp | null) => void;
   showDietary?: boolean;
@@ -34,6 +49,7 @@ export function GuestDirectory({
   guests,
   groups,
   eventId,
+  eventName,
   existingPhones,
   onSelectGuest,
   showDietary = false,
@@ -41,6 +57,7 @@ export function GuestDirectory({
   onStatusToggle: externalStatusToggle,
 }: GuestDirectoryProps) {
   const t = useTranslations('guests');
+  const isRTL = useLocale() === 'he';
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const { pageSize, isCalculated } = useDynamicPageSize({
@@ -111,6 +128,18 @@ export function GuestDirectory({
     onSelectGuest(null);
   };
 
+  const handleExport = (scope: IplanScope) => {
+    const fileName = eventName ? `${eventName}-iplan.xls` : 'iplan-guests.xls';
+    const promise = exportGuestsToIplan(guests, { scope, fileName });
+
+    toast.promise(promise, {
+      loading: t('directory.exportingIplan'),
+      success: () => t('directory.exportIplanSuccess'),
+      error: (err) =>
+        err instanceof Error ? err.message : t('directory.exportFailed'),
+    });
+  };
+
   const isEmpty = guests.length === 0;
 
   return (
@@ -128,6 +157,52 @@ export function GuestDirectory({
               <IconUpload size={16} />
               {t('directory.importCsv')}
             </Button>
+            <DropdownMenu dir={isRTL ? 'rtl' : 'ltr'}>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-2">
+                  <IconFileSpreadsheet size={16} />
+                  {t('directory.exportIplan')}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-64">
+                <DropdownMenuItem onClick={() => handleExport('confirmed')}>
+                  <Item size="sm" className="p-0 gap-3">
+                    <ItemMedia>
+                      <span className="size-2.5 rounded-full bg-green-500" />
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>{t('directory.exportConfirmed')}</ItemTitle>
+                      <ItemDescription>{t('directory.exportConfirmedDesc')}</ItemDescription>
+                    </ItemContent>
+                  </Item>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleExport('confirmedPending')}>
+                  <Item size="sm" className="p-0 gap-3">
+                    <ItemMedia>
+                      <span
+                        className="size-2.5 rounded-full shrink-0"
+                        style={{ background: 'linear-gradient(135deg, #22c55e 50%, #fb923c 50%)' }}
+                      />
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>{t('directory.exportConfirmedPending')}</ItemTitle>
+                      <ItemDescription>{t('directory.exportConfirmedPendingDesc')}</ItemDescription>
+                    </ItemContent>
+                  </Item>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleExport('all')}>
+                  <Item size="sm" className="p-0 gap-3">
+                    <ItemMedia>
+                      <span className="size-2.5 rounded-full bg-blue-500" />
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>{t('directory.exportAll')}</ItemTitle>
+                      <ItemDescription>{t('directory.exportAllDesc')}</ItemDescription>
+                    </ItemContent>
+                  </Item>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           <div className="flex items-center gap-2">
             <RsvpStatusFilter

--- a/features/guests/components/guests-page.tsx
+++ b/features/guests/components/guests-page.tsx
@@ -36,6 +36,7 @@ import { GuestActionsSection } from './guest-actions-section';
 interface GuestsPageProps {
   guests: GuestWithGroupApp[];
   eventId: string;
+  eventName?: string;
   groups: GroupWithGuestsApp[];
   existingPhones: Map<string, string>;
   showDietary?: boolean;
@@ -73,6 +74,7 @@ function getAvatarColor(name: string): string {
 export function GuestsPage({
   guests,
   eventId,
+  eventName,
   groups,
   existingPhones,
   showDietary = false,
@@ -271,6 +273,7 @@ export function GuestsPage({
             guests={guests}
             groups={groups}
             eventId={eventId}
+            eventName={eventName}
             existingPhones={existingPhones}
             onSelectGuest={handleSelectGuest}
             showDietary={showDietary}

--- a/features/guests/utils/export-iplan.ts
+++ b/features/guests/utils/export-iplan.ts
@@ -1,0 +1,61 @@
+/**
+ * Client-side utility to export guests to the iPlan seating-planning format.
+ *
+ * iPlan template requirements:
+ * - File format: legacy .xls
+ * - Row 1: reserved header (blank)
+ * - Row 2: column titles
+ * - Row 3+: guest data
+ * - Column order: name → guests amount → side → group → phone
+ */
+
+import type { GuestWithGroupApp } from '@/features/guests/schemas';
+
+const SIDE_HE: Record<string, string> = {
+  bride: 'כלה',
+  groom: 'חתן',
+};
+
+export const IPLAN_COLUMN_HEADERS = ['שם', 'כמות אורחים', 'צד', 'קבוצה', 'טלפון'];
+
+export type IplanScope = 'confirmed' | 'confirmedPending' | 'all';
+
+interface ExportIplanOptions {
+  scope: IplanScope;
+  /** Download filename (defaults to 'iplan-guests.xls'). */
+  fileName?: string;
+}
+
+export async function exportGuestsToIplan(
+  guests: GuestWithGroupApp[],
+  opts: ExportIplanOptions,
+): Promise<void> {
+  const { utils, writeFile } = await import('xlsx');
+
+  const filtered = guests.filter((g) => {
+    if (opts.scope === 'all') return true;
+    if (opts.scope === 'confirmed') return g.rsvpStatus === 'confirmed';
+    return g.rsvpStatus === 'confirmed' || g.rsvpStatus === 'pending';
+  });
+
+  // Column order: name, guests amount, side, group, phone
+  const dataRows = filtered.map((g) => [
+    g.name,
+    g.amount ?? 1,
+    g.side ? (SIDE_HE[g.side] ?? '') : 'חתן,כלה',
+    g.group?.name ?? '',
+    g.phone ?? '',
+  ]);
+
+  // Row 1: reserved/blank, Row 2: column titles, Row 3+: data
+  const aoa = [
+    [],
+    IPLAN_COLUMN_HEADERS,
+    ...dataRows,
+  ];
+
+  const ws = utils.aoa_to_sheet(aoa);
+  const wb = utils.book_new();
+  utils.book_append_sheet(wb, ws, 'Guests');
+  writeFile(wb, opts.fileName ?? 'iplan-guests.xls', { bookType: 'xls' });
+}

--- a/features/guests/utils/index.ts
+++ b/features/guests/utils/index.ts
@@ -12,3 +12,8 @@ export {
 export { DIETARY_PRESETS, DIETARY_LABEL_MAP } from './dietary-presets';
 
 export { parseCSVFile, getSampleData, type ParsedCSV } from './parse-csv';
+
+export {
+  exportGuestsToIplan,
+  type IplanScope,
+} from './export-iplan';

--- a/messages/en.json
+++ b/messages/en.json
@@ -472,6 +472,16 @@
     },
     "directory": {
       "importCsv": "Import File",
+      "exportIplan": "Export to iPlan",
+      "exportConfirmed": "Confirmed guests",
+      "exportConfirmedDesc": "Only guests who confirmed attendance",
+      "exportConfirmedPending": "Confirmed + pending",
+      "exportConfirmedPendingDesc": "Confirmed and awaiting response",
+      "exportAll": "All guests",
+      "exportAllDesc": "Complete guest list",
+      "exportingIplan": "Preparing iPlan file",
+      "exportIplanSuccess": "iPlan file downloaded",
+      "exportFailed": "Export failed - please try again",
       "deletingGuest": "Deleting {name}...",
       "guestDeleted": "Guest deleted successfully",
       "guestDeleteFailed": "Failed to delete guest. Please try again"

--- a/messages/he.json
+++ b/messages/he.json
@@ -473,6 +473,16 @@
     },
     "directory": {
       "importCsv": "ייבוא קובץ",
+      "exportIplan": "ייצוא ל-iPlan",
+      "exportConfirmed": "אורחים שאישרו",
+      "exportConfirmedDesc": "אורחים שאישרו הגעה בלבד",
+      "exportConfirmedPending": "אישרו + ממתינים",
+      "exportConfirmedPendingDesc": "אורחים שאישרו ומחכים לתשובה",
+      "exportAll": "כל האורחים",
+      "exportAllDesc": "רשימת כל האורחים המלאה",
+      "exportingIplan": "מכין קובץ iPlan",
+      "exportIplanSuccess": "קובץ iPlan הורד",
+      "exportFailed": "הייצוא נכשל - נסה שנית",
       "deletingGuest": "מוחק את {name}...",
       "guestDeleted": "האורח נמחק בהצלחה",
       "guestDeleteFailed": "מחיקת האורח נכשלה. נסה שנית"


### PR DESCRIPTION
- Client-side .xls export via xlsx library (dynamic import)
- Three scopes: confirmed / confirmed+pending / all guests
- Dropdown items use shadcn Item components with title, description, and color-coded circle indicators (split circle for mixed scope)
- Hebrew column headers stored as constant in export-iplan.ts
- RTL-aware dropdown direction via Radix dir prop
- Filename derived from event title