### PR TITLE
Add SMS thank-you template for post_event schedules

### DIFF
--- a/features/schedules/actions/execute-schedule.ts
+++ b/features/schedules/actions/execute-schedule.ts
@@ -110,13 +110,6 @@ export async function executeSchedule(
 
     const template = templateConfig.whatsapp;
 
-    if (!template) {
-      return {
-        success: false,
-        message: 'Template does not have a WhatsApp configuration',
-      };
-    }
-
     // 6. Fetch all event guests
     const allGuests = await getEventGuests(schedule.eventId);
 
@@ -173,7 +166,15 @@ export async function executeSchedule(
         }),
       );
     } else {
-      // 9. Validate template has parameters configuration
+      // 9. Validate WhatsApp template is available
+      if (!template) {
+        return {
+          success: false,
+          message: 'Template does not have a WhatsApp configuration',
+        };
+      }
+
+      // 11. Validate template has parameters configuration
       if (!template.parameters) {
         return {
           success: false,
@@ -181,7 +182,7 @@ export async function executeSchedule(
         };
       }
 
-      // 10. Batch fetch all needed groups for performance
+      // 12. Batch fetch all needed groups for performance
       const uniqueGroupIds = [
         ...new Set(
           guestsWithPhones
@@ -200,7 +201,7 @@ export async function executeSchedule(
         }),
       );
 
-      // 11. Send messages in rate-limited chunks
+      // 13. Send messages in rate-limited chunks
       sendResults = await sendInChunks(guestsWithPhones, (guest) => {
         const confirmationToken = generateConfirmationToken();
         const context: ParameterResolutionContext = {

--- a/features/schedules/config/sms-bodies.ts
+++ b/features/schedules/config/sms-bodies.ts
@@ -34,14 +34,14 @@ export function buildSmsConfirmationBody(
   return `${body}\n${rsvpLink}`;
 }
 
-export function buildSmsReminderBody(
+export function buildSmsTemplateBody(
   context: ParameterResolutionContext,
-  templateKey: string = 'event_reminder_casual',
+  templateKey: string,
 ): string {
   const smsConfig = getTemplateByKey(templateKey)?.sms;
   if (!smsConfig?.parameters?.placeholders) {
     console.error(`[SMS] Failed to resolve SMS config for ${templateKey}`);
-    throw new Error('SMS reminder template resolution failed');
+    throw new Error('SMS template resolution failed');
   }
 
   const params = buildDynamicTemplateParameters(smsConfig.parameters.placeholders, context);

--- a/features/schedules/config/whatsapp-templates.ts
+++ b/features/schedules/config/whatsapp-templates.ts
@@ -251,6 +251,29 @@ export const WHATSAPP_TEMPLATES: Record<string, TemplateConfig> = {
     },
   },
 
+  thank_you_sms_v1_he: {
+    whatsapp: undefined,
+    sms: {
+      bodyText:
+        'היי אורחים יקרים\nתודה שהגעתם לשמוח איתנו ביום המרגש שלנו \n\nאוהבים ומעריכים {{1}} ו{{2}} ❤️',
+      parameters: {
+        headerPlaceholders: [],
+        // Order = positional {{n}}: {{1}} bride, {{2}} groom.
+        placeholders: {
+          'host.bride.name': {
+            source: 'event.hostDetails.bride.name',
+            transformer: 'none',
+          },
+          'host.groom.name': {
+            source: 'event.hostDetails.groom.name',
+            transformer: 'none',
+          },
+        },
+        buttonPlaceholders: [],
+      },
+    },
+  },
+
   event_reminder_wartime: {
     whatsapp: undefined,
     sms: {

--- a/features/schedules/utils/send-helpers.ts
+++ b/features/schedules/utils/send-helpers.ts
@@ -4,7 +4,7 @@ import type { DeliveryMethod } from '../schemas';
 import type { WhatsAppTemplateApp } from '../schemas/whatsapp-templates';
 import { sendWhatsAppTemplateMessage } from '../actions/whatsapp';
 import { sendSmsMessage, buildSmsFallbackBody } from '../actions/sms';
-import { buildSmsConfirmationBody, buildSmsReminderBody } from '../config/sms-bodies';
+import { buildSmsConfirmationBody, buildSmsTemplateBody } from '../config/sms-bodies';
 import {
   buildDynamicTemplateParameters,
   buildDynamicButtonParameters,
@@ -143,9 +143,12 @@ export async function sendSmsToGuest(params: {
 }): Promise<GuestSendResult> {
   const { guest, context, confirmationToken } = params;
   const phoneE164 = formatPhoneE164(guest.phone!);
-  const body = context.schedule?.actionType === 'event_reminder'
-    ? buildSmsReminderBody(context, context.schedule.templateKey ?? undefined)
-    : buildSmsConfirmationBody(context, confirmationToken);
+  const actionType = context.schedule?.actionType;
+  const templateKey = context.schedule?.templateKey ?? undefined;
+  const body =
+    actionType === 'event_reminder' || actionType === 'post_event'
+      ? buildSmsTemplateBody(context, templateKey!)
+      : buildSmsConfirmationBody(context, confirmationToken);
   const result = await sendSmsMessage({ to: phoneE164, body });
 
   return {

--- a/lib/services/message-processor.ts
+++ b/lib/services/message-processor.ts
@@ -168,11 +168,6 @@ async function processSingleSchedule(
 
   const template = templateConfig.whatsapp;
 
-  if (!template) {
-    await revertOrCancel(supabase, schedule.id, rawScheduleWithEvent.scheduled_date);
-    throw new Error('Template does not have a WhatsApp configuration');
-  }
-
   // 5. Fetch all event guests
   const { data: rawGuests, error: guestsError } = await supabase
     .from('guests')
@@ -281,13 +276,19 @@ async function processSingleSchedule(
     return { sentCount, failedCount };
   }
 
-  // 7. Validate template has parameters configuration
+  // 7. Validate WhatsApp template is available (SMS was handled above)
+  if (!template) {
+    await revertOrCancel(supabase, schedule.id, rawScheduleWithEvent.scheduled_date);
+    throw new Error('Template does not have a WhatsApp configuration');
+  }
+
+  // 8. Validate template has parameters configuration
   if (!template.parameters) {
     await revertOrCancel(supabase, schedule.id, rawScheduleWithEvent.scheduled_date);
     throw new Error('Template missing parameter configuration');
   }
 
-  // 8. Batch fetch groups
+  // 9. Batch fetch groups
   const uniqueGroupIds = [
     ...new Set(
       pendingGuests
@@ -311,7 +312,7 @@ async function processSingleSchedule(
     }
   }
 
-  // 9. Send messages in rate-limited chunks, persisting delivery records after each chunk
+  // 10. Send messages in rate-limited chunks, persisting delivery records after each chunk
   let sentCount = 0;
   let failedCount = 0;
   const totalGuests = pendingGuests.length;


### PR DESCRIPTION
Adds thank_you_sms_v1_he - a new SMS-only template for post-event thank-you messages with bride/groom name placeholders. Fixes the implicit gate that blocked SMS-only templates in both the manual and cron send flows by moving the WhatsApp config requirement to after the SMS branch. Routes post_event SMS through the generic body builder instead of the confirmation body.