### PR TITLE
Verify auth locally instead of per request

### DIFF
--- a/src/features/auth/queries/auth.ts
+++ b/src/features/auth/queries/auth.ts
@@ -1,9 +1,13 @@
+import { cache } from 'react';
 import { createClient } from '@/lib/supabase/server';
 import { getImpersonation } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
 import type { User, ProfileData } from '../schemas';
 
-export async function getUserProfile(): Promise<ProfileData | null> {
+// Wrapped with React cache() so a single render resolves the auth call once,
+// however many server components ask for it - the same reason getImpersonation
+// and assertAdmin are cached in @/lib/supabase/admin.
+export const getUserProfile = cache(async function getUserProfile(): Promise<ProfileData | null> {
   try {
     const supabase = await createClient();
 
@@ -38,7 +42,7 @@ export async function getUserProfile(): Promise<ProfileData | null> {
   } catch {
     return null;
   }
-}
+});
 
 export async function getEffectiveUser(): Promise<User | null> {
   try {
@@ -79,7 +83,7 @@ export async function getEffectiveUser(): Promise<User | null> {
   }
 }
 
-export async function getCurrentUser(): Promise<User | null> {
+export const getCurrentUser = cache(async function getCurrentUser(): Promise<User | null> {
   try {
     const supabase = await createClient();
 
@@ -109,4 +113,4 @@ export async function getCurrentUser(): Promise<User | null> {
     console.error('Get current user error:', error);
     return null;
   }
-}
+});

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -27,14 +27,22 @@ export async function updateSession(request: NextRequest, effectivePath?: string
     },
   });
 
-  // IMPORTANT: DO NOT REMOVE auth.getUser()
+  // IMPORTANT: DO NOT REMOVE auth.getClaims(). It is what refreshes the session
+  // cookie; without it users get randomly logged out under server-side rendering.
+  //
+  // getClaims rather than getUser: this runs on every request the matcher
+  // catches, RSC prefetches included, so a single navigation used to fire ~18
+  // calls to /auth/v1/user - 88% of the project's auth traffic - each one a
+  // blocking round trip before the page could render. The project signs JWTs
+  // with an asymmetric key (ES256), so getClaims verifies the token locally via
+  // WebCrypto against a cached JWKS and only reaches the network to refresh.
+  // It still verifies cryptographically, so the guards below are as safe as
+  // they were with getUser.
 
-  let user = null;
+  let userId: string | null = null;
   try {
-    const {
-      data: { user: userData },
-    } = await supabase.auth.getUser();
-    user = userData;
+    const { data } = await supabase.auth.getClaims();
+    userId = data?.claims.sub ?? null;
   } catch (error) {
     console.error('Error getting user from Supabase:', error);
   }
@@ -45,7 +53,7 @@ export async function updateSession(request: NextRequest, effectivePath?: string
   const strippedPath = rawPath.replace(/^\/en/, '') || '/';
 
   if (
-    !user &&
+    !userId &&
     strippedPath !== '/' &&
     !strippedPath.startsWith('/login') &&
     !strippedPath.startsWith('/auth') &&
@@ -66,11 +74,11 @@ export async function updateSession(request: NextRequest, effectivePath?: string
   }
 
   // Guard /admin routes: require is_admin = true on the user's profile
-  if (user && strippedPath.startsWith('/admin')) {
+  if (userId && strippedPath.startsWith('/admin')) {
     const { data: profile } = await supabase
       .from('profiles')
       .select('is_admin')
-      .eq('id', user.id)
+      .eq('id', userId)
       .single();
 
     if (!profile?.is_admin) {


### PR DESCRIPTION
The proxy ran auth.getUser() on every request the matcher caught, RSC prefetches included, so one navigation cost ~20 blocking round trips to /auth/v1/user - 58% of the project's API traffic, 88% of it from the proxy alone. The project signs JWTs with an asymmetric key, so getClaims() verifies locally via WebCrypto against a cached JWKS and only reaches the network to refresh. It still verifies cryptographically, so the guards are as safe as they were.

getCurrentUser and getUserProfile get React cache() for the same reason getImpersonation and assertAdmin already have it: one render should resolve the auth call once, however many server components ask.

Measured per authenticated request against the local stack: /en/app 1 -> 0 auth calls, /en/app/{eventId}/guests 2 -> 1.


Claude-Session: https://claude.ai/code/session_01An6vysjyt2M57h2gzUjWg6