### PR TITLE
Fix missing receptionTime/shortCode in getScheduleById

### DIFF
--- a/features/schedules/queries/schedules.ts
+++ b/features/schedules/queries/schedules.ts
@@ -50,6 +50,8 @@ export async function getScheduleById(
       location?: { name: string; coords?: { lat: number; lng: number } } | null;
       hostDetails?: Record<string, unknown> | null;
       invitations?: { imageUrl?: string } | null;
+      receptionTime?: string;
+      shortCode?: string;
     };
   })
   | null
@@ -68,7 +70,9 @@ export async function getScheduleById(
         event_date,
         location,
         host_details,
-        invitations
+        invitations,
+        reception_time,
+        short_code
       )
     `,
     )
@@ -100,6 +104,8 @@ export async function getScheduleById(
         imageUrl: data.events.invitations.image_url,
       }
       : undefined,
+    receptionTime: (data.events.reception_time as string | null) ?? undefined,
+    shortCode: (data.events.short_code as string | null) ?? undefined,
   };
 
   return {


### PR DESCRIPTION
reception_time and short_code were not selected from the events join in getScheduleById, so execute-schedule.ts sent reminder SMS with empty {{4}} (time) and {{5}} (nav link). Matches the fix already applied to message-processor.ts and send-manual.ts.