### PR TITLE
feat: add invitations storage bucket with owner-scoped policies

### DIFF
--- a/supabase/migrations/20260717111544_create_invitations_bucket.sql
+++ b/supabase/migrations/20260717111544_create_invitations_bucket.sql
@@ -1,0 +1,73 @@
+-- Invitation images uploaded from the event details page.
+-- Client uploads to `invitations/{eventId}/invitation-{timestamp}.{ext}` with upsert,
+-- then stores the public URL on events.invitations.image_url.
+--
+-- The bucket is public because the stored URL is fetched unauthenticated by
+-- WhatsApp/Twilio as a template IMAGE header (see whatsapp-templates.ts).
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'invitations',
+  'invitations',
+  true,
+  5242880,
+  ARRAY['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Objects are foldered by event id, not by user id, so writes mirror the
+-- events UPDATE policy: the legacy creator column, or an 'owner' collaborator.
+-- A seating_manager collaborator cannot touch invitation images.
+CREATE OR REPLACE FUNCTION public.user_can_manage_event_invitation(p_folder text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id uuid;
+BEGIN
+  -- Folder name is client-supplied; a non-uuid must deny, not raise.
+  BEGIN
+    v_event_id := p_folder::uuid;
+  EXCEPTION WHEN invalid_text_representation THEN
+    RETURN false;
+  END;
+
+  RETURN EXISTS (
+    SELECT 1 FROM public.events
+    WHERE id = v_event_id AND user_id = auth.uid()
+  ) OR public.user_is_event_owner(v_event_id);
+END;
+$$;
+
+CREATE POLICY "Invitation images are publicly accessible"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'invitations');
+
+CREATE POLICY "Event owners can upload invitation images"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'invitations'
+    AND public.user_can_manage_event_invitation((storage.foldername(name))[1])
+  );
+
+-- Required by the client's upsert: true.
+CREATE POLICY "Event owners can update invitation images"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'invitations'
+    AND public.user_can_manage_event_invitation((storage.foldername(name))[1])
+  )
+  WITH CHECK (
+    bucket_id = 'invitations'
+    AND public.user_can_manage_event_invitation((storage.foldername(name))[1])
+  );
+
+CREATE POLICY "Event owners can delete invitation images"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'invitations'
+    AND public.user_can_manage_event_invitation((storage.foldername(name))[1])
+  );

--- a/supabase/migrations/20260717111644_drop_stray_invitations_bucket_policies.sql
+++ b/supabase/migrations/20260717111644_drop_stray_invitations_bucket_policies.sql
@@ -1,0 +1,10 @@
+-- Two policies were created in the Studio UI against an `invitations` bucket that
+-- never existed, so they sat dormant until the previous migration created it.
+-- The DELETE one granted every authenticated user delete on every event's image
+-- (qual: bucket_id = 'invitations', with no ownership check). Permissive policies
+-- are OR'd, so it defeated the ownership check the previous migration added.
+-- Its SELECT twin was redundant with the public-read policy.
+--
+-- These only ever existed on the remote project; the drops are a no-op elsewhere.
+DROP POLICY IF EXISTS "Authenticated users can delete from invitations 18l1j3u_0" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated users can delete from invitations 18l1j3u_1" ON storage.objects;

--- a/supabase/migrations/20260717111954_drop_remaining_stray_invitations_policies.sql
+++ b/supabase/migrations/20260717111954_drop_remaining_stray_invitations_policies.sql
@@ -1,0 +1,12 @@
+-- Two more dormant Studio-created policies on the `invitations` bucket, missed by
+-- the previous migration because their names don't mention "invitation" - only
+-- their bucket_id predicate does.
+--
+-- `Allow authenticated uploads 18l1j3u_0` was INSERT for any authenticated user
+-- with_check `bucket_id = 'invitations'` and no ownership check, so it OR'd past
+-- the scoped INSERT policy and allowed writing into any event's folder.
+-- `Allow public read access 18l1j3u_0` duplicated the public-read policy exactly.
+--
+-- These only ever existed on the remote project; the drops are a no-op elsewhere.
+DROP POLICY IF EXISTS "Allow authenticated uploads 18l1j3u_0" ON storage.objects;
+DROP POLICY IF EXISTS "Allow public read access 18l1j3u_0" ON storage.objects;


### PR DESCRIPTION
The event details page uploads invitation images to an `invitations` bucket that never existed, so every upload failed. Create it, public with a 5MB image-only limit: the stored URL is fetched unauthenticated by WhatsApp as a template IMAGE header, so it cannot be private.

Objects are foldered by event id rather than user id, so writes go through user_can_manage_event_invitation(), mirroring the events UPDATE policy (creator column OR 'owner' collaborator). A seating_manager cannot touch invitation images. Malformed folder names deny instead of raising.

Also drop four policies previously created through the Studio UI against the then-nonexistent bucket. They were dormant until the bucket existed; two granted every authenticated user INSERT and DELETE on every event's images, which would OR past the ownership check above.