### PR TITLE
feat: show Bar Mitzva celebrant name on landing page

### DIFF
--- a/src/app/(main)/[locale]/app/[eventId]/templates/page.tsx
+++ b/src/app/(main)/[locale]/app/[eventId]/templates/page.tsx
@@ -6,6 +6,7 @@ import {
   buildFormattedDate,
   buildTime,
   buildDishOptions,
+  type HostDetails,
 } from '@/features/templates';
 import { getEventById } from '@/features/events/queries';
 import type { LivePreviewEventData } from '@/features/templates/components/live-template-preview';
@@ -20,12 +21,10 @@ export default async function TemplatesServerPage({
 
   let livePreviewData: LivePreviewEventData | undefined;
   if (event) {
-    const hostDetails = event.hostDetails as
-      | { bride?: { name?: string }; groom?: { name?: string } }
-      | undefined;
+    const hostDetails = event.hostDetails as HostDetails;
 
     livePreviewData = {
-      coupleName: buildCoupleName(hostDetails, event.title),
+      coupleName: buildCoupleName(hostDetails, event.title, event.eventType),
       formattedDate: buildFormattedDate(event.eventDate),
       time: buildTime(event.receptionTime, event.ceremonyTime),
       venue: event.location?.name,

--- a/src/features/confirmation/components/confirmation-experience.tsx
+++ b/src/features/confirmation/components/confirmation-experience.tsx
@@ -7,6 +7,7 @@ import {
   buildFormattedDate,
   buildTime,
   buildDishOptions,
+  type HostDetails,
 } from '@/features/templates/utils';
 import { submitConfirmation, recordViewInteraction } from '../actions';
 import type { ConfirmationPageData } from '../schemas';
@@ -36,10 +37,8 @@ export function ConfirmationExperience({ token, data, templateId }: Confirmation
     ? `https://www.google.com/maps/search/?api=1&query=${event.location.coords.lat},${event.location.coords.lng}`
     : undefined;
 
-  const hostDetails = event.hostDetails as
-    | { bride?: { name?: string }; groom?: { name?: string } }
-    | undefined;
-  const coupleName = buildCoupleName(hostDetails, event.title);
+  const hostDetails = event.hostDetails as HostDetails;
+  const coupleName = buildCoupleName(hostDetails, event.title, event.eventType);
 
   const dishOptions = useMemo(
     () => buildDishOptions(event.guestExperience),

--- a/src/features/templates/index.ts
+++ b/src/features/templates/index.ts
@@ -23,6 +23,7 @@ export {
   DIETARY_EMOJI,
   DIETARY_LABEL,
   type DishOption,
+  type HostDetails,
 } from './utils';
 
 // Types

--- a/src/features/templates/utils.ts
+++ b/src/features/templates/utils.ts
@@ -18,8 +18,12 @@ export const DIETARY_LABEL: Record<string, string> = {
   strictly_kosher: 'כשר למהדרין',
 };
 
-type HostDetails =
-  | { bride?: { name?: string }; groom?: { name?: string } }
+export type HostDetails =
+  | {
+      bride?: { name?: string };
+      groom?: { name?: string };
+      child?: { name?: string };
+    }
   | undefined;
 
 type GuestExperience =
@@ -27,12 +31,20 @@ type GuestExperience =
   | null
   | undefined;
 
-export function buildCoupleName(hostDetails: HostDetails, eventTitle: string): string {
+export function buildCoupleName(
+  hostDetails: HostDetails,
+  eventTitle: string,
+  eventType?: string,
+): string {
   const brideName = hostDetails?.bride?.name;
   const groomName = hostDetails?.groom?.name;
-  return brideName && groomName
-    ? `${brideName} & ${groomName}`
-    : (brideName ?? groomName ?? eventTitle);
+  if (brideName && groomName) return `${brideName} & ${groomName}`;
+
+  // Non-couple events (Bar/Bat Mitzva) carry a single celebrant under `child`.
+  const childName = hostDetails?.child?.name;
+  if (eventType === 'bar_mitzva' && childName) return `בר המצווה של ${childName}`;
+
+  return brideName ?? groomName ?? childName ?? eventTitle;
 }
 
 export function buildFormattedDate(eventDate: string): string {


### PR DESCRIPTION
Bar Mitzva events store the celebrant under host_details.child instead of bride/groom, so the landing page hero fell back to the raw event title. buildCoupleName now resolves the child's name and, for bar_mitzva events specifically, renders "בר המצווה של <name>".