### PR TITLE
Plan phone call rounds as schedules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,48 @@ When adding code, preserve the pattern above:
   client component can import.
 - One icon location: `src/components/icons/`.
 
+## Database Migrations
+
+**There is no sandbox project.** The rollout is **local → production**, with nothing in
+between, so local is the only gate. Verify against a fresh local database
+(`npx supabase db reset`, which replays every migration from scratch) before anything
+reaches production. `.env.local` points at the local stack (`127.0.0.1:54321`); the linked
+remote project is `kululu-prod`.
+
+**Apply migrations with `npx supabase db push`, not the Supabase MCP.**
+`mcp__supabase__apply_migration` mints its own version number instead of using the
+migration file's timestamp, so the same migration ends up recorded in production under a
+version that matches no local file. The CLI then treats the local file as unapplied and
+tries to re-run it, which fails on the second pass. Three migrations already drifted this
+way (`add_message_deliveries_update_policy`, `add_message_deliveries_error_code`,
+`call_rounds_owner_visibility`). Use the MCP to *inspect* the database freely; use the CLI
+to *change* it.
+
+Check for drift before pushing - any row with an empty `local` or empty `remote` is drift:
+
+```
+npx supabase migration list --linked
+```
+
+To reconcile a migration that is really applied but recorded under the wrong version, fix
+the bookkeeping rather than re-running the SQL. Confirm the schema actually matches the
+file first, or the repair records something untrue:
+
+```
+npx supabase migration repair --status applied  <local-version...>   # file exists, not recorded
+npx supabase migration repair --status reverted <remote-version...>  # recorded, no file
+```
+
+Both accept several versions in one call, which is the form to use - `migration repair` does
+not reliably exit 0 on success, so chaining calls with `&&` silently drops everything after
+the first one.
+
+Conventions: `YYYYMMDDHHMMSS_snake_case.sql` in `supabase/migrations/`. Hand-written
+migrations use `000000` plus a sequence for same-day ordering, lowercase SQL, and a leading
+`--` comment block explaining *why* the change exists. Destructive or backfilling
+migrations should end with a guard that raises if the data did not land as intended - see
+`20260814000001_link_call_rounds_to_schedules.sql`.
+
 ## Patterns
 
 ### Data Flow

--- a/docs/adr/0001-call-rounds-are-not-schedules.md
+++ b/docs/adr/0001-call-rounds-are-not-schedules.md
@@ -4,7 +4,12 @@ Date: 2026-08-11
 
 ## Status
 
-Accepted
+Superseded by [ADR-0004](0004-call-schedules-are-plans-call-rounds-are-executions.md).
+
+The reasoning below holds for the question it answered: whether an *ad hoc*
+round can be a schedule. ADR-0004 changes that premise - rounds are now planned
+up front - which dissolves objection 3 and solves 1 and 2 rather than avoiding
+them.
 
 ## Context
 

--- a/docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md
+++ b/docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md
@@ -1,0 +1,142 @@
+# 4. Call schedules are plans, call rounds are executions
+
+Date: 2026-08-14
+
+## Status
+
+Accepted
+
+Supersedes [ADR-0001](0001-call-rounds-are-not-schedules.md).
+
+## Context
+
+ADR-0001 asked whether a phone call round should be a `schedules` row and
+answered no. Three months of that answer held up fine, because the question it
+was answering was "can an *ad hoc* round be a schedule". It cannot, and the
+reasons given were sound.
+
+The question has changed. Call rounds are no longer meant to be ad hoc. Every
+event should *plan* its calling the same way it plans messages: a date, a time,
+a target audience, chosen up front, visible to the Owner in the same timeline as
+everything else. The back office then executes a plan that already exists rather
+than inventing work out of nowhere.
+
+That reframing dissolves ADR-0001's third objection outright. It said
+`scheduled_date` "has no honest value for work that is started ad hoc rather
+than planned". The whole point of this change is that the work stops being
+started ad hoc, so the date becomes the most honest column on the row.
+
+The first two objections are real and are solved below rather than waved away.
+
+## Decision
+
+A phone call round is split across the two tables that already exist, along the
+seam between intent and execution.
+
+- **`schedules`** gains a `phone_call` type. That row is the **plan**:
+  `scheduled_date`, `scheduled_time`, `target_status`, and `template_id NULL`.
+- **`call_rounds`** gains `schedule_id` and becomes the **execution record**.
+- **`call_logs`** is untouched.
+
+`schedules.status` keeps one meaning across both kinds: `NULL` is outstanding,
+`'cancelled'` is called off, `'sent'` is dispatched. For a call plan,
+"dispatched" is the moment an admin hits Start. Everything long-lived and
+mutable about a round - outcomes arriving over days, `completed_at` - stays on
+`call_rounds`, which no trigger and no cron touches.
+
+That last point is what makes this work. ADR-0001 assumed the round's days-long
+open state would have to live on the schedule row, and reasoned correctly that
+"done" and "immutable" cannot be the same flag for it. They do not have to be.
+The plan is terminal the moment it executes; the round is what stays open.
+
+### Objection 1: the cron would send a call plan
+
+`processScheduledMessages` selects any row with `status IS NULL` and
+`scheduled_date <= now()`. `schedule_types` gains an `execution_kind` column
+(`'message' | 'phone_call'`, default `'message'`), and the cron filters
+**positively** on `execution_kind = 'message'`.
+
+The filter is positive rather than excluding `phone_call`, so a kind nobody has
+taught the cron about is inert by default instead of being blasted out over
+WhatsApp. This is also why it is a catalog column and not a hardcoded key list:
+`schedule_types` is a table precisely so it can grow, and a key list would make
+every future non-message type a code change in the cron - the permanently
+growing branch ADR-0001 was right to fear.
+
+It is not a `template_id IS NOT NULL` filter either. That would encode
+"templateless implies not-a-message" as folklore, and would silently swallow a
+real bug: a message schedule that lost its template currently surfaces as a
+logged `No template assigned` failure, and would instead vanish forever.
+
+The same column carries one guard inside `sendSchedule`, placed after the parse
+and before the claim. All four send entry points funnel through that engine, so
+ADR-0001's "each is individually solvable with a branch, but together every
+query grows a case" costs exactly one branch in one file.
+
+### Objection 2: `prevent_sent_schedule_mutation` freezes sent rows
+
+The invariant that trigger actually protects is "a message that physically went
+out cannot be retroactively edited". It is guarded on a new
+`schedule_type_is_message()` helper so it keeps protecting exactly that.
+
+A call plan needs to stay mutable at `'sent'` because `deleteCallRound` exists to
+undo a misclicked Start, and a frozen plan with its round deleted would be dead
+work nobody could restart. The invariant that does matter for calls - one round
+per plan - is carried by a unique index on `call_rounds.schedule_id` plus an
+optimistic `status IS NULL` claim on Start, in the database, rather than by a
+blanket freeze.
+
+### Consequences that follow rather than being decided separately
+
+- **The Owner is view-only on call plans**, enforced by two `RESTRICTIVE` RLS
+  policies rather than by UI convention. INSERT is deliberately untouched, so the
+  Owner still picks the date once in the setup wizard; after that the row belongs
+  to the back office. Narrowing the freeze trigger is what makes this necessary:
+  without it, `schedules_update` would let an Owner edit a dispatched plan.
+- **The back office can add and reschedule call plans.** The wizard only renders
+  from the schedules page empty state, so without an admin path an event that
+  already has schedules could never acquire a call plan, and a wrong wizard date
+  would be uncorrectable by anyone.
+- **Every legacy `call_rounds` row is backfilled with the plan it would have
+  had.** A round without a plan therefore does not exist, and the read model has
+  exactly one shape - plan first, round optional - instead of a permanent
+  orphan-round branch on every render.
+- **`round_number` is deprecated.** Ordering now comes from the plan's
+  `scheduled_date`. The column and its history stay; the `NOT NULL` and the
+  `unique (event_id, round_number)` constraint go, which also removes the
+  read-then-insert race two concurrent admins could hit.
+- **`CALL_ROUNDS_NAV_KEY` and `OutreachItem.kind` are deleted.** Both existed only
+  because call rounds had no catalog row. The nav key is now the real
+  `phone_call` key, and the messages/calls grouping becomes derived from
+  `execution_kind` rather than being the hardcoded position of a synthetic key.
+
+## Consequences
+
+**Good.** One table answers "what outreach does this event have", so the
+schedules page stops assembling a union in application code and the nav ordering
+is one sort over one query - the two costs ADR-0001 accepted. Calls inherit
+planning, targeting and the Owner-facing timeline for free. `target_status`
+replaces the hardcoded `rsvp_status = 'pending'` snapshot, so a round can target
+confirmed guests without new code.
+
+**Bad.** The freeze trigger and the cron are both conditional now, where before
+they were unconditional. That is two pieces of load-bearing conditional logic
+that did not exist, and both fail dangerously if the condition is ever inverted -
+hence the positive cron filter and the `coalesce(..., true)` default in
+`schedule_type_is_message`, which both fail toward "treat it as a message" only
+where that is the safe direction.
+
+**A deliberate widening of ADR-0001's visibility rule.** ADR-0001 granted call
+data to the `owner` collaborator role only, not to every collaborator, so a
+`seating_manager` scoped by `collaborator_guest_scope` never sees call data
+outside their scope. `schedules_select` uses `user_has_event_access`, so the
+*plan* row is now visible to every collaborator. This is accepted, not
+overlooked: the plan carries a date, a time and a target status and no guest
+data, and the results - `call_rounds`, `call_logs`, and the column-level revoke
+on `notes` and `called_by` - remain under ADR-0001's narrower policies. If that
+ever stops being acceptable, the fix is a third restrictive policy `for select`.
+
+**If we change our mind.** Going back means dropping `schedule_id`, restoring the
+unconditional trigger and cron, and deleting the `phone_call` plans while keeping
+their rounds. The rounds and their logs are untouched by this change, so the
+execution history survives a reversal intact. The plans are the disposable half.

--- a/messages/en.json
+++ b/messages/en.json
@@ -757,7 +757,8 @@
         "initial_invitation": "Initial Invitation",
         "confirmation": "RSVP Confirmation",
         "event_reminder": "Event Reminder",
-        "post_event": "Thank You"
+        "post_event": "Thank You",
+        "phone_call": "Call Round"
       }
     },
     "quickActions": {
@@ -900,7 +901,8 @@
       "allGuests": "All Guests",
       "confirmedGuests": "Confirmed Guests",
       "pendingGuests": "Pending Guests",
-      "sentTo": "Sent to"
+      "sentTo": "Sent to",
+      "calling": "Calling"
     },
     "messagePreview": {
       "cardTitle": "Message Preview",
@@ -948,6 +950,7 @@
       "step2Description": "Approve the schedules you want to send",
       "invitationPreviewLabel": "Invitation preview",
       "sendDateLabel": "Send date",
+      "callDateLabel": "Call date",
       "timeLabel": "Time",
       "sendDateHelper": "When the invitation goes out to guests",
       "invitationPrivacyNote": "Some couples prefer to send the initial invitation privately - totally up to you. You can always adjust this later.",
@@ -978,7 +981,8 @@
       "initial_invitation": "Initial Invitation",
       "confirmation": "RSVP Confirmation",
       "event_reminder": "Event Reminder",
-      "post_event": "Thank You"
+      "post_event": "Thank You",
+      "phone_call": "Call Round"
     },
     "relativeTime": {
       "justNow": "just now",
@@ -1437,6 +1441,11 @@
     "refresh": "Refresh",
     "startedOn": "Started {date}",
     "completedOn": "Finished {date}",
+    "plan": {
+      "title": "Planned call round",
+      "description": "Our team will phone these guests on this date",
+      "cancelledDescription": "This call round is switched off and will not run"
+    },
     "stats": {
       "confirmed": "Confirmed",
       "declined": "Declined",

--- a/messages/he.json
+++ b/messages/he.json
@@ -758,7 +758,8 @@
         "initial_invitation": "הזמנה ראשונית",
         "confirmation": "אישור הגעה",
         "event_reminder": "תזכורת אירוע",
-        "post_event": "תודה"
+        "post_event": "תודה",
+        "phone_call": "סבב שיחות"
       }
     },
     "quickActions": {
@@ -901,7 +902,8 @@
       "allGuests": "כל האורחים",
       "confirmedGuests": "אורחים שאישרו",
       "pendingGuests": "אורחים ממתינים",
-      "sentTo": "נשלח ל"
+      "sentTo": "נשלח ל",
+      "calling": "מתקשרים אל"
     },
     "messagePreview": {
       "cardTitle": "תצוגה מקדימה",
@@ -949,6 +951,7 @@
       "step2Description": "אשרו את התזמונים שתרצו לשלוח",
       "invitationPreviewLabel": "תצוגה מקדימה של ההזמנה",
       "sendDateLabel": "תאריך שליחה",
+      "callDateLabel": "תאריך השיחות",
       "timeLabel": "שעה",
       "sendDateHelper": "מתי ההזמנה תישלח לאורחים",
       "invitationPrivacyNote": "יש זוגות שמעדיפים לשלוח את ההזמנה הראשונית בצורה פרטית - לגמרי תלוי בכם. אפשר לשנות את זה בכל שלב.",
@@ -979,7 +982,8 @@
       "initial_invitation": "הזמנה ראשונית",
       "confirmation": "אישור הגעה",
       "event_reminder": "תזכורת אירוע",
-      "post_event": "תודה"
+      "post_event": "תודה",
+      "phone_call": "סבב שיחות"
     },
     "relativeTime": {
       "justNow": "זה עתה",
@@ -1440,6 +1444,11 @@
     "refresh": "רענן",
     "startedOn": "התחיל ב-{date}",
     "completedOn": "הסתיים ב-{date}",
+    "plan": {
+      "title": "סבב שיחות מתוכנן",
+      "description": "הצוות שלנו יתקשר לאורחים האלה בתאריך הזה",
+      "cancelledDescription": "סבב השיחות הזה כבוי ולא יתבצע"
+    },
     "stats": {
       "confirmed": "אישרו",
       "declined": "סירבו",

--- a/src/app/(admin)/admin/events/[eventId]/calls/page.tsx
+++ b/src/app/(admin)/admin/events/[eventId]/calls/page.tsx
@@ -1,4 +1,4 @@
-import { getCallRounds } from '@/features/admin/queries/calls';
+import { getCallPlans } from '@/features/admin/queries/calls';
 import { PhoneCallsView } from '@/features/admin/components/phone-calls-view';
 
 export default async function AdminEventCallsPage({
@@ -7,7 +7,7 @@ export default async function AdminEventCallsPage({
   params: Promise<{ eventId: string }>;
 }) {
   const { eventId } = await params;
-  const rounds = await getCallRounds(eventId);
+  const plans = await getCallPlans(eventId);
 
-  return <PhoneCallsView eventId={eventId} initialRounds={rounds} />;
+  return <PhoneCallsView eventId={eventId} initialPlans={plans} />;
 }

--- a/src/features/admin/actions/calls.ts
+++ b/src/features/admin/actions/calls.ts
@@ -5,65 +5,139 @@ import { assertAdmin } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
 import type { CallOutcome } from '../types';
 
+/**
+ * Refreshes both places a call round is visible.
+ *
+ * The Owner's schedules page shows call rounds too, so an admin action that
+ * only revalidated the back office would leave the Owner looking at stale work.
+ * The Owner route is a dynamic segment under a route group, so it is
+ * revalidated by its path pattern with the 'page' type - a literal '/app'
+ * matches no route in this app and quietly does nothing.
+ */
+function revalidateCallSurfaces(eventId: string) {
+  revalidatePath(`/admin/events/${eventId}/calls`);
+  revalidatePath('/[locale]/app/[eventId]/schedules', 'page');
+}
+
 export type StartCallRoundResult = {
   success: boolean;
   message: string;
   roundId?: string;
   count?: number;
-  roundNumber?: number;
 };
 
-export async function startCallRound(eventId: string): Promise<StartCallRoundResult> {
+/**
+ * Executes a planned call round: claims the plan and snapshots the guests it
+ * targets into `call_logs`.
+ *
+ * Takes the plan rather than the event because a round is no longer invented on
+ * the spot - the Owner scheduled it. The claim is an optimistic
+ * `status IS NULL -> 'sent'` update, so two admins hitting Start at once cannot
+ * both win, and the audience comes from the plan's `target_status` instead of
+ * the hardcoded 'pending' this used to assume. See docs/adr/0004.
+ */
+export async function startCallRound(
+  scheduleId: string,
+  eventId: string,
+): Promise<StartCallRoundResult> {
   try {
     const adminId = await assertAdmin();
     const supabase = createServiceClient();
 
-    const { data: existingRounds } = await supabase
-      .from('call_rounds')
-      .select('round_number')
-      .eq('event_id', eventId)
-      .order('round_number', { ascending: false })
-      .limit(1);
+    const { data: plan, error: planError } = await supabase
+      .from('schedules')
+      .select('id, event_id, target_status, status, schedule_types!inner (execution_kind)')
+      .eq('id', scheduleId)
+      .single();
 
-    const nextRoundNumber = (existingRounds?.[0]?.round_number ?? 0) + 1;
+    if (planError || !plan) {
+      return { success: false, message: 'Call plan not found' };
+    }
+
+    const executionKind = (
+      Array.isArray(plan.schedule_types) ? plan.schedule_types[0] : plan.schedule_types
+    )?.execution_kind;
+
+    if (executionKind !== 'phone_call') {
+      return { success: false, message: 'That schedule is not a call round' };
+    }
+
+    if (plan.status === 'cancelled') {
+      return { success: false, message: 'This call round was cancelled' };
+    }
+
+    // Claim the plan before doing any work. A lost race means another admin is
+    // already running this round, which is a no-op rather than an error.
+    //
+    // sent_at is set here rather than left to the auto_set_schedule_sent_at
+    // trigger: that trigger tests `OLD.status != 'sent'`, which is NULL - not
+    // true - when the old status is NULL, so it never fires on exactly this
+    // transition. sendSchedule passes sent_at explicitly for the same reason.
+    const { data: claimed, error: claimError } = await supabase
+      .from('schedules')
+      .update({ status: 'sent', sent_at: new Date().toISOString() })
+      .eq('id', scheduleId)
+      .is('status', null)
+      .select('id')
+      .single();
+
+    if (claimError || !claimed) {
+      return { success: false, message: 'This round has already been started' };
+    }
+
+    // Undo the claim so Start works again once whatever went wrong is fixed.
+    const releasePlan = async () => {
+      await supabase
+        .from('schedules')
+        .update({ status: null, sent_at: null })
+        .eq('id', scheduleId);
+    };
 
     const { data: round, error: roundError } = await supabase
       .from('call_rounds')
-      .insert({ event_id: eventId, round_number: nextRoundNumber, started_by: adminId })
+      .insert({
+        event_id: eventId,
+        schedule_id: scheduleId,
+        // Deprecated - the plan's date orders and names the round now.
+        round_number: null,
+        started_by: adminId,
+      })
       .select('id')
       .single();
 
     if (roundError || !round) {
+      await releasePlan();
       return { success: false, message: 'Failed to create call round' };
     }
 
-    const { data: pendingGuests } = await supabase
-      .from('guests')
-      .select('id')
-      .eq('event_id', eventId)
-      .eq('rsvp_status', 'pending');
+    let guestsQuery = supabase.from('guests').select('id').eq('event_id', eventId);
+    if (plan.target_status) {
+      guestsQuery = guestsQuery.eq('rsvp_status', plan.target_status);
+    }
+    const { data: targetGuests } = await guestsQuery;
 
-    if (!pendingGuests || pendingGuests.length === 0) {
+    if (!targetGuests || targetGuests.length === 0) {
       await supabase.from('call_rounds').delete().eq('id', round.id);
-      return { success: false, message: 'No pending guests to call' };
+      await releasePlan();
+      return { success: false, message: 'No guests to call for this round' };
     }
 
-    const logs = pendingGuests.map((g) => ({ round_id: round.id, guest_id: g.id }));
+    const logs = targetGuests.map((g) => ({ round_id: round.id, guest_id: g.id }));
     const { error: logsError } = await supabase.from('call_logs').insert(logs);
 
     if (logsError) {
       await supabase.from('call_rounds').delete().eq('id', round.id);
+      await releasePlan();
       return { success: false, message: 'Failed to snapshot guests' };
     }
 
-    revalidatePath(`/admin/events/${eventId}/calls`);
+    revalidateCallSurfaces(eventId);
 
     return {
       success: true,
-      message: `Round ${nextRoundNumber} started with ${pendingGuests.length} guest${pendingGuests.length !== 1 ? 's' : ''}`,
+      message: `Round started with ${targetGuests.length} guest${targetGuests.length !== 1 ? 's' : ''}`,
       roundId: round.id,
-      count: pendingGuests.length,
-      roundNumber: nextRoundNumber,
+      count: targetGuests.length,
     };
   } catch {
     return { success: false, message: 'Failed to start call round' };
@@ -99,7 +173,7 @@ export async function finishCallRound(
       return { success: false, message: 'Failed to finish round' };
     }
 
-    revalidatePath(`/admin/events/${eventId}/calls`);
+    revalidateCallSurfaces(eventId);
     return { success: true, message: 'Round finished' };
   } catch {
     return { success: false, message: 'Failed to finish round' };
@@ -123,7 +197,7 @@ export async function reopenCallRound(
       return { success: false, message: 'Failed to reopen round' };
     }
 
-    revalidatePath(`/admin/events/${eventId}/calls`);
+    revalidateCallSurfaces(eventId);
     return { success: true, message: 'Round reopened' };
   } catch {
     return { success: false, message: 'Failed to reopen round' };
@@ -160,13 +234,30 @@ export async function deleteCallRound(roundId: string, eventId: string): Promise
       };
     }
 
+    // Read the plan before the round goes, so the claim can be released after.
+    const { data: round } = await supabase
+      .from('call_rounds')
+      .select('schedule_id')
+      .eq('id', roundId)
+      .single();
+
     const { error } = await supabase.from('call_rounds').delete().eq('id', roundId);
 
     if (error) {
       return { success: false, message: 'Failed to delete round' };
     }
 
-    revalidatePath(`/admin/events/${eventId}/calls`);
+    // Undoing the round undoes the Start that created it, so the plan goes back
+    // to planned and can be started again. Leaving it 'sent' with no round
+    // would be dead work nobody could pick up.
+    if (round?.schedule_id) {
+      await supabase
+        .from('schedules')
+        .update({ status: null, sent_at: null })
+        .eq('id', round.schedule_id);
+    }
+
+    revalidateCallSurfaces(eventId);
     return { success: true, message: 'Round deleted' };
   } catch {
     return { success: false, message: 'Failed to delete round' };
@@ -238,10 +329,134 @@ export async function recordCallOutcome({
       }
     }
 
-    revalidatePath(`/admin/events/${eventId}/calls`);
+    revalidateCallSurfaces(eventId);
 
     return { success: true, message: 'Outcome saved' };
   } catch {
     return { success: false, message: 'Failed to record outcome' };
+  }
+}
+
+export type CallPlanMutationResult = {
+  success: boolean;
+  message: string;
+  scheduleId?: string;
+};
+
+/**
+ * Plans a new call round on an event.
+ *
+ * The setup wizard is the Owner's only creation path and it renders only from
+ * the schedules page empty state, so an event that already has schedules could
+ * never acquire a call plan without this. It is also the path used to add call
+ * rounds to events that predate the feature.
+ */
+export async function createCallPlan(
+  eventId: string,
+  {
+    scheduledDate,
+    scheduledTime,
+    targetStatus,
+  }: {
+    scheduledDate: string;
+    scheduledTime: string;
+    targetStatus: 'pending' | 'confirmed';
+  },
+): Promise<CallPlanMutationResult> {
+  try {
+    await assertAdmin();
+    const supabase = createServiceClient();
+
+    const { data: type, error: typeError } = await supabase
+      .from('schedule_types')
+      .select('id')
+      .eq('key', 'phone_call')
+      .single();
+
+    if (typeError || !type) {
+      return { success: false, message: 'Call round schedule type is missing' };
+    }
+
+    const { data: plan, error } = await supabase
+      .from('schedules')
+      .insert({
+        event_id: eventId,
+        schedule_type_id: type.id,
+        // A call round has nothing to send.
+        template_id: null,
+        scheduled_date: scheduledDate,
+        scheduled_time: scheduledTime,
+        target_status: targetStatus,
+        status: null,
+      })
+      .select('id')
+      .single();
+
+    if (error || !plan) {
+      return { success: false, message: 'Failed to plan call round' };
+    }
+
+    revalidateCallSurfaces(eventId);
+    return { success: true, message: 'Call round planned', scheduleId: plan.id };
+  } catch {
+    return { success: false, message: 'Failed to plan call round' };
+  }
+}
+
+/**
+ * Moves a planned call round to a different date.
+ *
+ * Only the back office can do this - the Owner is blocked by a restrictive RLS
+ * policy - so a date picked wrongly in the wizard is still correctable. Refuses
+ * once the round has started, because the date then describes something that
+ * already happened.
+ */
+export async function rescheduleCallPlan(
+  scheduleId: string,
+  eventId: string,
+  { scheduledDate, scheduledTime }: { scheduledDate: string; scheduledTime: string },
+): Promise<CallPlanMutationResult> {
+  try {
+    await assertAdmin();
+    const supabase = createServiceClient();
+
+    const { data: plan, error: planError } = await supabase
+      .from('schedules')
+      .select('id, status, schedule_types!inner (execution_kind)')
+      .eq('id', scheduleId)
+      .single();
+
+    if (planError || !plan) {
+      return { success: false, message: 'Call plan not found' };
+    }
+
+    const executionKind = (
+      Array.isArray(plan.schedule_types) ? plan.schedule_types[0] : plan.schedule_types
+    )?.execution_kind;
+
+    if (executionKind !== 'phone_call') {
+      return { success: false, message: 'That schedule is not a call round' };
+    }
+
+    if (plan.status === 'sent') {
+      return {
+        success: false,
+        message: 'This round has already started - delete it to plan a new date',
+      };
+    }
+
+    const { error } = await supabase
+      .from('schedules')
+      .update({ scheduled_date: scheduledDate, scheduled_time: scheduledTime })
+      .eq('id', scheduleId);
+
+    if (error) {
+      return { success: false, message: 'Failed to reschedule call round' };
+    }
+
+    revalidateCallSurfaces(eventId);
+    return { success: true, message: 'Call round rescheduled', scheduleId };
+  } catch {
+    return { success: false, message: 'Failed to reschedule call round' };
   }
 }

--- a/src/features/admin/components/call-plan-dialog.tsx
+++ b/src/features/admin/components/call-plan-dialog.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export type CallPlanFormValues = {
+  /** ISO 8601, combining the chosen date and time in local terms */
+  scheduledDate: string;
+  /** HH:MM */
+  scheduledTime: string;
+  targetStatus: 'pending' | 'confirmed';
+};
+
+interface CallPlanDialogProps {
+  open: boolean;
+  mode: 'create' | 'reschedule';
+  initialDate?: string;
+  initialTime?: string;
+  initialTarget?: 'pending' | 'confirmed';
+  onOpenChange: (open: boolean) => void;
+  onSave: (values: CallPlanFormValues) => void | Promise<void>;
+}
+
+function todayInput(): string {
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, '0');
+  const day = `${now.getDate()}`.padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+/**
+ * Plans a call round, or moves one that has not started yet.
+ *
+ * The back office is the only place a call round can be created after the setup
+ * wizard has run, and the only place one can be rescheduled at all - the Owner
+ * is blocked by a restrictive RLS policy. See docs/adr/0004.
+ */
+export function CallPlanDialog({
+  open,
+  mode,
+  initialDate,
+  initialTime,
+  initialTarget,
+  onOpenChange,
+  onSave,
+}: CallPlanDialogProps) {
+  const [date, setDate] = useState(initialDate ?? todayInput());
+  const [time, setTime] = useState(initialTime ?? '10:00');
+  const [target, setTarget] = useState<'pending' | 'confirmed'>(initialTarget ?? 'pending');
+  const [saving, setSaving] = useState(false);
+
+  // Reset to whatever the caller is editing each time the dialog opens, so
+  // reopening on a different plan never shows the previous one's values.
+  useEffect(() => {
+    if (!open) return;
+    setDate(initialDate ?? todayInput());
+    setTime(initialTime ?? '10:00');
+    setTarget(initialTarget ?? 'pending');
+  }, [open, initialDate, initialTime, initialTarget]);
+
+  const handleSave = async () => {
+    if (!date) return;
+    const [hours, minutes] = time.split(':').map(Number);
+    // Built from local components: a date input yields local midnight, and
+    // setUTCHours would shift it a day back in positive-offset zones.
+    const combined = new Date(`${date}T00:00:00`);
+    combined.setHours(hours, minutes, 0, 0);
+
+    setSaving(true);
+    try {
+      await onSave({
+        scheduledDate: combined.toISOString(),
+        scheduledTime: time,
+        targetStatus: target,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent dir="ltr" className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'reschedule' ? 'Reschedule call round' : 'Add call round'}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === 'reschedule'
+              ? 'Move this round to a different date. Only rounds that have not started can be moved'
+              : 'Plans a round on the owner schedule. Starting it later loads the guests'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="call-plan-date">Date</Label>
+              <Input
+                id="call-plan-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="call-plan-time">Time</Label>
+              <Input
+                id="call-plan-time"
+                type="time"
+                value={time}
+                onChange={(e) => setTime(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {/* The audience is fixed once the round exists, because it decides
+              which guests get snapshotted at Start. */}
+          {mode === 'create' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="call-plan-target">Who gets called</Label>
+              <Select
+                value={target}
+                onValueChange={(v) => setTarget(v as 'pending' | 'confirmed')}
+              >
+                <SelectTrigger id="call-plan-target" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pending">Pending guests</SelectItem>
+                  <SelectItem value="confirmed">Confirmed guests</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !date}>
+            {saving ? 'Saving…' : mode === 'reschedule' ? 'Reschedule' : 'Add round'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/components/manual-send-card.tsx
+++ b/src/features/admin/components/manual-send-card.tsx
@@ -21,7 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import { SCHEDULE_TYPE_LABELS, type ScheduleApp } from '@/features/schedules';
+import { SCHEDULE_TYPE_LABELS, isMessageSchedule, type ScheduleApp } from '@/features/schedules';
 import { getGuestsForManualSend } from '../queries/event-detail';
 import { sendManualMessages } from '../actions/send-manual';
 import type { GuestWithDeliveryStatus } from '../queries/event-detail';
@@ -56,6 +56,10 @@ export function ManualSendCard({
   eventId: string;
   schedules: ScheduleApp[];
 }) {
+  // Call rounds are schedules but not sends - they are executed from the calls
+  // tab, and the send engine refuses them outright.
+  const sendableSchedules = schedules.filter(isMessageSchedule);
+
   const [open, setOpen] = useState(false);
   const [selectedScheduleId, setSelectedScheduleId] = useState<string>('');
   const [guests, setGuests] = useState<GuestWithDeliveryStatus[]>([]);
@@ -149,7 +153,7 @@ export function ManualSendCard({
                 <SelectValue placeholder="Select a schedule…" />
               </SelectTrigger>
               <SelectContent>
-                {schedules.map((s) => (
+                {sendableSchedules.map((s) => (
                   <SelectItem key={s.id} value={s.id}>
                     <ScheduleLabel schedule={s} />
                   </SelectItem>

--- a/src/features/admin/components/phone-calls-view.tsx
+++ b/src/features/admin/components/phone-calls-view.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
-import { IconChevronLeft, IconChevronRight, IconLoader2, IconPhone, IconSearch, IconTrash, IconCheck } from '@tabler/icons-react';
+import { IconCalendarEvent, IconChevronLeft, IconChevronRight, IconLoader2, IconPhone, IconPlus, IconSearch, IconTrash, IconCheck } from '@tabler/icons-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Toggle } from '@/components/ui/toggle';
@@ -24,12 +24,28 @@ import {
   deleteCallRound,
   finishCallRound,
   reopenCallRound,
+  createCallPlan,
+  rescheduleCallPlan,
 } from '../actions/calls';
-import { getCallRounds, getRoundCallLogs } from '../queries/calls';
+import { getCallPlans, getRoundCallLogs } from '../queries/calls';
 import { RoundGuestRow } from './round-guest-row';
-import type { CallRoundSummary, CallLogWithGuest, CallOutcome } from '../types';
+import { CallPlanDialog } from './call-plan-dialog';
+import type {
+  CallPlanWithRound,
+  CallRoundSummary,
+  CallLogWithGuest,
+  CallOutcome,
+} from '../types';
 
 type SummaryFilterKey = 'awaiting' | 'confirmed' | 'declined' | 'noAnswer';
+
+/** yyyy-mm-dd for a date input, in local time */
+function toDateInput(iso: string): string {
+  const d = new Date(iso);
+  const month = `${d.getMonth() + 1}`.padStart(2, '0');
+  const day = `${d.getDate()}`.padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+}
 
 const SUMMARY_STATS: {
   key: keyof CallRoundSummary;
@@ -44,13 +60,21 @@ const SUMMARY_STATS: {
 
 interface PhoneCallsViewProps {
   eventId: string;
-  initialRounds: CallRoundSummary[];
+  initialPlans: CallPlanWithRound[];
 }
 
-export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) {
-  const [rounds, setRounds] = useState<CallRoundSummary[]>(initialRounds);
-  const [selectedRoundId, setSelectedRoundId] = useState<string | null>(
-    initialRounds[0]?.id ?? null,
+/**
+ * The back office's calling console.
+ *
+ * Works in *plans* rather than rounds: the Owner schedules call rounds like any
+ * other outreach, and this executes them. A plan with no round yet is the
+ * normal starting state, so the selector shows planned work as well as work in
+ * progress. See docs/adr/0004.
+ */
+export function PhoneCallsView({ eventId, initialPlans }: PhoneCallsViewProps) {
+  const [plans, setPlans] = useState<CallPlanWithRound[]>(initialPlans);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(
+    initialPlans[0]?.scheduleId ?? null,
   );
   const [logs, setLogs] = useState<CallLogWithGuest[]>([]);
   const [loadingLogs, setLoadingLogs] = useState(false);
@@ -58,6 +82,9 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
   const [deletingRoundId, setDeletingRoundId] = useState<string | null>(null);
   const [togglingRoundId, setTogglingRoundId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [planDialog, setPlanDialog] = useState<
+    { mode: 'create' } | { mode: 'reschedule'; plan: CallPlanWithRound } | null
+  >(null);
   const [activeFilter, setActiveFilter] = useState<SummaryFilterKey | null>(null);
   const [search, setSearch] = useState('');
   const [pageIndex, setPageIndex] = useState(0);
@@ -66,20 +93,29 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
   const ROW_HEIGHT = { sm: 51, md: 59, lg: 67 } as const;
   const { pageSize } = useDynamicPageSize({ containerRef: tableContainerRef, rowHeight: ROW_HEIGHT[fontSize] });
 
+  const selectedPlan = plans.find((p) => p.scheduleId === selectedScheduleId);
+  const selectedRound = selectedPlan?.round ?? null;
+  const selectedRoundId = selectedRound?.id ?? null;
+
   useEffect(() => {
-    if (!selectedRoundId) return;
     setActiveFilter(null);
     setSearch('');
     setPageIndex(0);
+    // A plan with no round has nothing to load - the guests are snapshotted at
+    // Start, so before that there is no roster to show.
+    if (!selectedRoundId) {
+      setLogs([]);
+      return;
+    }
     setLoadingLogs(true);
     getRoundCallLogs(selectedRoundId)
       .then(setLogs)
       .finally(() => setLoadingLogs(false));
   }, [selectedRoundId]);
 
-  async function handleStartRound() {
+  async function handleStartRound(plan: CallPlanWithRound) {
     startTransition(async () => {
-      const promise = startCallRound(eventId).then((result) => {
+      const promise = startCallRound(plan.scheduleId, eventId).then((result) => {
         if (!result.success) throw new Error(result.message);
         return result;
       });
@@ -87,9 +123,8 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
       toast.promise(promise, {
         loading: 'Starting round…',
         success: async (data) => {
-          const updated = await getCallRounds(eventId);
-          setRounds(updated);
-          if (data.roundId) setSelectedRoundId(data.roundId);
+          setPlans(await getCallPlans(eventId));
+          setSelectedScheduleId(plan.scheduleId);
           return data.message;
         },
         error: (err) => (err instanceof Error ? err.message : 'Failed to start round'),
@@ -97,6 +132,39 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
 
       await promise.catch(() => {});
     });
+  }
+
+  async function handleSavePlan(values: {
+    scheduledDate: string;
+    scheduledTime: string;
+    targetStatus: 'pending' | 'confirmed';
+  }) {
+    const editing = planDialog?.mode === 'reschedule' ? planDialog.plan : null;
+
+    const promise = (
+      editing
+        ? rescheduleCallPlan(editing.scheduleId, eventId, {
+            scheduledDate: values.scheduledDate,
+            scheduledTime: values.scheduledTime,
+          })
+        : createCallPlan(eventId, values)
+    ).then((result) => {
+      if (!result.success) throw new Error(result.message);
+      return result;
+    });
+
+    toast.promise(promise, {
+      loading: editing ? 'Rescheduling…' : 'Planning round…',
+      success: async (data) => {
+        setPlans(await getCallPlans(eventId));
+        if (data.scheduleId) setSelectedScheduleId(data.scheduleId);
+        return data.message;
+      },
+      error: (err) => (err instanceof Error ? err.message : 'Failed to save call round'),
+    });
+
+    await promise.catch(() => {});
+    setPlanDialog(null);
   }
 
   // Finishing is what the Owner sees as a green dot on their schedules page,
@@ -115,7 +183,7 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
     toast.promise(promise, {
       loading: isCompleted ? 'Reopening round…' : 'Finishing round…',
       success: async (data) => {
-        setRounds(await getCallRounds(eventId));
+        setPlans(await getCallPlans(eventId));
         return data.message;
       },
       error: (err) => (err instanceof Error ? err.message : 'Failed to update round'),
@@ -139,12 +207,10 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
     toast.promise(promise, {
       loading: 'Deleting round…',
       success: async () => {
-        const updated = await getCallRounds(eventId);
-        setRounds(updated);
-        if (selectedRoundId === roundId) {
-          setSelectedRoundId(updated[0]?.id ?? null);
-          setLogs([]);
-        }
+        // The plan survives the round and goes back to planned, so selection
+        // stays where it is rather than jumping to another round.
+        setPlans(await getCallPlans(eventId));
+        setLogs([]);
         return 'Round deleted';
       },
       error: (err) => (err instanceof Error ? err.message : 'Failed to delete round'),
@@ -156,11 +222,8 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
 
   async function handleOutcomeChange(logId: string, outcome: CallOutcome) {
     setLogs((prev) => prev.map((l) => (l.id === logId ? { ...l, outcome } : l)));
-    const updated = await getCallRounds(eventId);
-    setRounds(updated);
+    setPlans(await getCallPlans(eventId));
   }
-
-  const selectedRound = rounds.find((r) => r.id === selectedRoundId);
 
   const sortedLogs = [...logs].sort((a, b) => {
     if (!a.outcome && b.outcome) return -1;
@@ -203,35 +266,39 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
 
   return (
     <div className="space-y-4">
-      {/* Round selector */}
+      {/* Plan selector */}
       <div className="flex items-center justify-between gap-3">
         <div className="flex flex-wrap items-center gap-1 flex-1">
-          {rounds.map((round) => {
-            const isSelected = selectedRoundId === round.id;
-            const isDeleting = deletingRoundId === round.id;
-            const isComplete = round.status === 'completed';
+          {plans.map((plan) => {
+            const isSelected = selectedScheduleId === plan.scheduleId;
+            const round = plan.round;
+            const isDeleting = round ? deletingRoundId === round.id : false;
+            const isComplete = round?.status === 'completed';
             // Once an outcome is recorded the round is history the Owner can
             // already see - it can be finished, but not made to disappear.
-            const hasOutcomes = round.total - round.awaiting > 0;
+            const hasOutcomes = round ? round.total - round.awaiting > 0 : false;
             return (
-              <div key={round.id} className="group relative">
+              <div key={plan.scheduleId} className="group relative">
                 <button
-                  onClick={() => setSelectedRoundId(round.id)}
+                  onClick={() => setSelectedScheduleId(plan.scheduleId)}
                   className={cn(
                     'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
                     isSelected
                       ? 'bg-foreground text-background font-medium'
                       : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                    plan.cancelled && 'line-through opacity-60',
                   )}
                 >
-                  <span>Round {round.roundNumber}</span>
+                  <span>Round {plan.planNumber}</span>
                   <span
                     className={cn(
                       'text-xs tabular-nums',
                       isSelected ? 'text-background/50' : 'text-muted-foreground/50',
                     )}
                   >
-                    {round.awaiting}/{round.total}
+                    {round
+                      ? `${round.awaiting}/${round.total}`
+                      : new Date(plan.scheduledDate).toLocaleDateString()}
                   </span>
                   {isComplete && (
                     <IconCheck
@@ -242,7 +309,7 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
                     />
                   )}
                 </button>
-                {!hasOutcomes && (
+                {round && !hasOutcomes && (
                 <button
                   onClick={() => setConfirmDeleteId(round.id)}
                   disabled={isDeleting}
@@ -276,23 +343,55 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
               {selectedRound.status === 'completed' ? 'Reopen round' : 'Finish round'}
             </Button>
           )}
-          <Button size="sm" variant="outline" onClick={handleStartRound} disabled={isStarting}>
-            {isStarting ? (
-              <IconLoader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <IconPhone className="mr-1.5 h-3.5 w-3.5" />
-            )}
-            New round
+          {selectedPlan && !selectedRound && !selectedPlan.cancelled && (
+            <>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setPlanDialog({ mode: 'reschedule', plan: selectedPlan })}
+              >
+                <IconCalendarEvent className="mr-1.5 h-3.5 w-3.5" />
+                Reschedule
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => handleStartRound(selectedPlan)}
+                disabled={isStarting}
+              >
+                {isStarting ? (
+                  <IconLoader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <IconPhone className="mr-1.5 h-3.5 w-3.5" />
+                )}
+                Start round
+              </Button>
+            </>
+          )}
+          <Button size="sm" variant="outline" onClick={() => setPlanDialog({ mode: 'create' })}>
+            <IconPlus className="mr-1.5 h-3.5 w-3.5" />
+            Add call round
           </Button>
         </div>
       </div>
 
-      {rounds.length === 0 ? (
+      {plans.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-xl border border-dashed py-16 text-center">
           <IconPhone className="mb-3 h-8 w-8 text-muted-foreground" />
-          <p className="text-sm font-medium">No call rounds yet</p>
+          <p className="text-sm font-medium">No call rounds planned</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Start a round to load pending guests and begin tracking calls
+            Add a call round to schedule one, then start it to load the guests
+          </p>
+        </div>
+      ) : !selectedRound ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed py-16 text-center">
+          <IconPhone className="mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">
+            {selectedPlan?.cancelled ? 'This round was cancelled' : 'Not started yet'}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {selectedPlan?.cancelled
+              ? 'The owner switched this round off in their schedule'
+              : `Planned for ${selectedPlan ? new Date(selectedPlan.scheduledDate).toLocaleDateString() : ''} - starting it loads the ${selectedPlan?.targetStatus ?? 'matching'} guests`}
           </p>
         </div>
       ) : (
@@ -454,6 +553,30 @@ export function PhoneCallsView({ eventId, initialRounds }: PhoneCallsViewProps) 
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <CallPlanDialog
+        open={!!planDialog}
+        mode={planDialog?.mode ?? 'create'}
+        initialDate={
+          planDialog?.mode === 'reschedule'
+            ? toDateInput(planDialog.plan.scheduledDate)
+            : undefined
+        }
+        initialTime={
+          planDialog?.mode === 'reschedule'
+            ? (planDialog.plan.scheduledTime?.slice(0, 5) ?? '10:00')
+            : undefined
+        }
+        initialTarget={
+          planDialog?.mode === 'reschedule'
+            ? (planDialog.plan.targetStatus ?? 'pending')
+            : undefined
+        }
+        onOpenChange={(open) => {
+          if (!open) setPlanDialog(null);
+        }}
+        onSave={handleSavePlan}
+      />
     </div>
   );
 }

--- a/src/features/admin/components/trigger-schedule-card.tsx
+++ b/src/features/admin/components/trigger-schedule-card.tsx
@@ -18,7 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { SCHEDULE_TYPE_LABELS, type ScheduleApp } from '@/features/schedules';
+import { SCHEDULE_TYPE_LABELS, isMessageSchedule, type ScheduleApp } from '@/features/schedules';
 import { getGuestsForManualSend } from '../queries/event-detail';
 import type { GuestWithDeliveryStatus } from '../queries/event-detail';
 import { triggerScheduleAdmin } from '../actions/trigger-schedule';
@@ -49,8 +49,10 @@ export function TriggerScheduleCard({
   eventId: string;
   schedules: ScheduleApp[];
 }) {
+  // Call rounds are schedules but not sends - they are executed from the calls
+  // tab, and the send engine refuses them outright.
   const unsentSchedules = schedules.filter(
-    (s) => s.status !== 'sent' && s.status !== 'cancelled',
+    (s) => isMessageSchedule(s) && s.status !== 'sent' && s.status !== 'cancelled',
   );
 
   const [open, setOpen] = useState(false);

--- a/src/features/admin/queries/calls.ts
+++ b/src/features/admin/queries/calls.ts
@@ -2,26 +2,41 @@
 
 import { assertAdmin } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
-import type { CallRoundSummary, CallLogWithGuest, CallOutcome } from '../types';
+import type { CallPlanWithRound, CallLogWithGuest, CallOutcome } from '../types';
 
-export async function getCallRounds(eventId: string): Promise<CallRoundSummary[]> {
+/**
+ * The event's planned call rounds, each with the round executing it if one has
+ * been started.
+ *
+ * Driven by `schedules` rather than `call_rounds`: a plan exists before anyone
+ * picks up a phone, and the back office needs to see the ones nobody has
+ * started yet. Ordered by the planned date, which is also what numbers them -
+ * `round_number` is deprecated and null on anything created after 2026-08-14.
+ */
+export async function getCallPlans(eventId: string): Promise<CallPlanWithRound[]> {
   await assertAdmin();
   const supabase = createServiceClient();
 
-  const { data: rounds, error } = await supabase
-    .from('call_rounds')
-    .select('id, round_number, created_at, completed_at')
+  const { data: plans, error } = await supabase
+    .from('schedules')
+    .select(
+      `id, scheduled_date, scheduled_time, target_status, status,
+       schedule_types!inner (key, execution_kind),
+       call_rounds (id, round_number, created_at, completed_at)`,
+    )
     .eq('event_id', eventId)
-    .order('round_number', { ascending: false });
+    .eq('schedule_types.execution_kind', 'phone_call')
+    .order('scheduled_date', { ascending: true });
 
-  if (error || !rounds || rounds.length === 0) return [];
+  if (error || !plans || plans.length === 0) return [];
 
-  const roundIds = rounds.map((r) => r.id);
+  const roundIds = plans
+    .flatMap((p) => (p.call_rounds ?? []) as { id: string }[])
+    .map((r) => r.id);
 
-  const { data: logs } = await supabase
-    .from('call_logs')
-    .select('round_id, outcome')
-    .in('round_id', roundIds);
+  const { data: logs } = roundIds.length
+    ? await supabase.from('call_logs').select('round_id, outcome').in('round_id', roundIds)
+    : { data: [] };
 
   const logsByRound = new Map<string, { outcome: string | null }[]>();
   for (const log of logs ?? []) {
@@ -30,25 +45,33 @@ export async function getCallRounds(eventId: string): Promise<CallRoundSummary[]
     logsByRound.set(log.round_id, arr);
   }
 
-  return rounds.map((round) => {
-    const roundLogs = logsByRound.get(round.id) ?? [];
-    const total = roundLogs.length;
-    const awaiting = roundLogs.filter((l) => !l.outcome).length;
-    const confirmed = roundLogs.filter((l) => l.outcome === 'confirmed').length;
-    const declined = roundLogs.filter((l) => l.outcome === 'declined').length;
-    const noAnswer = roundLogs.filter((l) => l.outcome === 'no_answer').length;
+  return plans.map((plan, index) => {
+    // A unique index on call_rounds.schedule_id caps this at one.
+    const rawRound = ((plan.call_rounds ?? []) as Record<string, unknown>[])[0];
+    const roundLogs = rawRound ? (logsByRound.get(rawRound.id as string) ?? []) : [];
 
     return {
-      id: round.id,
-      roundNumber: round.round_number,
-      createdAt: round.created_at,
-      completedAt: round.completed_at ?? null,
-      status: round.completed_at ? ('completed' as const) : ('in_progress' as const),
-      total,
-      awaiting,
-      confirmed,
-      declined,
-      noAnswer,
+      scheduleId: plan.id,
+      planNumber: index + 1,
+      scheduledDate: plan.scheduled_date,
+      scheduledTime: plan.scheduled_time ?? null,
+      targetStatus: (plan.target_status ?? null) as 'pending' | 'confirmed' | null,
+      cancelled: plan.status === 'cancelled',
+      round: rawRound
+        ? {
+            id: rawRound.id as string,
+            scheduleId: plan.id,
+            roundNumber: (rawRound.round_number ?? null) as number | null,
+            createdAt: rawRound.created_at as string,
+            completedAt: (rawRound.completed_at ?? null) as string | null,
+            status: rawRound.completed_at ? ('completed' as const) : ('in_progress' as const),
+            total: roundLogs.length,
+            awaiting: roundLogs.filter((l) => !l.outcome).length,
+            confirmed: roundLogs.filter((l) => l.outcome === 'confirmed').length,
+            declined: roundLogs.filter((l) => l.outcome === 'declined').length,
+            noAnswer: roundLogs.filter((l) => l.outcome === 'no_answer').length,
+          }
+        : null,
     };
   });
 }

--- a/src/features/admin/types.ts
+++ b/src/features/admin/types.ts
@@ -2,7 +2,26 @@
 // domain owner, and the Owner-facing schedules page depends on these too.
 export type { CallOutcome, CallRoundSummary } from '@/features/calls';
 
-import type { CallOutcome } from '@/features/calls';
+import type { CallOutcome, CallRoundSummary } from '@/features/calls';
+
+/**
+ * A planned phone_call schedule together with the round executing it, if one
+ * has been started. This is the unit the back office works in: the plan is what
+ * the Owner scheduled, the round is what the calling team has done about it.
+ */
+export type CallPlanWithRound = {
+  /** The phone_call schedules row - the plan */
+  scheduleId: string;
+  /** Positional label within the event's call plans, 1-based */
+  planNumber: number;
+  scheduledDate: string;
+  scheduledTime: string | null;
+  targetStatus: 'pending' | 'confirmed' | null;
+  /** True when the plan was switched off rather than started */
+  cancelled: boolean;
+  /** Null until an admin starts the round */
+  round: CallRoundSummary | null;
+};
 
 // Admin-only: carries the operator's working data (phone, notes, seating
 // context) that the Owner is never shown.

--- a/src/features/calls/components/call-plan-card.tsx
+++ b/src/features/calls/components/call-plan-card.tsx
@@ -1,0 +1,101 @@
+import { getTranslations } from 'next-intl/server';
+import { IconCalendarEvent, IconClock, IconPhone } from '@tabler/icons-react';
+
+import { cn } from '@/lib/utils';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { TargetAudienceCard } from '@/features/schedules/components/target-audience-card';
+
+interface CallPlanCardProps {
+  /** The planned call date, ISO 8601 */
+  scheduledDate: string;
+  /** HH:MM, or null when the plan predates the time column */
+  scheduledTime: string | null;
+  targetStatus?: 'pending' | 'confirmed' | null;
+  /** The event date, used to show how far ahead the calling sits */
+  eventDate: string;
+  cancelled: boolean;
+}
+
+function dayOffset(scheduledDate: string, eventDate: string): number {
+  const event = new Date(eventDate);
+  event.setHours(0, 0, 0, 0);
+  const planned = new Date(scheduledDate);
+  planned.setHours(0, 0, 0, 0);
+  return Math.round((planned.getTime() - event.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * A phone call round that has been planned but not yet started.
+ *
+ * Read-only by design: the Owner picks the date once in the setup wizard and
+ * the plan then belongs to the back office, which is enforced by a restrictive
+ * RLS policy on `schedules` rather than by hiding controls. This is deliberately
+ * a separate component from `ScheduleTabContent` - the cards that one composes
+ * exist to be editable and carry the mutation actions with them, so a
+ * purpose-built card is smaller than threading `readOnly` through all of them.
+ * See docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md.
+ */
+export async function CallPlanCard({
+  scheduledDate,
+  scheduledTime,
+  targetStatus,
+  eventDate,
+  cancelled,
+}: CallPlanCardProps) {
+  const t = await getTranslations('calls.plan');
+  const tSchedules = await getTranslations('schedules');
+
+  const offset = dayOffset(scheduledDate, eventDate);
+  const offsetLabel =
+    offset === 0
+      ? tSchedules('dayOffset.onEventDay')
+      : offset < 0
+        ? tSchedules('dayOffset.daysBefore')
+        : tSchedules('dayOffset.daysAfter');
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div className="flex flex-col gap-4">
+        <Card className={cn(cancelled && 'opacity-60')}>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <div className="bg-primary/10 rounded-md p-1.5">
+                <IconPhone size={16} className="text-primary" />
+              </div>
+              {t('title')}
+            </CardTitle>
+            <CardDescription>
+              {cancelled ? t('cancelledDescription') : t('description')}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="flex items-center gap-2 text-sm">
+              <IconCalendarEvent size={16} className="text-muted-foreground shrink-0" />
+              <span className="font-medium">
+                {new Date(scheduledDate).toLocaleDateString()}
+              </span>
+              <Badge variant="secondary" className="gap-1 rounded-sm text-xs">
+                {Math.abs(offset)}
+              </Badge>
+              <span className="text-muted-foreground text-xs">{offsetLabel}</span>
+            </div>
+            {scheduledTime && (
+              <div className="flex items-center gap-2 text-sm">
+                <IconClock size={16} className="text-muted-foreground shrink-0" />
+                <span className="font-medium">{scheduledTime.slice(0, 5)}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+        <TargetAudienceCard targetStatus={targetStatus} disabled={cancelled} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/calls/components/call-round-results-card.tsx
+++ b/src/features/calls/components/call-round-results-card.tsx
@@ -49,7 +49,19 @@ function StatChip({
   );
 }
 
-export async function CallRoundResultsCard({ round }: { round: CallRoundSummary }) {
+export async function CallRoundResultsCard({
+  round,
+  label,
+}: {
+  round: CallRoundSummary;
+  /**
+   * The round's name, resolved from its plan's position in the timeline. Passed
+   * in rather than derived from `round_number`, which is deprecated and null on
+   * anything created after 2026-08-14 - and so that the card and the nav entry
+   * beside it can never disagree about what this round is called.
+   */
+  label: string;
+}) {
   const t = await getTranslations('calls');
   const results = await getCallRoundResults(round.id);
 
@@ -60,7 +72,7 @@ export async function CallRoundResultsCard({ round }: { round: CallRoundSummary 
           <div className="bg-primary/10 rounded-md p-1.5">
             <IconPhone size={16} className="text-primary" />
           </div>
-          {t('round', { number: round.roundNumber })}
+          {label}
         </CardTitle>
         <CardDescription>
           {round.status === 'completed' && round.completedAt

--- a/src/features/calls/components/index.ts
+++ b/src/features/calls/components/index.ts
@@ -1,3 +1,4 @@
+export { CallPlanCard } from './call-plan-card';
 export { CallRoundResultsCard } from './call-round-results-card';
 export {
   CallRoundResultsTable,

--- a/src/features/calls/queries/call-rounds.ts
+++ b/src/features/calls/queries/call-rounds.ts
@@ -23,7 +23,12 @@ function summarise(logs: { outcome: CallOutcome | null }[]) {
  * Call rounds for an event, as the Owner sees them.
  *
  * Goes through the RLS-bound client, so a user without Owner access simply
- * gets an empty list and the schedules page renders no call items at all.
+ * gets an empty list and the schedules page renders no call results at all.
+ *
+ * Deliberately unordered: a round is now attached to its planned schedule by
+ * `scheduleId`, and the page orders by the plan's date. `round_number` is
+ * deprecated and null on anything created after 2026-08-14, so sorting on it
+ * would put every new round first.
  */
 export async function getCallRoundsForEvent(
   eventId: string,
@@ -32,9 +37,8 @@ export async function getCallRoundsForEvent(
 
   const { data: rounds, error } = await supabase
     .from('call_rounds')
-    .select('id, round_number, created_at, completed_at')
-    .eq('event_id', eventId)
-    .order('round_number', { ascending: true });
+    .select('id, schedule_id, round_number, created_at, completed_at')
+    .eq('event_id', eventId);
 
   if (error) {
     console.error('Error fetching call rounds:', error);
@@ -67,12 +71,38 @@ export async function getCallRoundsForEvent(
 
   return rounds.map((round) => ({
     id: round.id,
-    roundNumber: round.round_number,
+    scheduleId: round.schedule_id ?? null,
+    roundNumber: round.round_number ?? null,
     createdAt: round.created_at,
     completedAt: round.completed_at ?? null,
     status: round.completed_at ? ('completed' as const) : ('in_progress' as const),
     ...summarise(logsByRound.get(round.id) ?? []),
   }));
+}
+
+/**
+ * The same rounds, keyed by the phone_call schedule each one executes, so the
+ * schedules page can pair a plan with its round in one lookup.
+ *
+ * The migration backfilled a plan for every pre-existing round, so a round with
+ * no `scheduleId` should not exist. One is skipped rather than dropped on the
+ * floor silently - if it ever happens, the plan is the thing that went missing.
+ */
+export async function getCallRoundsByScheduleId(
+  eventId: string,
+): Promise<Map<string, CallRoundSummary>> {
+  const rounds = await getCallRoundsForEvent(eventId);
+  const byScheduleId = new Map<string, CallRoundSummary>();
+
+  for (const round of rounds) {
+    if (!round.scheduleId) {
+      console.error(`Call round ${round.id} has no linked schedule - skipping`);
+      continue;
+    }
+    byScheduleId.set(round.scheduleId, round);
+  }
+
+  return byScheduleId;
 }
 
 /**

--- a/src/features/calls/queries/index.ts
+++ b/src/features/calls/queries/index.ts
@@ -1,1 +1,5 @@
-export { getCallRoundsForEvent, getCallRoundResults } from './call-rounds';
+export {
+  getCallRoundsForEvent,
+  getCallRoundsByScheduleId,
+  getCallRoundResults,
+} from './call-rounds';

--- a/src/features/calls/types.ts
+++ b/src/features/calls/types.ts
@@ -10,7 +10,17 @@ export type CallRoundStatus = 'in_progress' | 'completed';
 
 export type CallRoundSummary = {
   id: string;
-  roundNumber: number;
+  /**
+   * The phone_call schedule this round executes. Every round has one - the
+   * migration backfilled the legacy ones - but the column stays nullable as an
+   * escape hatch, so readers must handle its absence.
+   */
+  scheduleId: string | null;
+  /**
+   * Deprecated. Ordering and labelling come from the linked plan; null on
+   * anything created after 2026-08-14.
+   */
+  roundNumber: number | null;
   createdAt: string;
   completedAt: string | null;
   status: CallRoundStatus;

--- a/src/features/dashboard/components/upcoming-schedules-card.tsx
+++ b/src/features/dashboard/components/upcoming-schedules-card.tsx
@@ -4,7 +4,7 @@ import { Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { IconBrandWhatsapp, IconMessage, IconCalendarPlus } from '@tabler/icons-react';
+import { IconBrandWhatsapp, IconMessage, IconCalendarPlus, IconPhone } from '@tabler/icons-react';
 import { SCHEDULE_TYPE_KEYS, type ScheduleTypeKey, type ScheduleApp } from '@/features/schedules';
 
 const KNOWN_SCHEDULE_TYPE_KEYS: readonly string[] = SCHEDULE_TYPE_KEYS;
@@ -50,7 +50,12 @@ export function UpcomingSchedulesCard({
           upcoming.map((schedule) => (
             <div key={schedule.id} className="flex items-start gap-3 text-sm">
               <div className="mt-0.5 shrink-0 text-muted-foreground">
-                {schedule.deliveryMethod === 'whatsapp' ? (
+                {/* A call round has no delivery method - it is worked through
+                    by a person, so it gets the phone rather than falling
+                    through to the SMS icon. */}
+                {schedule.scheduleTypeKey === 'phone_call' ? (
+                  <IconPhone className="h-4 w-4" />
+                ) : schedule.deliveryMethod === 'whatsapp' ? (
                   <IconBrandWhatsapp className="h-4 w-4" />
                 ) : (
                   <IconMessage className="h-4 w-4" />

--- a/src/features/events/actions/duplicate-event.ts
+++ b/src/features/events/actions/duplicate-event.ts
@@ -120,7 +120,7 @@ export async function duplicateEvent(
       }
     }
 
-    // Copy schedules and reset status to draft
+    // Copy schedules and reset each one to outstanding
     const { data: originalSchedules } = await supabase
       .from('schedules')
       .select('*')
@@ -135,7 +135,11 @@ export async function duplicateEvent(
         return {
           ...scheduleFields,
           event_id: newEvent.id,
-          status: 'draft' as const,
+          // Null, not 'draft': schedule_completion_status only allows
+          // 'sent'/'cancelled', and null is how this schema spells "not done
+          // yet". 'draft' failed the check constraint on every row, so no
+          // schedule was ever copied - the error was only logged.
+          status: null,
           sent_at: null,
         };
       });

--- a/src/features/schedules/actions/schedules.ts
+++ b/src/features/schedules/actions/schedules.ts
@@ -6,6 +6,21 @@ import { createClient } from '@/lib/supabase/server';
 import { assertNotImpersonating } from '@/lib/supabase/admin';
 import { ScheduleSelectionSchema, type ScheduleSelectionItem } from '../schemas';
 
+/**
+ * Reads execution_kind off a raw `schedule_types` embed. PostgREST returns a
+ * to-one embed as an object, but the generated types allow an array, so both
+ * shapes are handled. Defaults to treating the row as a message: the safe
+ * direction is to keep applying the existing guards, never to skip them.
+ */
+function isMessageScheduleRow(row: {
+  schedule_types: { execution_kind: string } | { execution_kind: string }[] | null;
+}): boolean {
+  const types = Array.isArray(row.schedule_types)
+    ? row.schedule_types[0]
+    : row.schedule_types;
+  return (types?.execution_kind ?? 'message') === 'message';
+}
+
 export type UpdateScheduledDateState = {
   success: boolean;
   message?: string | null;
@@ -31,7 +46,7 @@ export async function updateScheduledDate(
 
     const { data: existing, error: fetchError } = await supabase
       .from('schedules')
-      .select('status')
+      .select('status, schedule_types (execution_kind)')
       .eq('id', scheduleId)
       .single();
 
@@ -41,6 +56,16 @@ export async function updateScheduledDate(
 
     if (existing.status === 'sent') {
       return { success: false, message: 'Cannot modify a schedule that has already been sent.' };
+    }
+
+    // A restrictive RLS policy already blocks this, but an UPDATE that matches
+    // no rows returns no error - without this the caller would be told it
+    // succeeded. Rescheduling a call plan is a back-office action.
+    if (!isMessageScheduleRow(existing)) {
+      return {
+        success: false,
+        message: 'A call round can only be rescheduled from the back office.',
+      };
     }
 
     const { error } = await supabase
@@ -87,7 +112,7 @@ export async function updateScheduleStatus(
 
     const { data: existing, error: fetchError } = await supabase
       .from('schedules')
-      .select('status')
+      .select('status, schedule_types (execution_kind)')
       .eq('id', scheduleId)
       .single();
 
@@ -97,6 +122,14 @@ export async function updateScheduleStatus(
 
     if (existing.status === 'sent') {
       return { success: false, message: 'Cannot modify a schedule that has already been sent.' };
+    }
+
+    // See updateScheduledDate: RLS blocks the write, but silently.
+    if (!isMessageScheduleRow(existing)) {
+      return {
+        success: false,
+        message: 'A call round can only be changed from the back office.',
+      };
     }
 
     const { error } = await supabase
@@ -127,7 +160,7 @@ export type CreateSchedulesFromSelectionState = {
 /**
  * Creates schedules from a user-customized selection made in the setup wizard.
  * Each selection carries a fully-resolved date/time decided by the user.
- * Idempotent - skips selections whose template_id|scheduled_date already exists.
+ * Idempotent - skips selections whose type|template|date already exists.
  * Referential integrity of schedule_type_id/template_id is enforced by FKs.
  *
  * @param eventId - The event ID to create schedules for
@@ -152,10 +185,13 @@ export async function createSchedulesFromSelection(
 
     const supabase = await createClient();
 
-    // Skip selections that already exist (guards against double-submit)
+    // Skip selections that already exist (guards against double-submit).
+    // Keyed on the schedule type as well as the template: a call round has no
+    // template, so a template-only key would collapse every call plan to
+    // 'null|<date>' and silently drop all but the first.
     const { data: existingSchedules, error: fetchError } = await supabase
       .from('schedules')
-      .select('template_id, scheduled_date')
+      .select('schedule_type_id, template_id, scheduled_date')
       .eq('event_id', eventId);
 
     if (fetchError) {
@@ -164,11 +200,16 @@ export async function createSchedulesFromSelection(
     }
 
     const existingKeys = new Set(
-      existingSchedules?.map((s) => `${s.template_id}|${s.scheduled_date}`) ?? [],
+      existingSchedules?.map(
+        (s) => `${s.schedule_type_id}|${s.template_id ?? ''}|${s.scheduled_date}`,
+      ) ?? [],
     );
 
     const toCreate = parsed.data.filter(
-      (s) => !existingKeys.has(`${s.templateId}|${s.scheduledDate}`),
+      (s) =>
+        !existingKeys.has(
+          `${s.scheduleTypeId}|${s.templateId ?? ''}|${s.scheduledDate}`,
+        ),
     );
 
     if (toCreate.length === 0) {

--- a/src/features/schedules/components/schedule-setup-wizard.tsx
+++ b/src/features/schedules/components/schedule-setup-wizard.tsx
@@ -70,10 +70,13 @@ export function ScheduleSetupWizard({
       suggestedSchedules
         .filter((s) => s.scheduleTypeKey !== 'initial_invitation')
         .map((s, index) => ({
-          key: `${s.templateId}-${index}`,
+          // Keyed on the schedule type, not the template: a call round row has
+          // no template, so a templateId-based key would collide across them.
+          key: `${s.scheduleTypeId}-${index}`,
           scheduleTypeId: s.scheduleTypeId,
           scheduleTypeKey: s.scheduleTypeKey,
           scheduleTypeName: s.scheduleTypeName,
+          executionKind: s.executionKind,
           templateId: s.templateId,
           targetStatus: s.targetStatus,
           enabled: true,

--- a/src/features/schedules/components/schedules-layout.tsx
+++ b/src/features/schedules/components/schedules-layout.tsx
@@ -33,17 +33,17 @@ import { cn } from '@/lib/utils';
 import { useFeatureLayoutContext } from '@/components/feature-layout/feature-layout-context';
 
 import { type ScheduleTypeKey } from '../schemas';
-import { CALL_ROUNDS_NAV_KEY, type OutreachItem, type OutreachNavGroup } from '../types';
+import { type OutreachItem, type OutreachNavGroup } from '../types';
 import { formatRelativeTime } from '../utils';
 
 type ScheduleTypeIcon = React.ComponentType<{ size?: number | string; className?: string }>;
 
-const ACTION_TYPE_ICONS: Record<ScheduleTypeKey | typeof CALL_ROUNDS_NAV_KEY, ScheduleTypeIcon> = {
+const ACTION_TYPE_ICONS: Record<ScheduleTypeKey, ScheduleTypeIcon> = {
   initial_invitation: IconMail,
   confirmation: IconUserCheck,
   event_reminder: IconBell,
   post_event: IconHeart,
-  [CALL_ROUNDS_NAV_KEY]: IconPhone,
+  phone_call: IconPhone,
 };
 
 // Any schedule type outside the four known here (e.g. one added directly to

--- a/src/features/schedules/components/schedules-page.tsx
+++ b/src/features/schedules/components/schedules-page.tsx
@@ -3,8 +3,8 @@ import { IconChartBar, IconLayoutGrid } from '@tabler/icons-react';
 
 import { type EventApp } from '@/features/events/schemas';
 import { getEventGuests } from '@/features/guests/queries/guests';
-import { CallRoundResultsCard } from '@/features/calls/components';
-import { getCallRoundsForEvent } from '@/features/calls/queries';
+import { CallPlanCard, CallRoundResultsCard } from '@/features/calls/components';
+import { getCallRoundsByScheduleId } from '@/features/calls/queries';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { getDefaultSchedulesForEventType } from '../queries/catalog';
 import {
@@ -14,9 +14,9 @@ import {
   type ScheduleApp,
   type WhatsAppTemplateApp,
 } from '../schemas';
-import { CALL_ROUNDS_NAV_KEY, type OutreachItem, type OutreachNavGroup } from '../types';
+import { type OutreachItem, type OutreachNavGroup } from '../types';
 import { resolveSmsBodyForPreview } from '../utils/parameter-resolvers';
-import { filterGuestsByTarget } from '../utils';
+import { filterGuestsByTarget, isMessageSchedule } from '../utils';
 import { buildSuggestedSchedules } from '../utils/suggested-schedules';
 import { ScheduleInteractionsCard } from './schedule-interactions-card';
 import { ScheduleTabContent } from './schedule-tab-content';
@@ -45,14 +45,13 @@ export async function SchedulesPage({
   event,
 }: SchedulesPageProps) {
   const t = await getTranslations('schedules');
-  const tCalls = await getTranslations('calls');
   const locale = await getLocale();
 
-  const [guests, callRounds] = await Promise.all([
+  const [guests, roundsBySchedule] = await Promise.all([
     getEventGuests(eventId),
-    // RLS-bound: a viewer without Owner access gets an empty list, so call
-    // rounds simply do not appear in their nav.
-    getCallRoundsForEvent(eventId),
+    // RLS-bound: a viewer without Owner access gets an empty map, so a call
+    // plan renders as planned rather than exposing its results.
+    getCallRoundsByScheduleId(eventId),
   ]);
   const canCreateSchedules = event?.canCreateSchedules ?? false;
 
@@ -86,18 +85,20 @@ export async function SchedulesPage({
     ...presentTypes.filter((type) => !KNOWN_SCHEDULE_TYPE_KEYS.includes(type)).sort(),
   ];
 
-  // The wizard shows only when there is no outreach at all. An event can have
-  // call rounds and no message schedules (can_create_schedules defaults to
-  // false), and hiding real work behind an onboarding prompt is exactly the
-  // blind spot this page exists to remove.
-  if (visibleTypes.length === 0 && callRounds.length === 0) {
+  // The wizard shows only when there is no outreach at all. Call rounds are
+  // schedules now, so an event that has only call plans is caught by this same
+  // check - hiding real work behind an onboarding prompt is exactly the blind
+  // spot this page exists to remove.
+  if (visibleTypes.length === 0) {
     const eventType = event?.eventType ?? 'wedding';
     const defaults = await getDefaultSchedulesForEventType(eventType);
     const suggestedSchedules = buildSuggestedSchedules(defaults, eventDate);
     const invitationDefault = defaults.find(
       (d) => d.scheduleTypeKey === 'initial_invitation',
     );
-    const invitationTemplate = invitationDefault
+    // A default can now be templateless (a call round), so the template is
+    // guarded as well as the default itself.
+    const invitationTemplate = invitationDefault?.template
       ? toWhatsAppTemplate(invitationDefault.template)
       : null;
     const targetCounts = {
@@ -132,9 +133,39 @@ export async function SchedulesPage({
     const multiple = items.length > 1;
 
     contentByType[type] = items.map(({ schedule, template, smsBody }, index) => {
+      const label = multiple ? `${baseLabel} ${index + 1}` : baseLabel;
+
+      // A call round is planned like a message but executed by a person, so it
+      // reports the state of its round rather than of a send. A plan with no
+      // round yet is simply pending - the same amber the nav already uses.
+      if (!isMessageSchedule(schedule)) {
+        const round = roundsBySchedule.get(schedule.id);
+        const cancelled = schedule.status === 'cancelled';
+
+        return {
+          label,
+          status: cancelled ? ('cancelled' as const) : (round?.status ?? ('pending' as const)),
+          timestamp: cancelled
+            ? undefined
+            : round
+              ? (round.completedAt ?? round.createdAt)
+              : schedule.scheduledDate,
+          details: round ? (
+            <CallRoundResultsCard round={round} label={label} />
+          ) : (
+            <CallPlanCard
+              scheduledDate={schedule.scheduledDate}
+              scheduledTime={schedule.scheduledTime}
+              targetStatus={schedule.targetStatus}
+              eventDate={eventDate}
+              cancelled={cancelled}
+            />
+          ),
+        };
+      }
+
       return {
-        kind: 'message' as const,
-        label: multiple ? `${baseLabel} ${index + 1}` : baseLabel,
+        label,
         status: schedule.status ?? ('pending' as const),
         // A sent schedule is dated by when it went out; a still-pending one by
         // when it is due. A cancelled one has no meaningful date.
@@ -188,36 +219,32 @@ export async function SchedulesPage({
     });
   }
 
-  // Call rounds are their own kind of outreach, so they get their own list in
-  // the nav rather than trailing the message types in one flat menu. Each round
-  // keeps its own number rather than a positional index - deleting round 1 must
-  // not renumber round 2 under the Owner's feet.
-  if (callRounds.length > 0) {
-    contentByType[CALL_ROUNDS_NAV_KEY] = callRounds.map((round) => ({
-      kind: 'call_round' as const,
-      label: tCalls('round', { number: round.roundNumber }),
-      status: round.status,
-      timestamp: round.completedAt ?? round.createdAt,
-      details: <CallRoundResultsCard round={round} />,
-    }));
-  }
+  // Messages and call rounds are two different kinds of outreach, so they get
+  // their own lists rather than sharing one flat menu. The split is derived
+  // from each type's execution_kind, so a future non-message kind lands in the
+  // right section without this code knowing its name. Only groups with
+  // something in them reach the nav, so a heading never sits above an empty
+  // list.
+  const messageTypes = visibleTypes.filter((type) =>
+    isMessageSchedule(schedulesByType[type]![0].schedule),
+  );
+  const callTypes = visibleTypes.filter(
+    (type) => !isMessageSchedule(schedulesByType[type]![0].schedule),
+  );
 
-  // An event can have message schedules, call rounds, or both. Only groups with
-  // something in them reach the nav, so a section heading never sits above an
-  // empty list.
   const navGroups: OutreachNavGroup[] = [];
-  if (visibleTypes.length > 0) {
+  if (messageTypes.length > 0) {
     navGroups.push({
       key: 'messages',
       label: t('nav.messages'),
-      types: visibleTypes,
+      types: messageTypes,
     });
   }
-  if (callRounds.length > 0) {
+  if (callTypes.length > 0) {
     navGroups.push({
       key: 'calls',
       label: t('nav.calls'),
-      types: [CALL_ROUNDS_NAV_KEY],
+      types: callTypes,
     });
   }
 

--- a/src/features/schedules/components/wizard/wizard-timeline-step.tsx
+++ b/src/features/schedules/components/wizard/wizard-timeline-step.tsx
@@ -24,7 +24,9 @@ export type TimelineRow = {
   scheduleTypeId: string;
   scheduleTypeKey: string;
   scheduleTypeName: string;
-  templateId: string;
+  executionKind: string;
+  /** Null for non-message types - a call round is planned without a template */
+  templateId: string | null;
   targetStatus: 'pending' | 'confirmed' | null;
   enabled: boolean;
   date: Date;
@@ -105,6 +107,10 @@ export function WizardTimelineStep({
       : row.scheduleTypeName;
     const label = total > 1 ? `${baseLabel} ${index}/${total}` : baseLabel;
     const audienceKind = row.targetStatus ?? 'all';
+    // A call round is worked through by a person, so the audience reads as who
+    // gets phoned rather than who gets messaged, and the date is when the
+    // calling starts rather than when something is dispatched.
+    const isCall = row.executionKind === 'phone_call';
 
     return (
       <div
@@ -118,7 +124,7 @@ export function WizardTimelineStep({
           <div className="min-w-0">
             <p className="text-sm font-semibold">{label}</p>
             <p className="text-muted-foreground flex items-center gap-1.5 text-xs">
-              {t('audience.sentTo')}
+              {isCall ? t('audience.calling') : t('audience.sentTo')}
               <Badge variant="secondary" className="gap-1.5 rounded-sm text-xs">
                 <span className={cn('size-1.5 rounded-full', AUDIENCE_DOT_CLASS[audienceKind])} />
                 {t(AUDIENCE_KEY[audienceKind])}
@@ -134,7 +140,9 @@ export function WizardTimelineStep({
         {row.enabled && (
           <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <p className="text-muted-foreground text-xs">{t('setupWizard.sendDateLabel')}</p>
+              <p className="text-muted-foreground text-xs">
+                {isCall ? t('setupWizard.callDateLabel') : t('setupWizard.sendDateLabel')}
+              </p>
               <DatePicker
                 date={row.date}
                 onDateChange={(date) => date && updateRow(row.key, { date })}

--- a/src/features/schedules/index.ts
+++ b/src/features/schedules/index.ts
@@ -20,6 +20,7 @@ export {
 export {
   calculateScheduledDate,
   filterGuestsByTarget,
+  isMessageSchedule,
   validatePhoneNumber,
   formatPhoneE164,
 } from './utils';
@@ -33,9 +34,11 @@ export {
   type WhatsAppTemplateApp,
   type MessageDeliveryApp,
   type DefaultScheduleApp,
+  type ExecutionKind,
   SCHEDULE_TYPE_KEYS,
   SCHEDULE_TYPE_LABELS,
   SCHEDULE_STATUSES,
+  EXECUTION_KINDS,
   DELIVERY_METHODS,
   DELIVERY_STATUSES,
 } from './schemas';

--- a/src/features/schedules/queries/catalog.ts
+++ b/src/features/schedules/queries/catalog.ts
@@ -17,7 +17,7 @@ export async function getDefaultSchedulesForEventType(
   const { data, error } = await supabase
     .from('event_type_default_schedules')
     .select(
-      '*, event_types!inner (key), schedule_types (key, name), message_templates (*)',
+      '*, event_types!inner (key), schedule_types (key, name, execution_kind), message_templates (*)',
     )
     .eq('event_types.key', eventTypeKey)
     .order('sort_order', { ascending: true });

--- a/src/features/schedules/schemas/catalog.ts
+++ b/src/features/schedules/schemas/catalog.ts
@@ -12,6 +12,7 @@ export const SCHEDULE_TYPE_KEYS = [
   'confirmation',
   'event_reminder',
   'post_event',
+  'phone_call',
 ] as const;
 export type ScheduleTypeKey = (typeof SCHEDULE_TYPE_KEYS)[number];
 
@@ -21,7 +22,16 @@ export const SCHEDULE_TYPE_LABELS: Record<string, string> = {
   confirmation: 'Confirmation',
   event_reminder: 'Event Reminder',
   post_event: 'Thank You',
+  phone_call: 'Call Round',
 };
+
+// Which engine executes a schedule type. Everything outside 'message' is run by
+// a human or another process and must never reach the send engine - see
+// docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md.
+// Consumers filter positively on 'message', so a kind added to the catalog that
+// this build has never heard of is inert rather than sent.
+export const EXECUTION_KINDS = ['message', 'phone_call'] as const;
+export type ExecutionKind = (typeof EXECUTION_KINDS)[number];
 
 // --- event_type_default_schedules (joined with schedule_types + message_templates) ---
 
@@ -29,13 +39,21 @@ export const DefaultScheduleDbSchema = z.object({
   id: z.uuid(),
   event_type_id: z.uuid(),
   schedule_type_id: z.uuid(),
-  template_id: z.uuid(),
+  // Null for non-message types - a call round has no template to send.
+  template_id: z.uuid().nullable(),
   days_offset: z.number().int(),
   default_time: z.string(),
   target_status: z.enum(['pending', 'confirmed']).nullable(),
   sort_order: z.number().int(),
-  schedule_types: z.object({ key: z.string(), name: z.string() }),
-  message_templates: MessageTemplateDbToAppSchema,
+  // execution_kind is z.string(), not z.enum(EXECUTION_KINDS): the catalog is a
+  // table and can grow past the kinds known at build time, and an unknown kind
+  // must still parse so the row renders rather than crashing the page.
+  schedule_types: z.object({
+    key: z.string(),
+    name: z.string(),
+    execution_kind: z.string(),
+  }),
+  message_templates: MessageTemplateDbToAppSchema.nullable(),
 });
 
 export const DefaultScheduleDbToAppSchema = DefaultScheduleDbSchema.transform(
@@ -45,8 +63,9 @@ export const DefaultScheduleDbToAppSchema = DefaultScheduleDbSchema.transform(
     scheduleTypeId: db.schedule_type_id,
     scheduleTypeKey: db.schedule_types.key,
     scheduleTypeName: db.schedule_types.name,
+    executionKind: db.schedule_types.execution_kind,
     templateId: db.template_id,
-    template: db.message_templates as MessageTemplateApp,
+    template: db.message_templates as MessageTemplateApp | null,
     daysOffset: db.days_offset,
     // Postgres time comes back as HH:MM:SS; the UI works in HH:MM
     defaultTime: db.default_time.slice(0, 5),

--- a/src/features/schedules/schemas/index.ts
+++ b/src/features/schedules/schemas/index.ts
@@ -64,7 +64,7 @@ export type CustomContent = z.infer<typeof CustomContentSchema>;
 // render a schedule type it has no curated i18n label/icon for yet - the
 // catalog is meant to grow past the four types known at build time.
 export const SCHEDULE_SELECT =
-  '*, schedule_types (key, name), message_templates (*)';
+  '*, schedule_types (key, name, execution_kind), message_templates (*)';
 
 // --- DB-Level Schema (snake_case, with catalog joins) ---
 export const ScheduleDbSchema = z.object({
@@ -79,7 +79,11 @@ export const ScheduleDbSchema = z.object({
   template_id: z.uuid().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
-  schedule_types: z.object({ key: z.string(), name: z.string() }),
+  schedule_types: z.object({
+    key: z.string(),
+    name: z.string(),
+    execution_kind: z.string(),
+  }),
   message_templates: MessageTemplateDbToAppSchema.nullable(),
 });
 
@@ -97,6 +101,8 @@ export const ScheduleDbToAppSchema = ScheduleDbSchema.transform((db) => ({
   scheduleTypeId: db.schedule_type_id,
   scheduleTypeKey: db.schedule_types.key,
   scheduleTypeName: db.schedule_types.name,
+  // Which engine owns this row. Only 'message' may reach sendSchedule.
+  executionKind: db.schedule_types.execution_kind,
   templateId: db.template_id,
   template: db.message_templates as MessageTemplateApp | null,
   // Derived from the template row - the single source of truth for channel
@@ -111,7 +117,8 @@ export type ScheduleApp = z.infer<typeof ScheduleDbToAppSchema>;
 // One user-customized schedule chosen in the schedule setup wizard.
 export const ScheduleSelectionItemSchema = z.object({
   scheduleTypeId: z.uuid(),
-  templateId: z.uuid(),
+  // Null for non-message types - a call round is planned without a template.
+  templateId: z.uuid().nullable(),
   scheduledDate: z.string(),
   scheduledTime: z.string(),
   targetStatus: z.enum(['pending', 'confirmed']).nullable(),

--- a/src/features/schedules/services/send-schedule.ts
+++ b/src/features/schedules/services/send-schedule.ts
@@ -12,6 +12,7 @@ import {
 } from '@/features/guests/schemas';
 import {
   filterGuestsByTarget,
+  isMessageSchedule,
   validatePhoneNumber,
   sendInChunks,
   sendSmsToGuest,
@@ -155,7 +156,21 @@ export async function sendSchedule(
   const schedule: ScheduleApp = ScheduleDbToAppSchema.parse(rawSchedule);
   const event = mapEventRow(rawSchedule.events);
 
-  // 2. Validate template assignment (channel and content both come from it)
+  // 2. Refuse anything this engine does not execute. A phone_call schedule is a
+  // plan for a person to work through, not a message - it has no template and
+  // no channel. Every send entry point (cron, owner send-now, admin trigger,
+  // admin manual resend) funnels through here, so this one guard covers them
+  // all. Placed before the claim so a non-message row is never marked sent on
+  // its way to failing. See docs/adr/0004.
+  if (!isMessageSchedule(schedule)) {
+    return outcomeError(
+      scheduleId,
+      `Schedule type ${schedule.scheduleTypeKey} is not executed by the message send engine`,
+      schedule.eventId,
+    );
+  }
+
+  // 3. Validate template assignment (channel and content both come from it)
   if (!schedule.template) {
     return outcomeError(
       scheduleId,
@@ -165,7 +180,7 @@ export async function sendSchedule(
   }
   const template = schedule.template;
 
-  // 3. Claim ('none' skips any guard - admin resend)
+  // 4. Claim ('none' skips any guard - admin resend)
   if (claim === 'precheck') {
     if (schedule.status === 'sent' || schedule.status === 'cancelled') {
       return outcomeError(
@@ -204,7 +219,7 @@ export async function sendSchedule(
     return outcomeError(scheduleId, message, schedule.eventId);
   };
 
-  // 4. Fetch and target guests
+  // 5. Fetch and target guests
   let guestsQuery = supabase
     .from('guests')
     .select('*')
@@ -245,7 +260,7 @@ export async function sendSchedule(
 
   const skippedCount = targetedGuests.length - guestsWithPhones.length;
 
-  // 5. Optionally skip guests already delivered (safe cron resume)
+  // 6. Optionally skip guests already delivered (safe cron resume)
   let pendingGuests = guestsWithPhones;
   if (skipAlreadyDelivered) {
     const { data: existingDeliveries } = await supabase
@@ -275,7 +290,7 @@ export async function sendSchedule(
     }
   }
 
-  // 6. Send per channel, persisting delivery records per chunk
+  // 7. Send per channel, persisting delivery records per chunk
   let sentCount = 0;
   let failedCount = 0;
 
@@ -376,7 +391,7 @@ export async function sendSchedule(
     );
   }
 
-  // 7. Final status
+  // 8. Final status
   if (sentCount > 0) {
     if (claim !== 'optimistic-lock' && markSentOnSuccess) {
       const { error: updateError } = await supabase

--- a/src/features/schedules/types.ts
+++ b/src/features/schedules/types.ts
@@ -3,29 +3,22 @@
 
 import type { ReactNode } from 'react';
 
-/**
- * The nav key under which call rounds are grouped on the schedules page.
- * Not a schedule_types row - call rounds are not schedules - but it slots
- * into the same type-keyed nav so the two kinds render identically.
- */
-export const CALL_ROUNDS_NAV_KEY = 'phone_calls';
-
 export type OutreachItemStatus =
   // Message schedules
   | 'pending'
   | 'sent'
   | 'cancelled'
-  // Call rounds
+  // Call rounds: a plan that has been started, and one that is finished
   | 'in_progress'
   | 'completed';
 
 /**
- * One entry in the schedules page nav: either a Message Schedule or a Call
- * Round. The two are unified here, in the read model, rather than in the
- * database - see docs/adr/0001-call-rounds-are-not-schedules.md.
+ * One entry in the schedules page nav. Every entry is a schedules row now -
+ * both message sends and planned call rounds - so this carries only what the
+ * nav and the status line need, with the details pane pre-rendered server-side.
+ * See docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md.
  */
 export type OutreachItem = {
-  kind: 'message' | 'call_round';
   /** Nav label, already localized and disambiguated server-side */
   label: string;
   status: OutreachItemStatus;
@@ -35,10 +28,10 @@ export type OutreachItem = {
 };
 
 /**
- * One labelled section of the schedules nav. Message schedules and call rounds
- * are two different kinds of outreach, so they get their own lists rather than
- * sharing one flat menu - the grouping is explicit in the read model instead of
- * being inferred from the position of {@link CALL_ROUNDS_NAV_KEY}.
+ * One labelled section of the schedules nav. Messages and call rounds are two
+ * different kinds of outreach, so they get their own lists rather than sharing
+ * one flat menu. The split is derived from the schedule type's execution_kind,
+ * not from a hardcoded key.
  */
 export type OutreachNavGroup = {
   key: 'messages' | 'calls';

--- a/src/features/schedules/utils/index.ts
+++ b/src/features/schedules/utils/index.ts
@@ -101,7 +101,23 @@ export function filterGuestsByTarget(
     );
   }
 
+  // Every other type, including phone_call, matches on status alone. That is
+  // deliberate for calls: an offline-RSVP guest has already answered a person,
+  // so phoning them again is exactly the thing the target is meant to prevent.
   return guests.filter((guest) => guest.rsvpStatus === targetStatus);
+}
+
+/**
+ * Whether a schedule is executed by the message send engine, as opposed to by a
+ * human (a phone call round) or a future non-message process.
+ *
+ * Deliberately a positive test on the catalog's `execution_kind` rather than a
+ * list of keys to exclude: a kind this build has never heard of is treated as
+ * not-a-message, so it is never sent by accident. See
+ * docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md.
+ */
+export function isMessageSchedule(schedule: { executionKind: string }): boolean {
+  return schedule.executionKind === 'message';
 }
 
 /**

--- a/src/features/schedules/utils/suggested-schedules.ts
+++ b/src/features/schedules/utils/suggested-schedules.ts
@@ -5,7 +5,9 @@ export type SuggestedSchedule = {
   scheduleTypeId: string;
   scheduleTypeKey: string;
   scheduleTypeName: string;
-  templateId: string;
+  executionKind: string;
+  /** Null for non-message types - a call round is planned without a template */
+  templateId: string | null;
   daysOffset: number;
   defaultTime: string;
   targetStatus: 'pending' | 'confirmed' | null;
@@ -28,6 +30,7 @@ export function buildSuggestedSchedules(
     scheduleTypeId: config.scheduleTypeId,
     scheduleTypeKey: config.scheduleTypeKey,
     scheduleTypeName: config.scheduleTypeName,
+    executionKind: config.executionKind,
     templateId: config.templateId,
     daysOffset: config.daysOffset,
     defaultTime: config.defaultTime,

--- a/src/lib/services/message-processor.ts
+++ b/src/lib/services/message-processor.ts
@@ -26,9 +26,17 @@ export async function processScheduledMessages(
     errors: [],
   };
 
+  // Only message schedules. A phone_call schedule is a plan for a person to
+  // work through, and handing one to the send engine would attempt it as a
+  // WhatsApp/SMS blast. The filter is positive rather than excluding known
+  // non-message kinds, so a kind added to the catalog that this build has never
+  // heard of is inert until code opts it in - see docs/adr/0004. `!inner` is
+  // required: a plain embed would return the row with a null join instead of
+  // filtering it out.
   const { data: dueSchedules, error } = await supabase
     .from('schedules')
-    .select('id')
+    .select('id, schedule_types!inner(execution_kind)')
+    .eq('schedule_types.execution_kind', 'message')
     .is('status', null)
     .lte('scheduled_date', new Date().toISOString())
     .order('scheduled_date', { ascending: true })

--- a/supabase/migrations/20260814000000_add_phone_call_schedule_type.sql
+++ b/supabase/migrations/20260814000000_add_phone_call_schedule_type.sql
@@ -1,0 +1,124 @@
+-- Phone call rounds become planned schedules.
+--
+-- Until now a round was ad hoc: an admin clicked "New round" and the system
+-- snapshotted every pending guest. There was no plan, no date and no target.
+-- From here a round is planned as a schedules row like any other outreach, and
+-- the back office executes that plan. See
+-- docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md.
+--
+-- This migration teaches the catalog that not every schedule type is a message
+-- send. Without it, processScheduledMessages would pick up a phone_call row and
+-- hand it to the WhatsApp/SMS engine.
+
+-- --------------------------------------------------------------------------
+-- 1. The catalog learns who executes a schedule type
+-- --------------------------------------------------------------------------
+
+alter table public.schedule_types
+  add column execution_kind text not null default 'message'
+    check (execution_kind in ('message', 'phone_call'));
+
+comment on column public.schedule_types.execution_kind is
+  'Which engine executes schedules of this type. message = the cron-driven WhatsApp/SMS send engine. Anything else is executed by a human or another process and must never reach sendSchedule. Consumers filter positively on ''message'', so a new kind is inert until code opts it in.';
+
+insert into public.schedule_types (key, name, sort_order, execution_kind)
+values ('phone_call', 'Call Round', 5, 'phone_call');
+
+-- --------------------------------------------------------------------------
+-- 2. A phone_call default has no message to send
+-- --------------------------------------------------------------------------
+
+alter table public.event_type_default_schedules
+  alter column template_id drop not null;
+
+comment on column public.event_type_default_schedules.template_id is
+  'Null for schedule types whose execution_kind is not ''message'' - a call round has no template.';
+
+-- Two call rounds per wedding, planned close enough to the event that the
+-- headcount they produce is still actionable.
+insert into public.event_type_default_schedules
+  (event_type_id, schedule_type_id, template_id, days_offset, default_time, target_status, sort_order)
+select
+  (select id from public.event_types where key = 'wedding'),
+  (select id from public.schedule_types where key = 'phone_call'),
+  null,
+  d.days_offset,
+  d.default_time::time,
+  'pending',
+  d.sort_order
+from (values (-7, '10:00', 6), (-3, '10:00', 7))
+  as d(days_offset, default_time, sort_order);
+
+-- --------------------------------------------------------------------------
+-- 3. One helper, three callers: the freeze trigger and the two RLS policies
+-- --------------------------------------------------------------------------
+
+-- coalesce(..., true) so an unknown schedule_type_id is treated as a message:
+-- the safe direction is "keep protecting it", never "unlock it".
+create or replace function public.schedule_type_is_message(p_schedule_type_id uuid)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select coalesce(
+    (select st.execution_kind = 'message'
+       from public.schedule_types st
+      where st.id = p_schedule_type_id),
+    true);
+$$;
+
+alter function public.schedule_type_is_message(uuid) owner to postgres;
+
+comment on function public.schedule_type_is_message(uuid) is
+  'True when schedules of this type are executed by the message send engine. Fails safe to true for an unknown type.';
+
+-- --------------------------------------------------------------------------
+-- 4. Narrow the sent-schedule freeze to the invariant it actually protects
+-- --------------------------------------------------------------------------
+
+-- The invariant is "a message that physically went out cannot be retroactively
+-- edited". For a call plan, status='sent' means "handed to the calling team",
+-- and undoing a misclicked Start is a legitimate admin action. One round per
+-- plan is carried by the unique index on call_rounds.schedule_id (next
+-- migration) plus the optimistic status IS NULL claim, not by freezing the row.
+create or replace function public.prevent_sent_schedule_mutation()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+BEGIN
+  IF OLD.status = 'sent'
+     AND public.schedule_type_is_message(OLD.schedule_type_id) THEN
+    RAISE EXCEPTION
+      'Cannot modify a schedule that has already been sent (id: %)', OLD.id
+      USING ERRCODE = 'raise_exception';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- --------------------------------------------------------------------------
+-- 5. The Owner plans the call once, then it belongs to the back office
+-- --------------------------------------------------------------------------
+
+-- Narrowing the trigger above leaves a sent call plan mutable, and
+-- schedules_update grants UPDATE to the Owner. These restrictive policies AND
+-- with every existing permissive policy, so a call plan is read-only to any
+-- authenticated user. INSERT is deliberately untouched: the Owner still creates
+-- call plans in the setup wizard. Admin actions use the service client and
+-- bypass RLS entirely.
+create policy "Only message schedules are mutable by users"
+  on public.schedules
+  as restrictive
+  for update
+  to authenticated
+  using (public.schedule_type_is_message(schedule_type_id))
+  with check (public.schedule_type_is_message(schedule_type_id));
+
+create policy "Only message schedules are deletable by users"
+  on public.schedules
+  as restrictive
+  for delete
+  to authenticated
+  using (public.schedule_type_is_message(schedule_type_id));

--- a/supabase/migrations/20260814000001_link_call_rounds_to_schedules.sql
+++ b/supabase/migrations/20260814000001_link_call_rounds_to_schedules.sql
@@ -1,0 +1,91 @@
+-- A call round is the execution of a planned phone_call schedule.
+--
+-- Legacy rounds predate the plan, so this mints the plan each one would have
+-- had and links it. Doing that here rather than tolerating orphans in the read
+-- model is the point: the schedules page then has exactly one shape to render -
+-- plan first, round optional - instead of a permanent "round without a plan"
+-- branch. See docs/adr/0004-call-schedules-are-plans-call-rounds-are-executions.md.
+
+alter table public.call_rounds
+  add column schedule_id uuid references public.schedules (id) on delete restrict;
+
+comment on column public.call_rounds.schedule_id is
+  'The phone_call schedule this round executes. Nullable only as an escape hatch; the backfill below leaves no nulls behind, and nothing in the app creates a round without a plan.';
+
+-- --------------------------------------------------------------------------
+-- Backfill: every existing round gets the plan it would have had
+-- --------------------------------------------------------------------------
+
+-- Dated at the round's own created_at, and marked 'sent' because the round did
+-- in fact start. target_status is 'pending' because that is what the old
+-- startCallRound hardcoded when it snapshotted the guests.
+do $$
+declare
+  v_type_id uuid;
+  r record;
+  v_schedule_id uuid;
+begin
+  select id into strict v_type_id
+    from public.schedule_types
+   where key = 'phone_call';
+
+  for r in
+    select id, event_id, created_at
+      from public.call_rounds
+     where schedule_id is null
+     order by created_at
+  loop
+    insert into public.schedules
+      (event_id, schedule_type_id, template_id, scheduled_date, scheduled_time,
+       target_status, status, sent_at, created_at)
+    values
+      (r.event_id, v_type_id, null, r.created_at,
+       to_char(r.created_at, 'HH24:MI')::time,
+       'pending', 'sent', r.created_at, r.created_at)
+    returning id into v_schedule_id;
+
+    update public.call_rounds
+       set schedule_id = v_schedule_id
+     where id = r.id;
+  end loop;
+end $$;
+
+-- Fail the migration rather than leave an orphan the read model would have to
+-- tolerate forever.
+do $$
+declare
+  v_orphans int;
+begin
+  select count(*) into v_orphans
+    from public.call_rounds
+   where schedule_id is null;
+
+  if v_orphans > 0 then
+    raise exception
+      'link_call_rounds_to_schedules: % round(s) still without a plan', v_orphans;
+  end if;
+end $$;
+
+-- --------------------------------------------------------------------------
+-- One round per plan
+-- --------------------------------------------------------------------------
+
+-- This, not the sent-schedule freeze, is what stops two admins starting the
+-- same planned round twice.
+create unique index call_rounds_schedule_id_key
+  on public.call_rounds (schedule_id)
+  where schedule_id is not null;
+
+-- --------------------------------------------------------------------------
+-- round_number is superseded by the plan
+-- --------------------------------------------------------------------------
+
+-- Ordering and labelling now come from the linked schedule's scheduled_date.
+-- Keep the historical data, stop requiring and stop generating it. Dropping the
+-- unique constraint also removes the read-then-insert race two concurrent
+-- admins could hit when allocating the next number.
+alter table public.call_rounds alter column round_number drop not null;
+alter table public.call_rounds drop constraint call_rounds_event_id_round_number_key;
+
+comment on column public.call_rounds.round_number is
+  'Deprecated. Ordering and labelling come from the linked schedule. Null on rounds created after 2026-08-14; retained for historical rows.';


### PR DESCRIPTION
Call rounds were ad hoc: an admin clicked "New round" and the system snapshotted every pending guest. No plan, no date, no target audience, and the owner only saw the round after the fact.

Now a round is planned like any other outreach. `schedules` gains a `phone_call` type carrying the date, time and target; `call_rounds` gains `schedule_id` and becomes the execution record. `call_logs` is untouched.

This supersedes ADR-0001, which rejected the same design. Its third objection dissolves under the new framing - a planned round has an honest `scheduled_date` - and the other two are solved rather than avoided:

- `schedule_types.execution_kind` lets the cron filter positively on 'message', so a kind the code has never heard of is inert instead of being sent. One matching guard in sendSchedule covers all four send entry points.
- `prevent_sent_schedule_mutation` is narrowed to message schedules, since a misclicked Start must stay undoable. One-round-per-plan is carried by a unique index on `call_rounds.schedule_id` plus an optimistic claim.

Owners are view-only on call plans, enforced by two restrictive RLS policies rather than by hiding controls. INSERT stays open so the setup wizard still creates them. The back office gains add and reschedule, without which an event that already has schedules could never acquire a call plan.

Every existing round is backfilled with the plan it would have had, so the read model has one shape - plan first, round optional - with no orphan branch.

Also fixes duplicate-event inserting status 'draft', which is not in the schedule_completion_status enum, so no schedule was ever copied.