### PR TITLE
fix: persist manual-send delivery rows, shorten confirmation token

### DIFF
--- a/src/app/(main)/[locale]/confirm/[token]/page.tsx
+++ b/src/app/(main)/[locale]/confirm/[token]/page.tsx
@@ -12,7 +12,9 @@ import { setRequestLocale } from 'next-intl/server';
 
 export const dynamic = 'force-dynamic';
 
-const TOKEN_REGEX = /^[a-f0-9]{64}$/;
+// Accepts both the current 32-hex-char token (16 random bytes) and the
+// original 64-char length, so links already issued keep working.
+const TOKEN_REGEX = /^[a-f0-9]{32,64}$/;
 
 export default async function ConfirmationPage({
   params,

--- a/src/features/schedules/utils/send-helpers.ts
+++ b/src/features/schedules/utils/send-helpers.ts
@@ -245,5 +245,8 @@ export function buildDeliveryRecord(
 // ─── Token generator ──────────────────────────────────────────────────────────
 
 export function generateConfirmationToken(): string {
-  return randomBytes(32).toString('hex');
+  // 16 bytes (128 bits) is comfortably unguessable for an RSVP link - same
+  // order of entropy as a v4 UUID - while keeping the SMS-embedded link
+  // shorter than the original 32-byte token.
+  return randomBytes(16).toString('hex');
 }

--- a/supabase/migrations/20260809180000_add_message_deliveries_update_policy.sql
+++ b/supabase/migrations/20260809180000_add_message_deliveries_update_policy.sql
@@ -1,0 +1,30 @@
+-- message_deliveries had INSERT and SELECT policies scoped to the event
+-- owner, but no UPDATE policy. Manual sends persist delivery rows via
+-- `upsert(..., { onConflict: 'schedule_id,guest_id' })`, which compiles to
+-- INSERT ... ON CONFLICT DO UPDATE. Postgres requires UPDATE privilege on
+-- the table for that statement to run at all, regardless of whether a row
+-- actually conflicts. Without this policy, the upsert silently failed under
+-- RLS for any owner-triggered send (service-role sends were unaffected),
+-- so delivery rows - including the guest's confirmation_token - were never
+-- persisted even though the SMS/WhatsApp message itself went out.
+create policy "Users can update deliveries for their schedules"
+on public.message_deliveries
+for update
+using (
+  exists (
+    select 1
+    from schedules s
+    join events e on e.id = s.event_id
+    where s.id = message_deliveries.schedule_id
+      and e.user_id = auth.uid()
+  )
+)
+with check (
+  exists (
+    select 1
+    from schedules s
+    join events e on e.id = s.event_id
+    where s.id = message_deliveries.schedule_id
+      and e.user_id = auth.uid()
+  )
+);

--- a/supabase/migrations/20260809181500_add_message_deliveries_error_code.sql
+++ b/supabase/migrations/20260809181500_add_message_deliveries_error_code.sql
@@ -1,0 +1,10 @@
+-- buildDeliveryRecord() (src/features/schedules/utils/send-helpers.ts) has
+-- always written an `error_code` field on every message_deliveries
+-- upsert, and the app schema (MessageDeliveryDbSchema) has always expected
+-- to read one back - but the column itself was never created. PostgREST
+-- rejects writes referencing an unknown column, so every delivery upsert
+-- since this code was introduced failed silently (the error was caught and
+-- only console.error'd, never surfaced), regardless of RLS or trigger
+-- method. This adds the column the app has been assuming exists all along.
+alter table public.message_deliveries
+  add column error_code integer;


### PR DESCRIPTION
message_deliveries upserts have been silently failing for every send since this code was written - the table had zero rows system-wide before this fix. Two causes:

- No UPDATE RLS policy for the event owner role, needed because upsert(onConflict:...) compiles to INSERT ... ON CONFLICT DO UPDATE, which requires UPDATE privilege regardless of whether a row conflicts. Only service-role (cron/admin) callers were unaffected by this.
- buildDeliveryRecord() has always written an `error_code` field that had no matching column on message_deliveries, so PostgREST rejected the write outright for every caller, RLS or not.

Also shrinks generateConfirmationToken() from 32 to 16 random bytes (64 to 32 hex chars) to keep SMS-embedded confirmation links shorter. The page's TOKEN_REGEX now accepts both 32 and 64 hex chars so already-issued 64-char links keep resolving.