### PR TITLE
Show SMS body in message preview for SMS-only templates

### DIFF
--- a/features/schedules/components/message-content-card.tsx
+++ b/features/schedules/components/message-content-card.tsx
@@ -52,11 +52,13 @@ const chatBgStyle: React.CSSProperties = {
 
 interface MessageContentCardProps {
   template: WhatsAppTemplateApp | null;
+  smsBody?: string | null;
   event: EventApp | null;
 }
 
 export function MessageContentCard({
   template,
+  smsBody,
   event,
 }: MessageContentCardProps) {
   const t = useTranslations('schedules.messagePreview');
@@ -92,7 +94,18 @@ export function MessageContentCard({
             className="flex flex-col gap-1 px-3 py-4"
             style={chatBgStyle}
           >
-            {template === null ? (
+            {template === null && smsBody ? (
+              <div className="flex justify-end rtl:justify-start py-2 px-1">
+                <div className="relative max-w-[85%]">
+                  <div className="absolute top-0 -right-[7px] rtl:right-auto rtl:-left-[7px] h-0 w-0 border-b-[8px] border-b-transparent border-l-[8px] border-l-zinc-200 rtl:border-l-0 rtl:border-r-[8px] rtl:border-r-zinc-200" />
+                  <div className="rounded-l-xl rounded-br-xl rtl:rounded-l-none rtl:rounded-br-none rtl:rounded-r-xl rtl:rounded-bl-xl bg-zinc-200 px-3 py-2 shadow-sm">
+                    <p className="text-sm leading-relaxed whitespace-pre-wrap text-zinc-800" dir="rtl">
+                      {smsBody}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : template === null ? (
               <div className="flex items-center justify-center py-6">
                 <p className="rounded-lg bg-white/80 px-3 py-1.5 text-xs text-zinc-500">
                   {t('noMessage')}

--- a/features/schedules/components/schedule-tab-content.tsx
+++ b/features/schedules/components/schedule-tab-content.tsx
@@ -8,6 +8,7 @@ import { TargetAudienceCard } from './target-audience-card';
 interface ScheduleTabContentProps {
   schedule: ScheduleApp;
   template: WhatsAppTemplateApp | null;
+  smsBody?: string | null;
   eventDate: string;
   event: EventApp | null;
   guestStats: GuestStats;
@@ -16,6 +17,7 @@ interface ScheduleTabContentProps {
 export function ScheduleTabContent({
   schedule,
   template,
+  smsBody,
   eventDate,
   event,
   guestStats,
@@ -30,6 +32,7 @@ export function ScheduleTabContent({
       <div className="h-full">
         <MessageContentCard
           template={template}
+          smsBody={smsBody}
           event={event}
         />
       </div>

--- a/features/schedules/components/schedules-page.tsx
+++ b/features/schedules/components/schedules-page.tsx
@@ -12,6 +12,7 @@ import {
   type ScheduleApp,
   type WhatsAppTemplateApp,
 } from '../schemas';
+import { resolveSmsBodyForPreview } from '../utils/parameter-resolvers';
 import { filterGuestsByTarget } from '../utils';
 import { buildSuggestedSchedules } from '../utils/suggested-schedules';
 import { ScheduleInteractionsCard } from './schedule-interactions-card';
@@ -29,6 +30,7 @@ interface SchedulesPageProps {
 type ScheduleWithTemplate = {
   schedule: ScheduleApp;
   template: WhatsAppTemplateApp | null;
+  smsBody: string | null;
 };
 
 export type ScheduleTabItem = {
@@ -78,6 +80,12 @@ export async function SchedulesPage({
     schedulesByActionType[schedule.actionType]!.push({
       schedule,
       template: schedule.templateKey ? (templateMap.get(schedule.templateKey)?.whatsapp ?? null) : null,
+      smsBody: schedule.deliveryMethod === 'sms' && schedule.templateKey
+        ? (() => {
+            const smsConfig = templateMap.get(schedule.templateKey!)?.sms;
+            return smsConfig ? resolveSmsBodyForPreview(smsConfig, event).resolvedBody : null;
+          })()
+        : null,
     });
   }
 
@@ -116,7 +124,7 @@ export async function SchedulesPage({
     const baseLabel = t(`actionTypes.${type}`);
     const multiple = items.length > 1;
 
-    contentByType[type] = items.map(({ schedule, template }, index) => {
+    contentByType[type] = items.map(({ schedule, template, smsBody }, index) => {
       const guestCount = filterGuestsByTarget(guests, schedule.targetStatus).length;
       return {
         label: multiple ? `${baseLabel} ${index + 1}` : baseLabel,
@@ -148,6 +156,7 @@ export async function SchedulesPage({
               <ScheduleTabContent
                 schedule={schedule}
                 template={template}
+                smsBody={smsBody}
                 eventDate={eventDate}
                 event={event}
                 guestStats={guestStats}

--- a/features/schedules/utils/parameter-resolvers.ts
+++ b/features/schedules/utils/parameter-resolvers.ts
@@ -352,6 +352,43 @@ export function buildDynamicButtonParameters(
  * no specific guest is selected at preview time. Event placeholders are resolved
  * against the provided event.
  */
+export function resolveSmsBodyForPreview(
+  smsConfig: { bodyText: string; parameters?: { placeholders?: Record<string, { source?: string; transformer: string }> } },
+  event: EventApp | null,
+): { resolvedBody: string; hasMissingFields: boolean } {
+  const placeholders = smsConfig.parameters?.placeholders;
+  if (!placeholders || Object.keys(placeholders).length === 0) {
+    return { resolvedBody: smsConfig.bodyText, hasMissingFields: false };
+  }
+
+  let hasMissingFields = false;
+  const resolvedValues: string[] = [];
+  const mockContext = { event: event ?? {}, guest: {} } as unknown as ParameterResolutionContext;
+
+  for (const [name, config] of Object.entries(placeholders)) {
+    const source = config.source ?? name;
+    if (source.startsWith('guest.') || source.startsWith('group.')) {
+      const fieldName = source.split('.').pop() ?? source;
+      resolvedValues.push(`[${fieldName.charAt(0).toUpperCase() + fieldName.slice(1)}]`);
+    } else {
+      const rawValue = event ? getValueByPath({ event }, source) : undefined;
+      if (!rawValue) {
+        hasMissingFields = true;
+        resolvedValues.push('…');
+      } else {
+        resolvedValues.push(resolvePlaceholder(name, config as Parameters<typeof resolvePlaceholder>[1], mockContext) || '…');
+      }
+    }
+  }
+
+  let resolvedBody = smsConfig.bodyText;
+  resolvedValues.forEach((value, index) => {
+    resolvedBody = resolvedBody.replaceAll(`{{${index + 1}}}`, value);
+  });
+
+  return { resolvedBody, hasMissingFields };
+}
+
 export function resolveTemplateBodyForPreview(
   template: WhatsAppTemplateApp,
   event: EventApp | null,


### PR DESCRIPTION
WhatsApp-only preview card showed "no message" for schedules using SMS-only templates (no whatsapp config). Thread smsBody through the component tree and render it as an SMS bubble when present.