### PR TITLE
fix: resolve pre-existing lint errors (a->Link, prefer-as-const)

### DIFF
--- a/components/homepage-client.tsx
+++ b/components/homepage-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { IconBrandWhatsapp } from '@tabler/icons-react';
 
 const WHATSAPP_NUMBER = '972556839696';
@@ -449,9 +450,9 @@ export function HomepageClient() {
       {/* NAV */}
       <header className="hp-nav" ref={navRef} id="nav" dir="rtl">
         <div className="wrap nav-inner">
-          <a href="/login" className="btn btn-primary heb" id="navCta">
+          <Link href="/login" className="btn btn-primary heb" id="navCta">
             כניסה / הרשמה
-          </a>
+          </Link>
 
           <button
             className="hp-nav-hamburger"
@@ -490,9 +491,9 @@ export function HomepageClient() {
           <a href="#how" className={activeSection === 'how' ? 'active' : ''} onClick={() => setMobileMenuOpen(false)}>יצירת אירוע</a>
           <a href="#pricing" className={activeSection === 'pricing' ? 'active' : ''} onClick={() => setMobileMenuOpen(false)}>חבילות</a>
         </nav>
-        <a href="/login" className="mobile-menu-cta" onClick={() => setMobileMenuOpen(false)}>
+        <Link href="/login" className="mobile-menu-cta" onClick={() => setMobileMenuOpen(false)}>
           כניסה / הרשמה
-        </a>
+        </Link>
       </div>
 
       {/* HERO */}

--- a/components/ui/bottom-nav-bar.tsx
+++ b/components/ui/bottom-nav-bar.tsx
@@ -53,7 +53,7 @@ export function BottomNavBar({ items, disabled, className }: BottomNavBarProps) 
         return (
           <motion.div key={item.title} whileTap={{ scale: 0.97 }}>
             <Link
-              href={disabled ? ('/app' as '/app') : (item.url as '/app')}
+              href={disabled ? ('/app' as const) : (item.url as '/app')}
               aria-label={item.title}
               aria-current={isActive ? 'page' : undefined}
               className={cn(


### PR DESCRIPTION
- homepage-client: use next/link Link for /login navigation (2 sites)
- bottom-nav-bar: use 'as const' instead of literal type assertion