### PR TITLE
Add wartime event reminder SMS template

### DIFF
--- a/features/schedules/actions/execute-schedule.ts
+++ b/features/schedules/actions/execute-schedule.ts
@@ -110,6 +110,13 @@ export async function executeSchedule(
 
     const template = templateConfig.whatsapp;
 
+    if (!template) {
+      return {
+        success: false,
+        message: 'Template does not have a WhatsApp configuration',
+      };
+    }
+
     // 6. Fetch all event guests
     const allGuests = await getEventGuests(schedule.eventId);
 

--- a/features/schedules/config/sms-bodies.ts
+++ b/features/schedules/config/sms-bodies.ts
@@ -20,7 +20,7 @@ export function buildSmsConfirmationBody(
   const siteUrl = resolveSiteUrl();
   const rsvpLink = `${siteUrl}/confirm/${confirmationToken}`;
 
-  const placeholders = getTemplateByKey('confirmation_casual_v1_he')?.whatsapp.parameters?.placeholders;
+  const placeholders = getTemplateByKey('confirmation_casual_v1_he')?.whatsapp?.parameters?.placeholders;
   if (!placeholders) {
     console.error('[SMS] Failed to resolve placeholders for confirmation_casual_v1_he');
     throw new Error('SMS template resolution failed');
@@ -34,10 +34,13 @@ export function buildSmsConfirmationBody(
   return `${body}\n${rsvpLink}`;
 }
 
-export function buildSmsReminderBody(context: ParameterResolutionContext): string {
-  const smsConfig = getTemplateByKey('event_reminder_casual')?.sms;
+export function buildSmsReminderBody(
+  context: ParameterResolutionContext,
+  templateKey: string = 'event_reminder_casual',
+): string {
+  const smsConfig = getTemplateByKey(templateKey)?.sms;
   if (!smsConfig?.parameters?.placeholders) {
-    console.error('[SMS] Failed to resolve SMS config for event_reminder_casual');
+    console.error(`[SMS] Failed to resolve SMS config for ${templateKey}`);
     throw new Error('SMS reminder template resolution failed');
   }
 

--- a/features/schedules/config/whatsapp-templates.ts
+++ b/features/schedules/config/whatsapp-templates.ts
@@ -250,6 +250,40 @@ export const WHATSAPP_TEMPLATES: Record<string, TemplateConfig> = {
       },
     },
   },
+
+  event_reminder_wartime: {
+    whatsapp: undefined,
+    sms: {
+      bodyText:
+        'היי אורחים יקרים\nלמרות המצב הרגיש - תזכורת לחתונה של {{1}} ו{{2}} המתקיימת הערב\n\n📍{{3}}\n🕒 {{4}}\n\nהאולם פועל בהתאם להנחיות פיקוד העורף וישנו מרחב מוגן תקני במקום\n\nנשמח לראותכם ❤️\nלניווט לאירוע - לחצו על הקישור\n{{5}}',
+      parameters: {
+        headerPlaceholders: [],
+        placeholders: {
+          'host.bride.name': {
+            source: 'event.hostDetails.bride.name',
+            transformer: 'none',
+          },
+          'host.groom.name': {
+            source: 'event.hostDetails.groom.name',
+            transformer: 'none',
+          },
+          'event.venueName': {
+            source: 'event.location.name',
+            transformer: 'none',
+          },
+          'event.receptionTime': {
+            source: 'event.receptionTime',
+            transformer: 'none',
+          },
+          'event.navShortUrl': {
+            source: 'event.shortCode',
+            transformer: 'navShortUrl',
+          },
+        },
+        buttonPlaceholders: [],
+      },
+    },
+  },
 };
 
 export function getTemplateByKey(key: string): TemplateConfig | null {

--- a/features/schedules/schemas/whatsapp-templates.ts
+++ b/features/schedules/schemas/whatsapp-templates.ts
@@ -20,7 +20,7 @@ export const SmsTemplateConfigSchema = z.object({
 });
 
 export const TemplateConfigSchema = z.object({
-  whatsapp: WhatsAppTemplateAppSchema,
+  whatsapp: WhatsAppTemplateAppSchema.optional(),
   sms: SmsTemplateConfigSchema.optional(),
 });
 

--- a/features/schedules/utils/send-helpers.ts
+++ b/features/schedules/utils/send-helpers.ts
@@ -144,7 +144,7 @@ export async function sendSmsToGuest(params: {
   const { guest, context, confirmationToken } = params;
   const phoneE164 = formatPhoneE164(guest.phone!);
   const body = context.schedule?.actionType === 'event_reminder'
-    ? buildSmsReminderBody(context)
+    ? buildSmsReminderBody(context, context.schedule.templateKey ?? undefined)
     : buildSmsConfirmationBody(context, confirmationToken);
   const result = await sendSmsMessage({ to: phoneE164, body });
 

--- a/lib/services/message-processor.ts
+++ b/lib/services/message-processor.ts
@@ -168,6 +168,11 @@ async function processSingleSchedule(
 
   const template = templateConfig.whatsapp;
 
+  if (!template) {
+    await revertOrCancel(supabase, schedule.id, rawScheduleWithEvent.scheduled_date);
+    throw new Error('Template does not have a WhatsApp configuration');
+  }
+
   // 5. Fetch all event guests
   const { data: rawGuests, error: guestsError } = await supabase
     .from('guests')


### PR DESCRIPTION
Adds event_reminder_wartime SMS-only template with Home Front Command messaging for sensitive security situations. Also makes whatsapp field optional in TemplateConfigSchema to support SMS-only templates, and threads templateKey through the SMS body builder so any reminder template can be selected per schedule.