### PR TITLE
feat: full-height sidebar with narrower top row

### DIFF
--- a/src/app/(main)/[locale]/app/layout.tsx
+++ b/src/app/(main)/[locale]/app/layout.tsx
@@ -40,16 +40,15 @@ export default async function Layout({
   const events = await getAllUserEvents();
 
   return (
-    <SidebarProvider className="!min-h-svh flex-col !bg-[#F4F4F6]">
-      <AppTopBar />
-      <div className="flex min-h-0 w-full flex-1">
-        <AppSidebar
-          variant="floating"
-          events={events}
-          currentUserId={effectiveUser?.id ?? data.user.id}
-          user={user}
-          className="!top-14 !h-[calc(100svh-3.5rem)]"
-        />
+    <SidebarProvider className="!min-h-svh !bg-[#F4F4F6]">
+      <AppSidebar
+        variant="floating"
+        events={events}
+        currentUserId={effectiveUser?.id ?? data.user.id}
+        user={user}
+      />
+      <div className="flex min-h-0 w-full flex-1 flex-col">
+        <AppTopBar />
         <SidebarInset className="!bg-[#F4F4F6]">
           <ImpersonationBanner />
           <LayoutContentWrapper>{children}</LayoutContentWrapper>

--- a/src/components/layout/app-top-bar.tsx
+++ b/src/components/layout/app-top-bar.tsx
@@ -4,9 +4,13 @@ import Image from 'next/image';
 
 export function AppTopBar() {
   return (
-    <header className="flex h-14 shrink-0 items-center gap-2 bg-[#F4F4F6] px-3">
-      {/* App-level start cluster: brand */}
-      <a href="#" dir="ltr" className="flex items-center gap-2.5 px-1.5">
+    <header className="relative flex h-14 shrink-0 items-center gap-2 bg-[#F4F4F6] px-3">
+      {/* Brand: pinned to the physical left edge regardless of text direction */}
+      <a
+        href="#"
+        dir="ltr"
+        className="absolute inset-y-0 left-3 flex items-center gap-2.5"
+      >
         <Image
           src="/kululu-logo-gray.svg"
           alt="Kululu"
@@ -17,8 +21,8 @@ export function AppTopBar() {
         <span className="text-xl font-semibold">Kululu</span>
       </a>
 
-      {/* Remaining space for future app-level buttons and elements */}
-      <div className="flex flex-1 items-center justify-end gap-2" />
+      {/* Remaining space for future app-level buttons and elements, offset past the logo */}
+      <div className="flex flex-1 items-center justify-end gap-2 pl-36" />
     </header>
   );
 }


### PR DESCRIPTION
Give the sidebar its own full-viewport column and shrink the top row to sit only beside it, with the logo pinned to the physical left edge regardless of RTL/LTR.