### PR TITLE
Fit RSVP links into fewer SMS segments

### DIFF
--- a/src/app/(main)/[locale]/c/[token]/page.tsx
+++ b/src/app/(main)/[locale]/c/[token]/page.tsx
@@ -2,10 +2,10 @@ import { ConfirmationPage } from '@/features/confirmation/components/confirmatio
 
 export const dynamic = 'force-dynamic';
 
-// Original RSVP path, superseded by /c/[token]. Links already sent out carry
-// this path and never expire, so it renders the same page rather than
-// redirecting - a redirect would cost a round trip on a guest's first tap.
-export default async function LegacyConfirmationRoute({
+// Short RSVP path. Kept terse because the full URL is embedded in SMS bodies,
+// where every character counts against the segment limit. /confirm/[token]
+// renders the same page for links sent before this path existed.
+export default async function ShortConfirmationRoute({
   params,
 }: {
   params: Promise<{ locale: string; token: string }>;

--- a/src/features/confirmation/components/confirmation-page.tsx
+++ b/src/features/confirmation/components/confirmation-page.tsx
@@ -1,0 +1,65 @@
+import {
+  getConfirmationDataByToken,
+  getConfirmationDataByGuestToken,
+  isGuestInvitationToken,
+} from '@/features/confirmation/queries';
+import { ConfirmationExperience } from '@/features/confirmation';
+import { Card, CardContent } from '@/components/ui/card';
+import { AlertCircle } from 'lucide-react';
+import { DEFAULT_TEMPLATE_ID } from '@/features/templates';
+
+import { setRequestLocale } from 'next-intl/server';
+
+// Accepts the current 12-char base62 token as well as the earlier 32- and
+// 64-hex-char formats, so links already issued keep working.
+const TOKEN_REGEX = /^[A-Za-z0-9]{12,64}$/;
+
+/**
+ * Renders the guest-facing RSVP page for a confirmation token.
+ *
+ * Server-only: pulls the service-role queries directly, so this is imported by
+ * the route files rather than re-exported through the feature barrel.
+ *
+ * Shared by both /c/[token] (current, short) and /confirm/[token] (the
+ * original path, kept alive for links already sent out).
+ */
+export async function ConfirmationPage({
+  locale,
+  token,
+}: {
+  locale: string;
+  token: string;
+}) {
+  setRequestLocale(locale);
+
+  const data = isGuestInvitationToken(token)
+    ? await getConfirmationDataByGuestToken(token)
+    : TOKEN_REGEX.test(token)
+      ? await getConfirmationDataByToken(token)
+      : null;
+
+  if (!data) {
+    return <InvalidTokenView />;
+  }
+
+  const templateId = data.event.landingTemplateId ?? DEFAULT_TEMPLATE_ID;
+  return <ConfirmationExperience token={token} data={data} templateId={templateId} />;
+}
+
+function InvalidTokenView() {
+  return (
+    <div className="min-h-screen bg-muted/30">
+      <div className="mx-auto flex max-w-md flex-col items-center gap-6 px-4 py-16">
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-8 text-center">
+            <AlertCircle className="text-destructive size-16" />
+            <h2 className="text-xl font-semibold">הקישור אינו תקין</h2>
+            <p className="text-muted-foreground">
+              הקישור שלך אינו תקין או שפג תוקפו. אנא פנה/י למארגני האירוע.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/features/guests/components/guest-actions-section.tsx
+++ b/src/features/guests/components/guest-actions-section.tsx
@@ -14,7 +14,7 @@ export function GuestActionsSection({ invitationToken }: GuestActionsSectionProp
   const [copied, setCopied] = useState(false);
 
   const handleCopyLink = () => {
-    const url = `${window.location.origin}/confirm/${invitationToken}`;
+    const url = `${window.location.origin}/c/${invitationToken}`;
     const text = `${t('copyInvitationLinkPrefix')}\n${url}`;
     navigator.clipboard.writeText(text).catch(() => {});
     setCopied(true);

--- a/src/features/schedules/actions/sms.ts
+++ b/src/features/schedules/actions/sms.ts
@@ -93,7 +93,7 @@ export function buildSmsFallbackBody(
     process.env.NEXT_PUBLIC_SITE_URL ||
     process.env.NEXT_PUBLIC_VERCEL_URL ||
     'http://localhost:3000';
-  const rsvpLink = `${siteUrl}/confirm/${confirmationToken}`;
+  const rsvpLink = `${siteUrl}/c/${confirmationToken}`;
 
   const body = DEFAULT_SMS_BODY.replace(
     '{{event_name}}',

--- a/src/features/schedules/utils/parameter-resolvers.ts
+++ b/src/features/schedules/utils/parameter-resolvers.ts
@@ -141,7 +141,7 @@ const transformers: Record<TransformerType, TransformerFunction> = {
       process.env.NEXT_PUBLIC_SITE_URL ||
       process.env.NEXT_PUBLIC_VERCEL_URL ||
       'http://localhost:3000';
-    return `${siteUrl}/confirm/${token}`;
+    return `${siteUrl}/c/${token}`;
   },
 
   phoneNumber: (value: unknown) => {

--- a/src/features/schedules/utils/send-helpers.ts
+++ b/src/features/schedules/utils/send-helpers.ts
@@ -244,9 +244,30 @@ export function buildDeliveryRecord(
 
 // ─── Token generator ──────────────────────────────────────────────────────────
 
+const BASE62_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const TOKEN_LENGTH = 12;
+
+// Largest multiple of 62 that fits in a byte. Bytes at or above it are
+// discarded rather than folded, since 256 is not a multiple of 62 and plain
+// modulo would over-represent the first 8 characters of the alphabet.
+const BASE62_REJECTION_THRESHOLD = 248;
+
 export function generateConfirmationToken(): string {
-  // 16 bytes (128 bits) is comfortably unguessable for an RSVP link - same
-  // order of entropy as a v4 UUID - while keeping the SMS-embedded link
-  // shorter than the original 32-byte token.
-  return randomBytes(16).toString('hex');
+  // 12 base62 characters is ~71 bits - unreachable by online guessing even
+  // with millions of live tokens - while keeping the SMS-embedded link short.
+  // Alphanumeric only (no - or _), which SMS clients autolink most reliably.
+  // Tokens already sent out were 32 hex characters, and originally 64; both
+  // still resolve, since lookup is an exact match on the stored value.
+  let token = '';
+
+  while (token.length < TOKEN_LENGTH) {
+    for (const byte of randomBytes(TOKEN_LENGTH)) {
+      if (byte >= BASE62_REJECTION_THRESHOLD) continue;
+      token += BASE62_ALPHABET[byte % 62];
+      if (token.length === TOKEN_LENGTH) break;
+    }
+  }
+
+  return token;
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -51,6 +51,10 @@ export async function updateSession(request: NextRequest, effectivePath?: string
     !strippedPath.startsWith('/auth') &&
     !strippedPath.startsWith('/error') &&
     !strippedPath.startsWith('/confirm') &&
+    // Exact segment match - a bare startsWith('/c') would open up every route
+    // beginning with c, /collaborate among them
+    strippedPath !== '/c' &&
+    !strippedPath.startsWith('/c/') &&
     !strippedPath.startsWith('/invitations') &&
     !strippedPath.startsWith('/privacy') &&
     !strippedPath.startsWith('/nav')


### PR DESCRIPTION
Confirmation tokens drop from 32 hex chars to 12 base62 (~71 bits, still far beyond online guessing), and the RSVP path shortens from /confirm to /c - 26 characters saved per message, which matters most in Hebrew where UCS-2 caps a segment at 70 characters.

Both old paths and old token formats keep resolving: /confirm/[token] renders the same page rather than redirecting, so links already sent cost guests no extra round trip. The WhatsApp templates pass the bare token to a Meta-hosted button URL, so they pick up the short token automatically and keep working on /confirm until that base URL is edited in WhatsApp Manager.