### PR TITLE
Events exist before they are complete

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -706,7 +706,8 @@
       "pctOfEstimate": "{pct}% of estimate",
       "scheduledMessages": "Scheduled Messages",
       "pendingMessageSingular": "pending message",
-      "pendingMessages": "pending messages"
+      "pendingMessages": "pending messages",
+      "noDateYet": "No date yet"
     },
     "guestStats": {
       "totalGuests": "Total Guests",
@@ -746,7 +747,10 @@
     "countdown": {
       "today": "Today is the day!",
       "daysSince": "days since the event",
-      "daysTo": "days to go"
+      "daysTo": "days to go",
+      "noDateTitle": "Waiting on the perfect date",
+      "noDateDescription": "The moment you pick one, everything here updates itself",
+      "noDateChip": "The date is still ahead of you"
     },
     "upcomingSchedules": {
       "title": "Upcoming Schedules",

--- a/messages/he.json
+++ b/messages/he.json
@@ -707,7 +707,8 @@
       "pctOfEstimate": "{pct}% מהאומדן",
       "scheduledMessages": "הודעות מתוזמנות",
       "pendingMessageSingular": "הודעה ממתינה",
-      "pendingMessages": "הודעות ממתינות"
+      "pendingMessages": "הודעות ממתינות",
+      "noDateYet": "עוד אין תאריך"
     },
     "guestStats": {
       "totalGuests": "סה\"כ אורחים",
@@ -747,7 +748,10 @@
     "countdown": {
       "today": "היום זה היום!",
       "daysSince": "ימים מאז האירוע",
-      "daysTo": "ימים נותרו"
+      "daysTo": "ימים נותרו",
+      "noDateTitle": "מחכים לתאריך המושלם",
+      "noDateDescription": "ברגע שתקבעו, הכל כאן יתעדכן לבד",
+      "noDateChip": "התאריך עוד לפניכם"
     },
     "upcomingSchedules": {
       "title": "תזמונים קרובים",

--- a/src/app/(main)/[locale]/app/[eventId]/dashboard/page.tsx
+++ b/src/app/(main)/[locale]/app/[eventId]/dashboard/page.tsx
@@ -17,7 +17,9 @@ import {
   type OnboardingStatus,
 } from '@/features/dashboard';
 
-function getDaysRemaining(eventDate: string): number {
+/** Null for an event with no date - there is no countdown to run. */
+function getDaysRemaining(eventDate: string | null): number | null {
+  if (!eventDate) return null;
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const event = new Date(eventDate);

--- a/src/app/(main)/[locale]/app/[eventId]/layout.tsx
+++ b/src/app/(main)/[locale]/app/[eventId]/layout.tsx
@@ -22,7 +22,10 @@ export default async function EventLayout({
   setRequestLocale(locale);
   const event = await getEventById(eventId);
 
-  if (!event) {
+  // A Draft Event is not a workspace: it may have no date, and every page below
+  // this layout assumes the answers exist. Reaching one by URL sends the user
+  // back into onboarding to finish it, which is the only way out of the state.
+  if (!event || event.status === 'draft') {
     redirect({ href: '/app/new-event', locale });
   }
 

--- a/src/app/(main)/[locale]/app/[eventId]/schedules/page.tsx
+++ b/src/app/(main)/[locale]/app/[eventId]/schedules/page.tsx
@@ -17,7 +17,7 @@ export default async function SchedulesPage({
     <SchedulesPageComponent
       schedules={schedules}
       eventId={eventId}
-      eventDate={event?.eventDate ?? ''}
+      eventDate={event?.eventDate ?? null}
       event={event ?? null}
     />
   );

--- a/src/app/(main)/[locale]/app/page.tsx
+++ b/src/app/(main)/[locale]/app/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from '@/i18n/navigation';
 import { setRequestLocale } from 'next-intl/server';
-import { getLastUserEvent } from '@/features/events/queries';
+import { getDraftEvent, getLastUserEvent } from '@/features/events/queries';
 
 export default async function AppPage({
   params,
@@ -9,6 +9,16 @@ export default async function AppPage({
 }) {
   const { locale } = await params;
   setRequestLocale(locale);
+
+  // An unfinished event takes priority over a finished one: someone who
+  // abandoned onboarding is returned to where they left off, not to a workspace
+  // they have not created yet. A Draft Event never opens a dashboard - it may
+  // not even have a date.
+  const draft = await getDraftEvent();
+
+  if (draft) {
+    redirect({ href: '/app/new-event', locale });
+  }
 
   const event = await getLastUserEvent();
 

--- a/src/features/admin/queries/events.ts
+++ b/src/features/admin/queries/events.ts
@@ -11,7 +11,10 @@ export async function listAllEvents(userId?: string): Promise<AdminEvent[]> {
   let eventsQuery = supabase
     .from('events')
     .select('id, title, user_id, event_date, status')
-    .order('event_date', { ascending: false });
+    // Nulls last: a descending sort puts them first by default, which would
+    // float every dateless event and every abandoned draft above the dated
+    // ones an admin actually came to look at.
+    .order('event_date', { ascending: false, nullsFirst: false });
 
   if (userId) {
     eventsQuery = eventsQuery.eq('user_id', userId);

--- a/src/features/admin/queries/users.ts
+++ b/src/features/admin/queries/users.ts
@@ -20,26 +20,35 @@ export async function listUsers(): Promise<AdminUser[]> {
 
   const ids = profiles.map((p) => p.id);
 
-  // Count events per user in one query
+  // Count events per user in one query. Drafts are counted separately: an
+  // abandoned draft is a record of interest, not an event the user has, and
+  // folding the two together overstates how many events exist.
   const { data: eventCounts } = await supabase
     .from('events')
-    .select('user_id')
+    .select('user_id, status')
     .in('user_id', ids);
 
-  const countMap = new Map<string, number>();
+  const countMap = new Map<string, { published: number; draft: number }>();
   for (const row of eventCounts ?? []) {
-    countMap.set(row.user_id, (countMap.get(row.user_id) ?? 0) + 1);
+    const entry = countMap.get(row.user_id) ?? { published: 0, draft: 0 };
+    if (row.status === 'draft') entry.draft++;
+    else entry.published++;
+    countMap.set(row.user_id, entry);
   }
 
-  return profiles.map((p) => ({
-    id: p.id,
-    email: p.email ?? '',
-    fullName: p.full_name ?? '',
-    plan: p.pricing_plan ?? 'basic',
-    signupDate: p.created_at,
-    eventCount: countMap.get(p.id) ?? 0,
-    isAdmin: p.is_admin ?? false,
-  }));
+  return profiles.map((p) => {
+    const counts = countMap.get(p.id) ?? { published: 0, draft: 0 };
+    return {
+      id: p.id,
+      email: p.email ?? '',
+      fullName: p.full_name ?? '',
+      plan: p.pricing_plan ?? 'basic',
+      signupDate: p.created_at,
+      eventCount: counts.published,
+      draftCount: counts.draft,
+      isAdmin: p.is_admin ?? false,
+    };
+  });
 }
 
 export async function getUserById(userId: string): Promise<AdminUser | null> {
@@ -54,10 +63,18 @@ export async function getUserById(userId: string): Promise<AdminUser | null> {
 
   if (error || !profile) return null;
 
-  const { count } = await supabase
-    .from('events')
-    .select('*', { count: 'exact', head: true })
-    .eq('user_id', userId);
+  const [{ count: publishedCount }, { count: draftCount }] = await Promise.all([
+    supabase
+      .from('events')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .neq('status', 'draft'),
+    supabase
+      .from('events')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('status', 'draft'),
+  ]);
 
   return {
     id: profile.id,
@@ -65,7 +82,8 @@ export async function getUserById(userId: string): Promise<AdminUser | null> {
     fullName: profile.full_name ?? '',
     plan: profile.pricing_plan ?? 'basic',
     signupDate: profile.created_at,
-    eventCount: count ?? 0,
+    eventCount: publishedCount ?? 0,
+    draftCount: draftCount ?? 0,
     isAdmin: profile.is_admin ?? false,
   };
 }

--- a/src/features/admin/types.ts
+++ b/src/features/admin/types.ts
@@ -45,7 +45,10 @@ export type AdminUser = {
   fullName: string;
   plan: string;
   signupDate: string;
+  /** Published events only. An abandoned draft is interest, not an event. */
   eventCount: number;
+  /** Draft Events: onboarding started and not finished. */
+  draftCount: number;
   isAdmin: boolean;
 };
 

--- a/src/features/calls/components/call-plan-card.tsx
+++ b/src/features/calls/components/call-plan-card.tsx
@@ -19,7 +19,7 @@ interface CallPlanCardProps {
   scheduledTime: string | null;
   targetStatus?: 'pending' | 'confirmed' | null;
   /** The event date, used to show how far ahead the calling sits */
-  eventDate: string;
+  eventDate: string | null;
   cancelled: boolean;
 }
 
@@ -55,13 +55,17 @@ export async function CallPlanCard({
   // the *server's* locale - m/d/yyyy - whatever the Owner is reading the app in.
   const locale = await getLocale();
 
-  const offset = dayOffset(scheduledDate, eventDate);
+  // Offsets are relative to the event date, so an event without one has no
+  // offset to state - the card shows the scheduled date on its own.
+  const offset = eventDate ? dayOffset(scheduledDate, eventDate) : null;
   const offsetLabel =
-    offset === 0
-      ? tSchedules('dayOffset.onEventDay')
-      : offset < 0
-        ? tSchedules('dayOffset.daysBefore')
-        : tSchedules('dayOffset.daysAfter');
+    offset === null
+      ? null
+      : offset === 0
+        ? tSchedules('dayOffset.onEventDay')
+        : offset < 0
+          ? tSchedules('dayOffset.daysBefore')
+          : tSchedules('dayOffset.daysAfter');
 
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -88,10 +92,14 @@ export async function CallPlanCard({
                   year: 'numeric',
                 })}
               </span>
-              <Badge variant="secondary" className="gap-1 rounded-sm text-xs">
-                {Math.abs(offset)}
-              </Badge>
-              <span className="text-muted-foreground text-xs">{offsetLabel}</span>
+              {offset !== null && (
+                <>
+                  <Badge variant="secondary" className="gap-1 rounded-sm text-xs">
+                    {Math.abs(offset)}
+                  </Badge>
+                  <span className="text-muted-foreground text-xs">{offsetLabel}</span>
+                </>
+              )}
             </div>
             {scheduledTime && (
               <div className="flex items-center gap-2 text-sm">

--- a/src/features/dashboard/components/event-countdown-card.tsx
+++ b/src/features/dashboard/components/event-countdown-card.tsx
@@ -14,6 +14,48 @@ function getDaysRemaining(eventDate: string): number {
   return Math.ceil((event.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
 }
 
+/**
+ * The card for an event whose owner has not picked a date yet.
+ *
+ * A permanent, legitimate state, not a gap to be filled in later - so it says
+ * what is true rather than showing a zero or an empty slot where the countdown
+ * would be.
+ */
+function NoDateCountdown({ event }: { event: EventApp }) {
+  const t = useTranslations('dashboard.countdown');
+
+  return (
+    <Card className="h-full overflow-hidden">
+      <CardContent className="flex h-full flex-col justify-between p-6">
+        <div className="flex items-start justify-between gap-2">
+          <h2 className="text-xl leading-tight font-semibold">{event.title}</h2>
+          <Badge variant={statusVariant[event.status] ?? 'secondary'} className="shrink-0 capitalize">
+            {event.status}
+          </Badge>
+        </div>
+
+        <div className="py-4 text-center">
+          <p className="text-2xl leading-tight font-semibold text-balance">
+            {t('noDateTitle')}
+          </p>
+          <p className="text-muted-foreground mt-2 text-sm">
+            {t('noDateDescription')}
+          </p>
+        </div>
+
+        <div className="text-muted-foreground space-y-2 text-sm">
+          {event.location?.name && (
+            <div className="flex items-center gap-2">
+              <IconMapPin className="h-4 w-4 shrink-0" />
+              <span className="truncate">{event.location.name}</span>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function formatEventDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('en-US', {
     weekday: 'long',
@@ -31,6 +73,9 @@ const statusVariant: Record<string, 'default' | 'secondary' | 'outline'> = {
 
 export function EventCountdownCard({ event }: { event: EventApp }) {
   const t = useTranslations('dashboard.countdown');
+
+  if (!event.eventDate) return <NoDateCountdown event={event} />;
+
   const daysRemaining = getDaysRemaining(event.eventDate);
   const isPast = daysRemaining < 0;
   const isToday = daysRemaining === 0;

--- a/src/features/dashboard/components/event-hero-banner.tsx
+++ b/src/features/dashboard/components/event-hero-banner.tsx
@@ -1,6 +1,6 @@
-import { getLocale } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 import { ConfettiBackground } from '@/components/ui/confetti';
-import { IconCalendar, IconMapPin } from '@tabler/icons-react';
+import { IconCalendar, IconMapPin, IconSparkles } from '@tabler/icons-react';
 import type { EventApp } from '@/features/events/schemas';
 
 const LIGHT_CONFETTI_COLORS = [
@@ -26,6 +26,7 @@ export async function EventHeroBanner({ event }: { event: EventApp }) {
   // Formatted against the active locale rather than a fixed one, so the
   // headline date reads in the language the rest of the page is in.
   const locale = await getLocale();
+  const t = await getTranslations('dashboard.countdown');
 
   return (
     <ConfettiBackground
@@ -40,10 +41,20 @@ export async function EventHeroBanner({ event }: { event: EventApp }) {
             {event.title}
           </h2>
           <div className="flex flex-col gap-2">
-            <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200/60 bg-white/60 px-3 py-1.5 text-sm font-medium text-zinc-700 shadow-sm backdrop-blur-sm">
-              <IconCalendar className="h-3.5 w-3.5 shrink-0 text-pink-400" />
-              <span>{formatEventDate(event.eventDate, locale)}</span>
-            </div>
+            {event.eventDate ? (
+              <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200/60 bg-white/60 px-3 py-1.5 text-sm font-medium text-zinc-700 shadow-sm backdrop-blur-sm">
+                <IconCalendar className="h-3.5 w-3.5 shrink-0 text-pink-400" />
+                <span>{formatEventDate(event.eventDate, locale)}</span>
+              </div>
+            ) : (
+              // Dashed rather than solid, so a date the owner has not picked
+              // reads as deliberately open rather than as a chip that failed to
+              // load.
+              <div className="inline-flex items-center gap-2 rounded-full border border-dashed border-violet-400/50 bg-violet-100/50 px-3 py-1.5 text-sm font-medium text-violet-700 backdrop-blur-sm">
+                <IconSparkles className="h-3.5 w-3.5 shrink-0" />
+                <span>{t('noDateChip')}</span>
+              </div>
+            )}
             {event.location?.name && (
               <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200/60 bg-white/60 px-3 py-1.5 text-sm font-medium text-zinc-700 shadow-sm backdrop-blur-sm">
                 <IconMapPin className="h-3.5 w-3.5 shrink-0 text-violet-400" />

--- a/src/features/dashboard/components/hero-stat-cards.tsx
+++ b/src/features/dashboard/components/hero-stat-cards.tsx
@@ -4,19 +4,6 @@ import { useTranslations } from 'next-intl';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { GuestsEstimate } from '@/features/events/schemas';
 
-const ESTIMATE_UPPER: Record<GuestsEstimate, number> = {
-  up_to_100: 100,
-  '100_200': 200,
-  '200_350': 350,
-  '350_plus': 500,
-};
-
-const ESTIMATE_LABEL: Record<GuestsEstimate, string> = {
-  up_to_100: 'up to 100',
-  '100_200': '100–200',
-  '200_350': '200–350',
-  '350_plus': '350+',
-};
 
 function StatCard({
   label,
@@ -46,9 +33,17 @@ function StatCard({
 export function DaysToEventCard({
   daysRemaining,
 }: {
-  daysRemaining: number;
+  /** Null when the event has no date - there is nothing to count down to. */
+  daysRemaining: number | null;
 }) {
   const t = useTranslations('dashboard.stats');
+
+  // An em-dash-free placeholder rather than a zero: zero would read as "the
+  // event is today", which is the one thing we know it is not.
+  if (daysRemaining === null) {
+    return <StatCard label={t('daysToEvent')} value="-" sub={t('noDateYet')} />;
+  }
+
   const isToday = daysRemaining === 0;
   const isPast = daysRemaining < 0;
 
@@ -66,14 +61,19 @@ export function GuestsInvitedCard({
   estimate?: GuestsEstimate;
 }) {
   const t = useTranslations('dashboard.stats');
-  const upper = estimate ? ESTIMATE_UPPER[estimate] : null;
-  const pct = upper ? Math.min(100, Math.round((total / upper) * 100)) : null;
+  // The estimate is now the number the owner chose on the slider, so it is both
+  // the bar's ceiling and the figure shown - no bucket to widen into a range.
+  const pct = estimate ? Math.min(100, Math.round((total / estimate) * 100)) : null;
 
   return (
     <StatCard
       label={t('guestsInvited')}
       value={total}
-      sub={estimate ? t('ofEstimated', { estimate: ESTIMATE_LABEL[estimate] }) : undefined}
+      sub={
+        estimate
+          ? t('ofEstimated', { estimate: estimate.toLocaleString() })
+          : undefined
+      }
     >
       {pct !== null && (
         <div className="mt-3">

--- a/src/features/events/actions/draft-event.ts
+++ b/src/features/events/actions/draft-event.ts
@@ -1,0 +1,451 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getLocale } from 'next-intl/server';
+import { getCurrentUser } from '@/features/auth/queries';
+import { assertNotImpersonating } from '@/lib/supabase/admin';
+import { createClient } from '@/lib/supabase/server';
+import {
+  DraftDateSchema,
+  DraftEstimateSchema,
+  DraftLocationSchema,
+  DraftNamesSchema,
+  EventTypeKeySchema,
+  type CreateDraftEventState,
+  type DraftStepState,
+  type EventTypeKey,
+} from '../schemas';
+import {
+  buildEventTitle,
+  buildHostDetails,
+  readEventTypeKey,
+  readHostNames,
+} from '../utils/event-title';
+import type { OnboardingStep } from '../types';
+
+/**
+ * Server Actions behind the onboarding takeover.
+ *
+ * Every one of these patches a single Draft Event that already exists - the row
+ * is created the moment the couple picks an event type, and each answer after
+ * that is an update. Nothing here blocks a screen transition: the takeover
+ * moves on optimistically and these save behind it, which is why each returns a
+ * plain state object rather than throwing.
+ *
+ * See docs/adr/0003-events-exist-before-they-are-complete.md.
+ */
+
+/** Records how far onboarding got, without ever moving the marker backwards. */
+const STEP_ORDER: readonly OnboardingStep[] = [
+  'type',
+  'names',
+  'date',
+  'venue',
+  'estimate',
+];
+
+function furthestStep(
+  current: string | null | undefined,
+  reached: OnboardingStep,
+): OnboardingStep {
+  const currentIdx = STEP_ORDER.indexOf(current as OnboardingStep);
+  const reachedIdx = STEP_ORDER.indexOf(reached);
+  return currentIdx > reachedIdx ? (current as OnboardingStep) : reached;
+}
+
+/**
+ * Loads the draft and checks it is one - a published event must never be
+ * patched by an onboarding screen, and RLS already guarantees it is the caller's.
+ */
+async function loadDraft(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  eventId: string,
+) {
+  const { data, error } = await supabase
+    .from('events')
+    .select('id, status, onboarding_step, host_details, event_types (key)')
+    .eq('id', eventId)
+    .maybeSingle();
+
+  if (error || !data) return { draft: null, message: 'Event not found' };
+  if (data.status !== 'draft') {
+    return { draft: null, message: 'This event has already been created' };
+  }
+  return { draft: data, message: null };
+}
+
+async function resolveEventTypeId(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  eventTypeKey: EventTypeKey,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('event_types')
+    .select('id')
+    .eq('key', eventTypeKey)
+    .single();
+
+  if (error || !data) {
+    console.error('Error resolving event type:', eventTypeKey, error);
+    return null;
+  }
+  return data.id;
+}
+
+/**
+ * Creates the Draft Event, or retypes the existing one.
+ *
+ * Picking a type is the first answer, and the point from which the event
+ * exists. Going back and picking a different type retypes the draft in place
+ * rather than starting a second one, so abandoning and returning never leaves a
+ * trail of half-events behind one user.
+ */
+export async function createDraftEvent(
+  eventType: string,
+): Promise<CreateDraftEventState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return { success: false, message: 'You must be logged in to create events' };
+    }
+
+    const parsed = EventTypeKeySchema.safeParse(eventType);
+    if (!parsed.success) {
+      return { success: false, message: 'Unknown event type' };
+    }
+
+    const supabase = await createClient();
+    const eventTypeId = await resolveEventTypeId(supabase, parsed.data);
+    if (!eventTypeId) return { success: false, message: 'Unknown event type' };
+
+    // Retype the draft in place if one is already open.
+    const { data: existing } = await supabase
+      .from('events')
+      .select('id, host_details')
+      .eq('status', 'draft')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (existing) {
+      // The title is derived from the type, so retyping has to rebuild it from
+      // whatever names were already given - otherwise a couple who backs up and
+      // switches from wedding to henna keeps a title saying "The Wedding of".
+      const locale = await getLocale();
+      const names = readHostNames(
+        existing.host_details as Record<string, unknown> | undefined,
+      );
+      const title = buildEventTitle(parsed.data, names, locale);
+
+      const { error } = await supabase
+        .from('events')
+        .update({
+          event_type_id: eventTypeId,
+          title,
+          host_details: buildHostDetails(parsed.data, names),
+        })
+        .eq('id', existing.id);
+
+      if (error) {
+        console.error('Error retyping draft event:', error);
+        return { success: false, message: 'Failed to save your choice' };
+      }
+      return { success: true, message: null, eventId: existing.id };
+    }
+
+    const { data: newEvent, error } = await supabase
+      .from('events')
+      .insert({
+        user_id: currentUser.id,
+        event_type_id: eventTypeId,
+        status: 'draft',
+        onboarding_step: 'type',
+        // title defaults to '' and event_date stays null until those screens.
+      })
+      .select('id')
+      .single();
+
+    if (error || !newEvent) {
+      console.error('Error creating draft event:', error);
+      return { success: false, message: 'Failed to create your event' };
+    }
+
+    return { success: true, message: null, eventId: newEvent.id };
+  } catch (error) {
+    console.error('Create draft event error:', error);
+    return { success: false, message: 'Failed to create your event' };
+  }
+}
+
+/**
+ * Saves the host names and regenerates the title from them.
+ *
+ * The title is never an editable field: it is built from these names every time
+ * they change, so it cannot drift from `host_details`.
+ */
+export async function setDraftNames(
+  input: unknown,
+): Promise<DraftStepState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  const parsed = DraftNamesSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: parsed.error.issues[0].message };
+  }
+  const { eventId, ...names } = parsed.data;
+
+  try {
+    const supabase = await createClient();
+    const { draft, message } = await loadDraft(supabase, eventId);
+    if (!draft) return { success: false, message };
+
+    const eventType = readEventTypeKey(draft.event_types) as
+      | EventTypeKey
+      | undefined;
+    if (!eventType) {
+      return { success: false, message: 'This event has no type yet' };
+    }
+
+    const locale = await getLocale();
+    const { error } = await supabase
+      .from('events')
+      .update({
+        title: buildEventTitle(eventType, names, locale),
+        host_details: buildHostDetails(eventType, names),
+        onboarding_step: furthestStep(draft.onboarding_step, 'names'),
+      })
+      .eq('id', eventId);
+
+    if (error) {
+      console.error('Error saving draft names:', error);
+      return { success: false, message: 'Failed to save the names' };
+    }
+    return { success: true, message: null };
+  } catch (error) {
+    console.error('Set draft names error:', error);
+    return { success: false, message: 'Failed to save the names' };
+  }
+}
+
+/**
+ * Saves the event date, or records that there is not one yet.
+ *
+ * An empty `eventDate` is the "we don't have a date yet" answer, and is as valid
+ * an answer as a date. It stores null and still advances `onboarding_step`, so
+ * resuming does not ask again.
+ */
+export async function setDraftDate(input: unknown): Promise<DraftStepState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  const parsed = DraftDateSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: parsed.error.issues[0].message };
+  }
+  const { eventId, eventDate } = parsed.data;
+
+  const trimmed = eventDate.trim();
+  if (trimmed) {
+    const asDate = new Date(trimmed);
+    if (Number.isNaN(asDate.getTime())) {
+      return { success: false, message: 'That is not a valid date' };
+    }
+    // Compared against the start of today so choosing today is allowed.
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+    if (asDate < startOfToday) {
+      return { success: false, message: 'That date has already passed' };
+    }
+  }
+
+  try {
+    const supabase = await createClient();
+    const { draft, message } = await loadDraft(supabase, eventId);
+    if (!draft) return { success: false, message };
+
+    const { error } = await supabase
+      .from('events')
+      .update({
+        event_date: trimmed || null,
+        onboarding_step: furthestStep(draft.onboarding_step, 'date'),
+      })
+      .eq('id', eventId);
+
+    if (error) {
+      console.error('Error saving draft date:', error);
+      return { success: false, message: 'Failed to save the date' };
+    }
+    return { success: true, message: null };
+  } catch (error) {
+    console.error('Set draft date error:', error);
+    return { success: false, message: 'Failed to save the date' };
+  }
+}
+
+/**
+ * Saves the venue, or records that one has not been booked.
+ *
+ * As with the date, omitting the location is an answer rather than a gap.
+ */
+export async function setDraftLocation(
+  input: unknown,
+): Promise<DraftStepState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  const parsed = DraftLocationSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: parsed.error.issues[0].message };
+  }
+  const { eventId, location } = parsed.data;
+
+  try {
+    const supabase = await createClient();
+    const { draft, message } = await loadDraft(supabase, eventId);
+    if (!draft) return { success: false, message };
+
+    const { error } = await supabase
+      .from('events')
+      .update({
+        location: location ?? null,
+        onboarding_step: furthestStep(draft.onboarding_step, 'venue'),
+      })
+      .eq('id', eventId);
+
+    if (error) {
+      console.error('Error saving draft location:', error);
+      return { success: false, message: 'Failed to save the venue' };
+    }
+    return { success: true, message: null };
+  } catch (error) {
+    console.error('Set draft location error:', error);
+    return { success: false, message: 'Failed to save the venue' };
+  }
+}
+
+/**
+ * Saves the guest-record estimate from the slider.
+ *
+ * Only the count is stored. The channel the couple toyed with, and the price it
+ * implied, are deliberately not saved - that choice is re-made at payment time
+ * and is not a commitment here.
+ */
+export async function setDraftEstimate(
+  input: unknown,
+): Promise<DraftStepState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  const parsed = DraftEstimateSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, message: parsed.error.issues[0].message };
+  }
+  const { eventId, guestsEstimate } = parsed.data;
+
+  try {
+    const supabase = await createClient();
+    const { draft, message } = await loadDraft(supabase, eventId);
+    if (!draft) return { success: false, message };
+
+    const { error } = await supabase
+      .from('events')
+      .update({
+        guests_estimate: guestsEstimate,
+        onboarding_step: furthestStep(draft.onboarding_step, 'estimate'),
+      })
+      .eq('id', eventId);
+
+    if (error) {
+      console.error('Error saving draft estimate:', error);
+      return { success: false, message: 'Failed to save the estimate' };
+    }
+    return { success: true, message: null };
+  } catch (error) {
+    console.error('Set draft estimate error:', error);
+    return { success: false, message: 'Failed to save the estimate' };
+  }
+}
+
+/**
+ * Completes onboarding: the Draft Event becomes a real one.
+ *
+ * This is the only way out of the draft state, and the point at which the event
+ * gains a workspace and appears in the event switcher.
+ */
+export async function publishDraftEvent(
+  eventId: string,
+): Promise<DraftStepState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return { success: false, message: 'You must be logged in' };
+    }
+
+    const supabase = await createClient();
+    const { draft, message } = await loadDraft(supabase, eventId);
+    if (!draft) return { success: false, message };
+
+    const { error } = await supabase
+      .from('events')
+      .update({ status: 'published', is_default: true })
+      .eq('id', eventId);
+
+    if (error) {
+      console.error('Error publishing draft event:', error);
+      return { success: false, message: 'Failed to finish creating your event' };
+    }
+
+    // The freshly published event becomes the one the app opens by default.
+    await supabase
+      .from('events')
+      .update({ is_default: false })
+      .eq('user_id', currentUser.id)
+      .neq('id', eventId);
+
+    revalidatePath('/app');
+    revalidatePath(`/app/${eventId}/dashboard`);
+
+    return { success: true, message: null };
+  } catch (error) {
+    console.error('Publish draft event error:', error);
+    return { success: false, message: 'Failed to finish creating your event' };
+  }
+}
+
+/**
+ * Discards an abandoned Draft Event.
+ *
+ * Not part of the flow itself - onboarding never deletes what the couple
+ * answered. This exists for the back office, where an abandoned draft is a
+ * record of interest someone may decide to clear.
+ */
+export async function discardDraftEvent(
+  eventId: string,
+): Promise<DraftStepState> {
+  const blocked = await assertNotImpersonating();
+  if (blocked) return { success: false, message: blocked };
+
+  try {
+    const supabase = await createClient();
+    const { draft, message } = await loadDraft(supabase, eventId);
+    if (!draft) return { success: false, message };
+
+    const { error } = await supabase.from('events').delete().eq('id', eventId);
+    if (error) {
+      console.error('Error discarding draft event:', error);
+      return { success: false, message: 'Failed to discard the draft' };
+    }
+
+    revalidatePath('/app');
+    return { success: true, message: null };
+  } catch (error) {
+    console.error('Discard draft event error:', error);
+    return { success: false, message: 'Failed to discard the draft' };
+  }
+}

--- a/src/features/events/actions/duplicate-event.ts
+++ b/src/features/events/actions/duplicate-event.ts
@@ -47,7 +47,10 @@ export async function duplicateEvent(
       .insert({
         ...eventFields,
         title: `Copy of ${originalEvent.title}`,
-        status: 'draft',
+        // A copy of a finished event is itself finished - it inherits every
+        // answer. 'draft' would strip the copy of its workspace and hide it
+        // from the event switcher.
+        status: 'published',
         is_default: false,
       })
       .select('id')

--- a/src/features/events/actions/events.ts
+++ b/src/features/events/actions/events.ts
@@ -94,7 +94,11 @@ export async function createEvent(formData: FormData): Promise<CreateEventState>
         title,
         event_date: eventDate,
         event_type_id: eventTypeId,
-        status: 'draft',
+        // Published, not draft: this path creates a complete event in one
+        // insert. 'draft' now means onboarding is unfinished, and such an event
+        // has no workspace and is hidden from the event switcher.
+        status: 'published',
+        onboarding_step: 'estimate',
         is_default: true,
       })
       .select('id')
@@ -223,7 +227,10 @@ export async function createOnboardingEvent(
         title,
         event_date: eventDate,
         event_type_id: eventTypeId,
-        status: 'draft',
+        // See createEvent: this wizard writes once, at the end, so what it
+        // creates is a finished event rather than a Draft Event.
+        status: 'published',
+        onboarding_step: 'estimate',
         is_default: true,
         host_details: hostDetails,
         location: location ?? null,

--- a/src/features/events/actions/index.ts
+++ b/src/features/events/actions/index.ts
@@ -13,6 +13,18 @@ export {
 
 export type { CreateOnboardingEventState } from '../schemas';
 
+export {
+  createDraftEvent,
+  setDraftNames,
+  setDraftDate,
+  setDraftLocation,
+  setDraftEstimate,
+  publishDraftEvent,
+  discardDraftEvent,
+} from './draft-event';
+
+export type { CreateDraftEventState, DraftStepState } from '../schemas';
+
 export { duplicateEvent, type DuplicateEventState } from './duplicate-event';
 
 export { updateEventLandingTemplate, type UpdateLandingTemplateState } from './landing-template';

--- a/src/features/events/components/event-details/date-time-card.tsx
+++ b/src/features/events/components/event-details/date-time-card.tsx
@@ -35,7 +35,10 @@ const DateTimeCardSchema = EventDetailsUpdateSchema.pick({
 });
 type DateTimeCardValues = z.infer<typeof DateTimeCardSchema>;
 
-function formatEventDate(dateStr: string | undefined, locale: string): string {
+function formatEventDate(
+  dateStr: string | null | undefined,
+  locale: string,
+): string {
   if (!dateStr) return '—';
   return new Date(dateStr).toLocaleDateString(locale, {
     weekday: 'long',

--- a/src/features/events/index.ts
+++ b/src/features/events/index.ts
@@ -3,3 +3,19 @@
 
 export * from './schemas';
 export * from './actions';
+export * from './types';
+
+// Pure helpers, safe for client bundles. Queries stay out of this barrel and
+// are imported from '@/features/events/queries' directly.
+export {
+  buildEventTitle,
+  buildHostDetails,
+  readEventTypeKey,
+  readHostNames,
+  type EventHostNames,
+} from './utils/event-title';
+export {
+  ONBOARDING_STEPS,
+  resolveResumeStep,
+  hasAnswered,
+} from './utils/onboarding-progress';

--- a/src/features/events/queries/events.ts
+++ b/src/features/events/queries/events.ts
@@ -2,6 +2,9 @@
 
 import { getEffectiveClient } from '@/lib/supabase/admin';
 import { DbToAppTransformerSchema, type EventApp } from '../schemas';
+import { readEventTypeKey, readHostNames } from '../utils/event-title';
+import { hasAnswered, resolveResumeStep } from '../utils/onboarding-progress';
+import type { DraftEventResume } from '../types';
 
 export async function getEventById(eventId: string): Promise<EventApp | null> {
   const { supabase } = await getEffectiveClient();
@@ -25,8 +28,13 @@ export async function getEventById(eventId: string): Promise<EventApp | null> {
 }
 
 /**
- * Fetches the latest event created by the current user.
- * @returns The most recently created event, or null if no events exist or user is not authenticated.
+ * Fetches the latest published event created by the current user.
+ *
+ * Drafts are excluded: a Draft Event is not a workspace and opening one would
+ * land the user on a dashboard for an event that may have no date. `/app` looks
+ * for a draft separately, via `getDraftEvent`, and routes back into onboarding.
+ *
+ * @returns The most recently created published event, or null if there is none.
  */
 export async function getLastUserEvent(): Promise<EventApp | null> {
   try {
@@ -35,6 +43,7 @@ export async function getLastUserEvent(): Promise<EventApp | null> {
     let query = supabase
       .from('events')
       .select('*, event_types (key)')
+      .eq('status', 'published')
       .order('created_at', { ascending: false })
       .limit(1);
 
@@ -62,10 +71,20 @@ export async function getLastUserEvent(): Promise<EventApp | null> {
   }
 }
 
+/**
+ * Every event the user can open.
+ *
+ * Backs the event switcher, so drafts are excluded - a Draft Event does not
+ * appear there and cannot be opened.
+ */
 export async function getAllUserEvents(): Promise<EventApp[]> {
   const { supabase, impersonation } = await getEffectiveClient();
 
-  let query = supabase.from('events').select('*, event_types (key)').order('created_at', { ascending: false });
+  let query = supabase
+    .from('events')
+    .select('*, event_types (key)')
+    .eq('status', 'published')
+    .order('created_at', { ascending: false });
 
   if (impersonation) {
     query = query.eq('user_id', impersonation.userId);
@@ -78,4 +97,59 @@ export async function getAllUserEvents(): Promise<EventApp[]> {
   }
 
   return data.map((event) => DbToAppTransformerSchema.parse(event));
+}
+
+/**
+ * The user's open Draft Event, if they have one.
+ *
+ * There is at most one: picking an event type retypes an existing draft rather
+ * than opening a second. Returns everything the takeover needs to resume -
+ * the answers so far, and the question to open on.
+ */
+export async function getDraftEvent(): Promise<DraftEventResume | null> {
+  try {
+    const { supabase, impersonation } = await getEffectiveClient();
+
+    let query = supabase
+      .from('events')
+      .select(
+        'id, title, event_date, location, guests_estimate, host_details, onboarding_step, event_types (key)',
+      )
+      .eq('status', 'draft')
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    if (impersonation) {
+      query = query.eq('user_id', impersonation.userId);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error) {
+      console.error('Error fetching draft event:', error);
+      return null;
+    }
+    if (!data) return null;
+
+    const names = readHostNames(
+      data.host_details as Record<string, unknown> | undefined,
+    );
+    const location = data.location as { name?: string } | null;
+
+    return {
+      eventId: data.id,
+      eventType: readEventTypeKey(data.event_types) ?? '',
+      title: data.title ?? '',
+      ...names,
+      eventDate: data.event_date ?? null,
+      answeredDate: hasAnswered(data.onboarding_step, 'date'),
+      locationName: location?.name || undefined,
+      answeredVenue: hasAnswered(data.onboarding_step, 'venue'),
+      guestsEstimate: data.guests_estimate ?? undefined,
+      resumeAt: resolveResumeStep(data.onboarding_step),
+    };
+  } catch (error) {
+    console.error('Error in getDraftEvent:', error);
+    return null;
+  }
 }

--- a/src/features/events/queries/index.ts
+++ b/src/features/events/queries/index.ts
@@ -1,5 +1,10 @@
 // Event queries
 // This file provides a clean API for importing event-related queries
 
-export { getLastUserEvent, getEventById, getAllUserEvents } from './events';
+export {
+  getLastUserEvent,
+  getEventById,
+  getAllUserEvents,
+  getDraftEvent,
+} from './events';
 

--- a/src/features/events/schemas/index.ts
+++ b/src/features/events/schemas/index.ts
@@ -98,8 +98,17 @@ export const GuestExperienceDbSchema = z.object({
 export type GuestExperienceDb = z.infer<typeof GuestExperienceDbSchema>;
 
 // --- Guests Estimate Schema ---
-export const GuestsEstimateSchema = z.enum(['up_to_100', '100_200', '200_350', '350_plus']);
+// Roughly how many guest records the owner expects, from the onboarding slider.
+// A guess, not a limit - nothing enforces it.
+export const GuestsEstimateSchema = z.number().int().positive();
 export type GuestsEstimate = z.infer<typeof GuestsEstimateSchema>;
+
+// Bounds of the onboarding slider. Exported so the estimate screen and anything
+// clamping a stored value read the same numbers.
+export const GUESTS_ESTIMATE_MIN = 50;
+export const GUESTS_ESTIMATE_MAX = 800;
+export const GUESTS_ESTIMATE_STEP = 10;
+export const GUESTS_ESTIMATE_DEFAULT = 300;
 
 // --- 1. The "Canonical" App-Level Schema ---
 // This is the SINGLE SOURCE OF TRUTH for what an "Event" object
@@ -109,12 +118,14 @@ export type GuestsEstimate = z.infer<typeof GuestsEstimateSchema>;
 export const EventAppSchema = z.object({
   id: z.uuid(),
   userId: z.uuid(),
-  title: z
-    .string()
-    .min(2, 'Title must be at least 2 characters')
-    .max(200, 'Title is too long'),
+  // No minimum: a Draft Event exists before the names are known, and the row
+  // defaults to an empty title until the names screen generates one.
+  title: z.string().max(200, 'Title is too long'),
   description: z.string().optional(),
-  eventDate: z.string(),
+  // Null until the date question is answered, and permanently null for events
+  // whose owner said they do not have a date yet. Anything derived from it -
+  // countdowns, schedule offsets - is undefined for those events.
+  eventDate: z.string().nullable(),
   eventType: z.string().optional(),
   receptionTime: z.string().optional(),
   ceremonyTime: z.string().optional(),
@@ -163,7 +174,7 @@ export const EventDbSchema = z.object({
   user_id: z.uuid(),
   title: z.string(),
   description: z.string().optional().nullable(),
-  event_date: z.string(),
+  event_date: z.string().nullable(),
   event_type_id: z.uuid().optional().nullable(),
   // Joined from event_types when the query selects it
   event_types: z.object({ key: z.string() }).optional().nullable(),
@@ -198,7 +209,7 @@ export function dbToAppTransformer(dbData: {
   user_id: string;
   title: string;
   description?: string | null;
-  event_date: string;
+  event_date: string | null;
   event_type_id?: string | null;
   event_types?: { key: string } | null;
   reception_time?: string | null;
@@ -250,7 +261,7 @@ export function dbToAppTransformer(dbData: {
     userId: dbData.user_id,
     title: dbData.title,
     description: dbData.description ?? undefined,
-    eventDate: dbData.event_date,
+    eventDate: dbData.event_date ?? null,
     eventType: dbData.event_types?.key ?? undefined,
     receptionTime: dbData.reception_time ?? undefined,
     ceremonyTime: dbData.ceremony_time ?? undefined,
@@ -336,13 +347,28 @@ export type CreateEventState = {
   eventId?: string | null;
 };
 
-// --- 6. Event Onboarding Schema ---
+// --- 6. Event Onboarding Schemas ---
+
+export const EventTypeKeySchema = z.enum([
+  'wedding',
+  'henna',
+  'bar_mitzva',
+  'bat_mitzva',
+]);
+
+export type EventTypeKey = z.infer<typeof EventTypeKeySchema>;
+
+/** Wedding and henna are hosted by two people; the mitzvas by one. */
+export function isCoupleEvent(eventType: EventTypeKey): boolean {
+  return eventType === 'wedding' || eventType === 'henna';
+}
+
 export const EventOnboardingSchema = z.object({
-  eventType: z.enum(['wedding', 'henna', 'bar_mitzva', 'bat_mitzva']),
+  eventType: EventTypeKeySchema,
   brideName: z.string().optional(),
   groomName: z.string().optional(),
   childName: z.string().optional(),
-  eventDate: z.string().min(1, 'Event date is required'),
+  eventDate: z.string().optional(),
   location: LocationSchema.optional(),
   guestsEstimate: GuestsEstimateSchema.optional(),
   pricingPlan: z.enum(['tier_100', 'tier_200', 'tier_300', 'tier_400']).optional(),
@@ -351,6 +377,56 @@ export const EventOnboardingSchema = z.object({
 export type EventOnboarding = z.infer<typeof EventOnboardingSchema>;
 
 export type CreateOnboardingEventState = {
+  success: boolean;
+  message?: string | null;
+  eventId?: string | null;
+};
+
+// --- 7. Draft Event step schemas ---
+// One schema per onboarding question. Each patches the Draft Event created at
+// the type screen, so every field beyond the id is what that one screen asked
+// for. See docs/adr/0003-events-exist-before-they-are-complete.md.
+
+export const DraftNamesSchema = z
+  .object({
+    eventId: z.uuid(),
+    brideName: z.string().trim().max(100).optional(),
+    groomName: z.string().trim().max(100).optional(),
+    childName: z.string().trim().max(100).optional(),
+  })
+  .refine((v) => !!(v.brideName || v.groomName || v.childName), {
+    message: 'At least one name is required',
+    path: ['brideName'],
+  });
+
+export const DraftDateSchema = z.object({
+  eventId: z.uuid(),
+  // Empty string is the explicit "we don't have a date yet" answer, which is a
+  // real answer and stores null - not the same as never having reached this
+  // screen, which the resume logic tells apart via answeredSteps.
+  eventDate: z.string(),
+});
+
+export const DraftLocationSchema = z.object({
+  eventId: z.uuid(),
+  location: LocationSchema.optional(),
+});
+
+export const DraftEstimateSchema = z.object({
+  eventId: z.uuid(),
+  guestsEstimate: z
+    .number()
+    .int()
+    .min(GUESTS_ESTIMATE_MIN)
+    .max(GUESTS_ESTIMATE_MAX),
+});
+
+export type DraftStepState = {
+  success: boolean;
+  message?: string | null;
+};
+
+export type CreateDraftEventState = {
   success: boolean;
   message?: string | null;
   eventId?: string | null;

--- a/src/features/events/types.ts
+++ b/src/features/events/types.ts
@@ -1,0 +1,33 @@
+/**
+ * TypeScript-only types for the events feature. Zod lives in `schemas/`.
+ */
+
+/**
+ * A question in the onboarding takeover, in the order it is asked.
+ *
+ * Stored on the event as the furthest step answered, where skipping a question
+ * ("we don't have a date yet") counts as answering it.
+ */
+export type OnboardingStep = 'type' | 'names' | 'date' | 'venue' | 'estimate';
+
+/**
+ * What the takeover needs to resume a Draft Event: the answers already given,
+ * and the question to open on.
+ */
+export type DraftEventResume = {
+  eventId: string;
+  eventType: string;
+  /** Empty while the names screen is unanswered. */
+  title: string;
+  brideName?: string;
+  groomName?: string;
+  childName?: string;
+  /** Null both before the date screen and after "no date yet" - `answeredDate` tells them apart. */
+  eventDate: string | null;
+  answeredDate: boolean;
+  locationName?: string;
+  answeredVenue: boolean;
+  guestsEstimate?: number;
+  /** The question to open on: the first one not yet answered. */
+  resumeAt: OnboardingStep;
+};

--- a/src/features/events/utils/event-title.ts
+++ b/src/features/events/utils/event-title.ts
@@ -1,0 +1,125 @@
+import { isCoupleEvent, type EventTypeKey } from '../schemas';
+
+/**
+ * Names as the couple typed them on the names screen.
+ *
+ * A couple event uses `bride`/`groom`; a mitzva uses `child`. Passing the wrong
+ * pair for the type is not an error - the unused ones are ignored - because the
+ * names screen keeps whatever was typed before the type was changed.
+ */
+export type EventHostNames = {
+  brideName?: string;
+  groomName?: string;
+  childName?: string;
+};
+
+const HE = {
+  wedding: { prefix: 'החתונה של', fallback: 'החתונה שלי' },
+  henna: { prefix: 'החינה של', fallback: 'החינה שלי' },
+  bar_mitzva: { label: 'בר מצווה' },
+  bat_mitzva: { label: 'בת מצווה' },
+} as const;
+
+const EN = {
+  wedding: { prefix: 'The Wedding of', fallback: 'My Wedding' },
+  henna: { prefix: 'The Henna of', fallback: 'My Henna' },
+  bar_mitzva: { label: 'Bar Mitzva' },
+  bat_mitzva: { label: 'Bat Mitzva' },
+} as const;
+
+/**
+ * Builds the event title from the host names.
+ *
+ * The title is generated, never typed: the names screen is the only place these
+ * names are captured, and the couple never sees an editable title field. It is
+ * regenerated on every names edit, so it always agrees with `host_details`.
+ *
+ * Returns an empty string only when there is nothing to build from, which is
+ * what a Draft Event carries until the names screen is answered.
+ */
+export function buildEventTitle(
+  eventType: EventTypeKey,
+  names: EventHostNames,
+  locale: string,
+): string {
+  const t = locale === 'he' ? HE : EN;
+  const trim = (v?: string) => v?.trim() || undefined;
+
+  if (isCoupleEvent(eventType)) {
+    const copy = t[eventType as 'wedding' | 'henna'];
+    const first = trim(names.brideName);
+    const second = trim(names.groomName);
+
+    if (first && second) {
+      const joined =
+        locale === 'he' ? `${first} ו${second}` : `${first} and ${second}`;
+      return `${copy.prefix} ${joined}`;
+    }
+    if (first || second) return `${copy.prefix} ${first ?? second}`;
+    return copy.fallback;
+  }
+
+  const copy = t[eventType as 'bar_mitzva' | 'bat_mitzva'];
+  const child = trim(names.childName);
+  if (!child) return copy.label;
+  return locale === 'he'
+    ? `${copy.label} של ${child}`
+    : `${child}'s ${copy.label}`;
+}
+
+/**
+ * Shapes the names into the `host_details` jsonb the rest of the app reads.
+ */
+export function buildHostDetails(
+  eventType: EventTypeKey,
+  names: EventHostNames,
+): Record<string, unknown> {
+  const trim = (v?: string) => v?.trim() || undefined;
+
+  if (isCoupleEvent(eventType)) {
+    const bride = trim(names.brideName);
+    const groom = trim(names.groomName);
+    return {
+      bride: bride ? { name: bride } : undefined,
+      groom: groom ? { name: groom } : undefined,
+    };
+  }
+
+  const child = trim(names.childName);
+  return { child: child ? { name: child } : undefined };
+}
+
+/**
+ * Pulls the event type key out of a joined `event_types` relation.
+ *
+ * PostgREST types an embedded to-one relation as an array, so the shape varies
+ * with how the row was selected; this reads either form.
+ */
+export function readEventTypeKey(relation: unknown): string | undefined {
+  const row = Array.isArray(relation) ? relation[0] : relation;
+  if (!row || typeof row !== 'object') return undefined;
+  const key = (row as { key?: unknown }).key;
+  return typeof key === 'string' ? key : undefined;
+}
+
+/**
+ * Reads the names back out of `host_details`, so a resumed onboarding can
+ * repopulate the names screen with whatever was already answered.
+ */
+export function readHostNames(
+  hostDetails: Record<string, unknown> | undefined,
+): EventHostNames {
+  if (!hostDetails) return {};
+  const nameOf = (key: string): string | undefined => {
+    const entry = hostDetails[key];
+    if (!entry || typeof entry !== 'object') return undefined;
+    const name = (entry as { name?: unknown }).name;
+    return typeof name === 'string' && name.trim() ? name : undefined;
+  };
+
+  return {
+    brideName: nameOf('bride'),
+    groomName: nameOf('groom'),
+    childName: nameOf('child'),
+  };
+}

--- a/src/features/events/utils/onboarding-progress.ts
+++ b/src/features/events/utils/onboarding-progress.ts
@@ -1,0 +1,40 @@
+import type { OnboardingStep } from '../types';
+
+/** The onboarding questions, in the order the takeover asks them. */
+export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
+  'type',
+  'names',
+  'date',
+  'venue',
+  'estimate',
+] as const;
+
+/**
+ * The question a Draft Event resumes at: the first one not yet answered.
+ *
+ * Driven by the stored `onboarding_step` rather than by which columns are
+ * filled, because skipping is an answer - "we don't have a date yet" leaves
+ * `event_date` null exactly as never reaching the screen does, and the couple
+ * should not be asked twice.
+ *
+ * A draft that answered the last question but never published resumes there, so
+ * the flow always has a screen to land on.
+ */
+export function resolveResumeStep(
+  onboardingStep: string | null | undefined,
+): OnboardingStep {
+  const answeredIdx = ONBOARDING_STEPS.indexOf(onboardingStep as OnboardingStep);
+  if (answeredIdx < 0) return 'type';
+  const next = ONBOARDING_STEPS[answeredIdx + 1];
+  return next ?? ONBOARDING_STEPS[ONBOARDING_STEPS.length - 1];
+}
+
+/** Whether a step's question has already been answered on this draft. */
+export function hasAnswered(
+  onboardingStep: string | null | undefined,
+  step: OnboardingStep,
+): boolean {
+  const answeredIdx = ONBOARDING_STEPS.indexOf(onboardingStep as OnboardingStep);
+  const stepIdx = ONBOARDING_STEPS.indexOf(step);
+  return answeredIdx >= 0 && stepIdx >= 0 && answeredIdx >= stepIdx;
+}

--- a/src/features/schedules/components/schedule-details-card.tsx
+++ b/src/features/schedules/components/schedule-details-card.tsx
@@ -28,7 +28,7 @@ import type { ScheduleApp } from '../schemas';
 
 interface ScheduleDetailsCardProps {
   schedule: ScheduleApp | undefined;
-  eventDate: string;
+  eventDate: string | null;
 }
 
 /**
@@ -99,7 +99,9 @@ export function ScheduleDetailsCard({
 
   const handleTimeChange = (value: string) => {
     const [hours, minutes] = value.split(':').map(Number);
-    const newDate = new Date(scheduledDate || eventDate);
+    // The card returns null without an event date, so the last fallback is
+    // unreachable; it is here because this runs before that guard.
+    const newDate = new Date(scheduledDate || eventDate || Date.now());
     newDate.setUTCHours(hours, minutes, 0, 0);
     setScheduledDate(newDate.toISOString());
     setScheduledTime(value);

--- a/src/features/schedules/components/schedule-tab-content.tsx
+++ b/src/features/schedules/components/schedule-tab-content.tsx
@@ -9,7 +9,7 @@ interface ScheduleTabContentProps {
   schedule: ScheduleApp;
   template: WhatsAppTemplateApp | null;
   smsBody?: string | null;
-  eventDate: string;
+  eventDate: string | null;
   event: EventApp | null;
 }
 

--- a/src/features/schedules/components/schedules-page.tsx
+++ b/src/features/schedules/components/schedules-page.tsx
@@ -25,7 +25,8 @@ import { SchedulesLayout } from './schedules-layout';
 
 interface SchedulesPageProps {
   eventId: string;
-  eventDate: string;
+  /** Null for an event with no date; every offset below is relative to it. */
+  eventDate: string | null;
   schedules: ScheduleApp[];
   event: EventApp | null;
 }

--- a/src/features/schedules/components/wizard/wizard-timeline-step.tsx
+++ b/src/features/schedules/components/wizard/wizard-timeline-step.tsx
@@ -37,7 +37,11 @@ interface WizardTimelineStepProps {
   rows: TimelineRow[];
   onRowsChange: (rows: TimelineRow[]) => void;
   targetCounts: { all: number; pending: number; confirmed: number };
-  eventDate?: string;
+  /**
+   * Null for an event with no date. Offsets are all relative to it, so the
+   * "N days before" label is simply not shown rather than computed from zero.
+   */
+  eventDate?: string | null;
 }
 
 const AUDIENCE_KEY: Record<'pending' | 'confirmed' | 'all', string> = {

--- a/src/features/schedules/services/send-schedule.ts
+++ b/src/features/schedules/services/send-schedule.ts
@@ -88,7 +88,10 @@ function mapEventRow(rawEvent: Record<string, unknown>) {
     id: rawEvent.id as string,
     userId: rawEvent.user_id as string,
     title: rawEvent.title as string,
-    eventDate: rawEvent.event_date as string,
+    // Null for an event with no date. Such an event cannot have schedules -
+    // every offset is relative to the date - so this engine should never see
+    // one, but the column is nullable and the type says so.
+    eventDate: rawEvent.event_date as string | null,
     location:
       (rawEvent.location as {
         name: string;

--- a/src/features/schedules/utils/parameter-resolvers.ts
+++ b/src/features/schedules/utils/parameter-resolvers.ts
@@ -30,7 +30,7 @@ export interface ParameterResolutionContext {
     id: string;
     userId: string;
     title: string;
-    eventDate: string;
+    eventDate: string | null;
     [key: string]: unknown; // Allow additional fields
   };
   group?: GroupApp | null;

--- a/src/features/schedules/utils/suggested-schedules.ts
+++ b/src/features/schedules/utils/suggested-schedules.ts
@@ -22,7 +22,7 @@ export type SuggestedSchedule = {
  */
 export function buildSuggestedSchedules(
   defaults: DefaultScheduleApp[],
-  eventDate: string,
+  eventDate: string | null,
 ): SuggestedSchedule[] {
   if (!eventDate) return [];
 

--- a/src/features/templates/utils.ts
+++ b/src/features/templates/utils.ts
@@ -47,7 +47,15 @@ export function buildCoupleName(
   return brideName ?? groomName ?? childName ?? eventTitle;
 }
 
-export function buildFormattedDate(eventDate: string): string {
+/**
+ * Undefined for an event with no date yet. Every template treats the date as
+ * optional and simply omits the pill, which is the honest rendering - an
+ * invitation for an undated event cannot state a date.
+ */
+export function buildFormattedDate(
+  eventDate: string | null | undefined,
+): string | undefined {
+  if (!eventDate) return undefined;
   return new Intl.DateTimeFormat('he-IL', { dateStyle: 'full' }).format(
     new Date(eventDate),
   );

--- a/supabase/migrations/20260815000000_events_exist_before_they_are_complete.sql
+++ b/supabase/migrations/20260815000000_events_exist_before_they_are_complete.sql
@@ -1,0 +1,119 @@
+-- An event row is now created the moment the couple picks an event type, and
+-- each subsequent onboarding answer patches it. See
+-- docs/adr/0003-events-exist-before-they-are-complete.md.
+--
+-- Two columns blocked that: title and event_date were both not null, and
+-- neither is known at the first screen. The date is not known until the third,
+-- and some couples never have one at all - "we don't have a date yet" is a
+-- legitimate, permanent path, not a skipped question. So event_date loses
+-- not null outright, and title gains a default so a row can exist before the
+-- names are known.
+--
+-- events.status carries the lifecycle from here on: 'draft' means onboarding is
+-- unfinished (no workspace, not in the switcher), 'published' means it is real.
+-- Until now status was written by every insert path and read by none.
+
+alter table public.events
+  alter column event_date drop not null;
+
+comment on column public.events.event_date is
+  'Null while onboarding has not reached the date question, and permanently null for events whose owner answered "no date yet". Everything derived from it - countdowns, schedule offsets - is undefined for those events rather than zero.';
+
+alter table public.events
+  alter column title set default '';
+
+comment on column public.events.status is
+  'draft = onboarding unfinished; the event is not a workspace and does not appear in the event switcher. published = onboarding completed. archived is declared by the app enum but not yet used.';
+
+-- --------------------------------------------------------------------------
+-- Backfill: every event that exists today is a finished one
+-- --------------------------------------------------------------------------
+
+-- status was vestigial until now - every insert path wrote 'draft' and nothing
+-- ever read it or moved it on. So every event in the table says 'draft' while
+-- being a complete, in-use workspace. Now that 'draft' means "no workspace",
+-- leaving them would hide every existing event from its owner and empty the
+-- event switcher. They completed the old flow, so they are published.
+update public.events
+   set status = 'published'
+ where status = 'draft';
+
+-- --------------------------------------------------------------------------
+-- onboarding_step: where a Draft Event resumes
+-- --------------------------------------------------------------------------
+
+-- A draft resumes at the first unanswered question, and the answered columns
+-- alone cannot say which that is: "we don't have a date yet" and "has not
+-- reached the date screen" both leave event_date null, and the same is true of
+-- location on the venue screen. Skipping is a real answer, so the flow records
+-- how far it got rather than inferring it.
+alter table public.events
+  add column onboarding_step text
+  check (onboarding_step is null or onboarding_step in ('type', 'names', 'date', 'venue', 'estimate'));
+
+comment on column public.events.onboarding_step is
+  'Furthest onboarding question answered, where skipping counts as answering. Read only while status = draft, to resume the takeover at the next question. Null on events created before this flow existed.';
+
+-- Events that predate this flow were all created by the single terminal insert,
+-- so every one of them answered every question.
+update public.events
+   set onboarding_step = 'estimate'
+ where onboarding_step is null;
+
+-- --------------------------------------------------------------------------
+-- guests_estimate: bucket label -> integer
+-- --------------------------------------------------------------------------
+
+-- The estimate is now a slider, which produces a number. The old text buckets
+-- map to their upper bound, matching what ESTIMATE_UPPER in
+-- hero-stat-cards.tsx already treated them as ('350_plus' had no upper bound,
+-- and 500 was the figure the progress bar used).
+alter table public.events
+  alter column guests_estimate type integer
+  using (
+    case guests_estimate
+      when 'up_to_100' then 100
+      when '100_200'   then 200
+      when '200_350'   then 350
+      when '350_plus'  then 500
+      when ''          then null
+      else nullif(regexp_replace(guests_estimate, '\D', '', 'g'), '')::integer
+    end
+  );
+
+alter table public.events
+  add constraint events_guests_estimate_positive
+  check (guests_estimate is null or guests_estimate > 0);
+
+comment on column public.events.guests_estimate is
+  'Roughly how many guest records the owner expects, from the onboarding slider. A guess, not a limit - nothing enforces it.';
+
+-- --------------------------------------------------------------------------
+-- Guard: the conversion must not have silently dropped anyone's estimate
+-- --------------------------------------------------------------------------
+
+do $$
+declare
+  v_type text;
+begin
+  select data_type into v_type
+    from information_schema.columns
+   where table_schema = 'public'
+     and table_name = 'events'
+     and column_name = 'guests_estimate';
+
+  if v_type is distinct from 'integer' then
+    raise exception 'guests_estimate is %, expected integer', v_type;
+  end if;
+
+  -- The status backfill is the destructive half of this migration: get it wrong
+  -- and existing owners lose access to their own workspace. Nothing created
+  -- before today can legitimately still be a draft.
+  if exists (select 1 from public.events where status = 'draft' and created_at < now()) then
+    raise exception 'pre-existing events left in draft status; they would vanish from the event switcher';
+  end if;
+
+  if exists (select 1 from public.events where onboarding_step is null) then
+    raise exception 'events left without an onboarding_step; their drafts could not resume';
+  end if;
+end $$;


### PR DESCRIPTION
Implements [ADR 0003](docs/adr/0003-events-exist-before-they-are-complete.md): the event row is created as soon as the couple picks an event type, and each subsequent onboarding answer patches it.

This is the DB and action layer only. **The takeover UI is not here** - the existing wizard still runs the flow, unchanged. The new UI lands in a follow-up, built from the desktop and mobile designs together.

## Schema

`20260815000000_events_exist_before_they_are_complete.sql` - **already applied to production.** It had to go first: the new code writes `onboarding_step`, so deploying this app against the old schema would break event creation. The migration is backward-compatible with the code currently live.

- `event_date` loses `NOT NULL`, `title` gains a `''` default - neither is known at the first screen
- `guests_estimate` becomes `integer` (the slider produces a number, not a bucket). All production rows were null; legacy bucket labels map to their upper bound
- `onboarding_step` records how far onboarding got

## Two things that would have broken production

**Every event in the table said `status='draft'`** while being a complete, in-use workspace - `status` was written by every insert path and read by none. Now that `draft` means "no workspace", leaving them would have hidden all 5 production events from their owners and emptied the event switcher. The migration promotes them, and guards by raising if any pre-existing row is left in draft.

**`createEvent`, `createOnboardingEvent` and `duplicateEvent` all wrote `status: 'draft'`.** The old wizard is still the live flow, so newly created events would have vanished on creation. All three now write `published`.

## Why `onboarding_step` exists

The resume rule is "the first unanswered question", and that is not derivable from the columns: "we don't have a date yet" and "hasn't reached the date screen" both leave `event_date` null, and a skipped venue has the same problem. Skipping is a real answer, so progress is recorded rather than inferred - otherwise a resumed draft asks twice.

## Dateless events

A permanent, legitimate state, so every consumer of `event.eventDate` handles null deliberately rather than rendering a zero: the countdown card, hero banner and stat cards get explicit no-date states, schedule offsets and the call plan card omit the offset, and template previews drop the date pill (they already treated it as optional).

## Also

- `getLastUserEvent` / `getAllUserEvents` filter to `published`; `/app` routes a draft back into onboarding; `[eventId]/layout.tsx` refuses to open a draft by URL
- Admin `eventCount` counts published only, with `draftCount` alongside - per the ADR, drafts would otherwise misreport
- Title generation extracted to `utils/event-title.ts` so the names screen can regenerate it

## Verification

Migration replayed from scratch via `db reset`, then separately against production-shaped seed data to prove the backfills. `tsc` and `npm run build` clean, lint 0 errors. Exercised the pure utils (24 assertions) and drove a full draft lifecycle against the local DB as an authenticated user, covering RLS and both check constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)