### PR TITLE
Add minimal mobile dashboard with RSVP status and recent activity

### DIFF
--- a/app/[locale]/app/[eventId]/dashboard/page.tsx
+++ b/app/[locale]/app/[eventId]/dashboard/page.tsx
@@ -36,7 +36,7 @@ export default async function DashboardPage({
     getEventById(eventId),
     getEventGuests(eventId),
     getEventGroupsWithGuests(eventId),
-    getRecentRsvpActivity(eventId, 5),
+    getRecentRsvpActivity(eventId, 50),
     getCollaboratorCount(eventId),
     getPendingSchedulesCount(eventId),
   ]);
@@ -58,38 +58,47 @@ export default async function DashboardPage({
 
   return (
     <>
-      <DashboardHeader />
-
-      {/* Row 1: Hero banner + stat cards */}
-      {event ? (
-        <div className="grid grid-cols-5 gap-4">
-          <div className="col-span-2 h-full">
-            <EventHeroBanner event={event} />
-          </div>
-          <DaysToEventCard daysRemaining={getDaysRemaining(event.eventDate)} />
-          <GuestsInvitedCard total={stats.total} estimate={event.guestsEstimate} />
-          <ScheduledMessagesCard count={pendingSchedulesCount} />
-        </div>
-      ) : (
-        <div className="flex h-40 items-center justify-center rounded-xl border bg-card text-muted-foreground">
-          {t('eventNotFound')}
-        </div>
-      )}
-
-      {/* Row 2: RSVP Breakdown + Quick Actions + Group Breakdown */}
-      <div className="grid grid-cols-3 gap-4">
+      {/* Mobile view - minimal dashboard */}
+      <div className="flex flex-col gap-4 md:hidden">
         <RsvpBreakdownCard stats={stats} />
-        <RsvpEngagementCard groups={groups} />
-        <GroupBreakdownCard groups={groups} />
+        <RecentRsvpActivityCard activity={recentActivity} eventId={eventId} pageSize={10} />
       </div>
 
-      {/* Row 3: Onboarding Checklist + Recent Activity */}
-      <div className="grid grid-cols-12 gap-4">
-        <div className="col-span-7">
-          <OnboardingChecklistCard eventId={eventId} status={onboardingStatus} />
+      {/* Desktop view - full dashboard */}
+      <div className="hidden md:flex md:flex-col md:gap-6">
+        <DashboardHeader />
+
+        {/* Row 1: Hero banner + stat cards */}
+        {event ? (
+          <div className="grid grid-cols-5 gap-4">
+            <div className="col-span-2 h-full">
+              <EventHeroBanner event={event} />
+            </div>
+            <DaysToEventCard daysRemaining={getDaysRemaining(event.eventDate)} />
+            <GuestsInvitedCard total={stats.total} estimate={event.guestsEstimate} />
+            <ScheduledMessagesCard count={pendingSchedulesCount} />
+          </div>
+        ) : (
+          <div className="flex h-40 items-center justify-center rounded-xl border bg-card text-muted-foreground">
+            {t('eventNotFound')}
+          </div>
+        )}
+
+        {/* Row 2: RSVP Breakdown + Quick Actions + Group Breakdown */}
+        <div className="grid grid-cols-3 gap-4">
+          <RsvpBreakdownCard stats={stats} />
+          <RsvpEngagementCard groups={groups} />
+          <GroupBreakdownCard groups={groups} />
         </div>
-        <div className="col-span-5">
-          <RecentRsvpActivityCard activity={recentActivity} eventId={eventId} />
+
+        {/* Row 3: Onboarding Checklist + Recent Activity */}
+        <div className="grid grid-cols-12 gap-4">
+          <div className="col-span-7">
+            <OnboardingChecklistCard eventId={eventId} status={onboardingStatus} />
+          </div>
+          <div className="col-span-5">
+            <RecentRsvpActivityCard activity={recentActivity.slice(0, 5)} eventId={eventId} />
+          </div>
         </div>
       </div>
     </>

--- a/components/mobile-block.tsx
+++ b/components/mobile-block.tsx
@@ -1,9 +1,19 @@
-import { getTranslations } from 'next-intl/server';
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { usePathname } from '@/i18n/navigation';
 import { Monitor } from 'lucide-react';
 import { IconDeviceMobile } from '@tabler/icons-react';
 
-export async function MobileBlock({ children }: { children: React.ReactNode }) {
-  const t = await getTranslations('mobileBlock');
+const MOBILE_ALLOWED_ROUTES = /^\/app\/[^/]+\/dashboard\/?$/;
+
+export function MobileBlock({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('mobileBlock');
+  const pathname = usePathname();
+
+  if (MOBILE_ALLOWED_ROUTES.test(pathname)) {
+    return <>{children}</>;
+  }
 
   return (
     <>

--- a/features/admin/actions/trigger-schedule.ts
+++ b/features/admin/actions/trigger-schedule.ts
@@ -34,7 +34,7 @@ export async function triggerScheduleAdmin(scheduleId: string): Promise<TriggerS
 
     const { data: scheduleRow, error: scheduleError } = await supabase
       .from('schedules')
-      .select(`*, events (id, user_id, title, event_date, location, host_details, invitations)`)
+      .select(`*, events (id, user_id, title, event_date, location, host_details, invitations, reception_time, short_code)`)
       .eq('id', scheduleId)
       .single();
 
@@ -67,6 +67,8 @@ export async function triggerScheduleAdmin(scheduleId: string): Promise<TriggerS
       location: eventRow.location ?? undefined,
       hostDetails: eventRow.host_details ?? undefined,
       invitations: eventRow.invitations ? { imageUrl: eventRow.invitations.image_url } : undefined,
+      receptionTime: eventRow.reception_time ?? undefined,
+      shortCode: eventRow.short_code ?? undefined,
     };
 
     const { data: guestRows, error: guestError } = await supabase

--- a/features/dashboard/components/recent-rsvp-activity-card.tsx
+++ b/features/dashboard/components/recent-rsvp-activity-card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import {
@@ -46,11 +47,16 @@ function StatusIcon({ status }: { status: RecentRsvpRow['rsvpStatus'] }) {
 export function RecentRsvpActivityCard({
   activity,
   eventId,
+  pageSize,
 }: {
   activity: RecentRsvpRow[];
   eventId: string;
+  pageSize?: number;
 }) {
   const t = useTranslations('dashboard.recentActivity');
+  const [visibleCount, setVisibleCount] = useState(pageSize ?? activity.length);
+  const visibleActivity = pageSize ? activity.slice(0, visibleCount) : activity;
+  const hasMore = pageSize ? visibleCount < activity.length : false;
 
   function getActionLabel(status: RecentRsvpRow['rsvpStatus']): string {
     switch (status) {
@@ -89,7 +95,7 @@ export function RecentRsvpActivityCard({
           </div>
         </div>
       </CardHeader>
-      <CardContent className="max-h-72 flex-1 overflow-y-auto p-0">
+      <CardContent className={pageSize ? 'flex-1 p-0' : 'max-h-72 flex-1 overflow-y-auto p-0'}>
         {activity.length === 0 ? (
           <div className="flex h-full items-center justify-center">
             <p className="text-muted-foreground text-center text-sm">
@@ -97,7 +103,7 @@ export function RecentRsvpActivityCard({
             </p>
           </div>
         ) : (
-          activity.map((row) => (
+          visibleActivity.map((row) => (
             <Item key={row.id} size="sm">
               <ItemMedia>
                 <StatusIcon status={row.rsvpStatus} />
@@ -117,7 +123,17 @@ export function RecentRsvpActivityCard({
         )}
       </CardContent>
       {activity.length > 0 && (
-        <CardFooter className="pt-2">
+        <CardFooter className="flex flex-col gap-2 pt-2">
+          {hasMore && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full"
+              onClick={() => setVisibleCount((c) => c + pageSize!)}
+            >
+              {t('showMore')}
+            </Button>
+          )}
           <Button variant="outline" size="sm" className="w-full" asChild>
             <Link href={`/app/${eventId}/guests`}>{t('viewAllGuests')}</Link>
           </Button>

--- a/messages/en.json
+++ b/messages/en.json
@@ -763,7 +763,8 @@
       "minutesAgo": "{count} minutes ago",
       "hoursAgo": "{count} hours ago",
       "dayAgo": "{count} day ago",
-      "daysAgo": "{count} days ago"
+      "daysAgo": "{count} days ago",
+      "showMore": "Show more"
     },
     "onboarding": {
       "title": "Get started with Kululu",

--- a/messages/he.json
+++ b/messages/he.json
@@ -764,7 +764,8 @@
       "minutesAgo": "לפני {count} דקות",
       "hoursAgo": "לפני {count} שעות",
       "dayAgo": "לפני {count} יום",
-      "daysAgo": "לפני {count} ימים"
+      "daysAgo": "לפני {count} ימים",
+      "showMore": "הצג עוד"
     },
     "onboarding": {
       "title": "התחל עם Kululu",


### PR DESCRIPTION
- Make MobileBlock route-aware (client component) so the dashboard renders on mobile while all other routes keep the coming-soon screen
- Show donut RSVP breakdown + recent activity cards on mobile
- Paginate mobile activity list: 10 items initially, Show more (+10)
- Desktop dashboard unchanged