### PR TITLE
Assign guests to tables from the guest form

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -433,7 +433,17 @@
       "adding": "Adding...",
       "phoneInvalid": "Must be a valid Israeli mobile number (e.g. 054-1234567)",
       "side": "Side",
-      "noSide": "No side"
+      "noSide": "No side",
+      "table": {
+        "label": "Table",
+        "placeholder": "No table",
+        "searchPlaceholder": "Search or type a table number",
+        "empty": "No tables found",
+        "none": "No table",
+        "tableNumber": "Table {number}",
+        "create": "Create table {number}",
+        "createError": "Could not create the table"
+      }
     },
     "rsvp": {
       "pending": "Pending",
@@ -467,6 +477,8 @@
       "phone": "Phone",
       "group": "Group",
       "side": "Side",
+      "tableColumn": "Table",
+      "tableNumber": "Table {number}",
       "rsvpStatus": "RSVP Status",
       "dietaryRestrictions": "Dietary Restrictions",
       "dietaryNone": "None",
@@ -1277,6 +1289,8 @@
       "title": "Guest Experience",
       "lockGuestCount": "Lock Attendance Count",
       "lockGuestCountDescription": "Guests won't be able to change the number of seats assigned to their invitation",
+      "sendTableNumbers": "Send table numbers",
+      "sendTableNumbersDescription": "Guests will receive their table number in the event reminder",
       "specialMealSelection": "Special Meal Selection",
       "specialMealSelectionDescription": "Ask guests to choose a meal option",
       "specialMealsLabel": "Special Meal Options",

--- a/messages/he.json
+++ b/messages/he.json
@@ -433,7 +433,17 @@
       "adding": "מוסיף...",
       "phoneInvalid": "יש להזין מספר נייד ישראלי תקין (למשל 054-1234567)",
       "side": "צד",
-      "noSide": "ללא צד"
+      "noSide": "ללא צד",
+      "table": {
+        "label": "שולחן",
+        "placeholder": "ללא שולחן",
+        "searchPlaceholder": "חפש או הקלד מספר שולחן",
+        "empty": "לא נמצאו שולחנות",
+        "none": "ללא שולחן",
+        "tableNumber": "שולחן {number}",
+        "create": "צור שולחן {number}",
+        "createError": "יצירת השולחן נכשלה"
+      }
     },
     "rsvp": {
       "pending": "ממתין",
@@ -467,6 +477,8 @@
       "phone": "טלפון",
       "group": "קבוצה",
       "side": "צד",
+      "tableColumn": "שולחן",
+      "tableNumber": "שולחן {number}",
       "rsvpStatus": "סטטוס אישור",
       "dietaryRestrictions": "הגבלות תזונה",
       "dietaryNone": "ללא",
@@ -1277,6 +1289,8 @@
       "title": "חוויית האורח",
       "lockGuestCount": "נעל מספר מוזמנים",
       "lockGuestCountDescription": "האורחים לא יוכלו לשנות את מספר המקומות שנקבע להם בהזמנה",
+      "sendTableNumbers": "שליחת מספר שולחן",
+      "sendTableNumbersDescription": "המוזמנים יקבלו את מספר השולחן שלהם בתזכורת לאירוע",
       "specialMealSelection": "בחירת מנה מיוחדת",
       "specialMealSelectionDescription": "בקש מהאורחים לבחור מנה",
       "specialMealsLabel": "מנות מיוחדות לבחירה",

--- a/src/app/(main)/[locale]/app/[eventId]/guests/page.tsx
+++ b/src/app/(main)/[locale]/app/[eventId]/guests/page.tsx
@@ -7,6 +7,7 @@ import { getEventGroupsWithGuests } from '@/features/guests/queries/groups';
 import { GuestsPage as GuestsPageComponent } from '@/features/guests';
 import { getEventById } from '@/features/events/queries';
 import { getCurrentUser } from '@/features/auth/queries';
+import { getEventTableOptions } from '@/features/seating/queries';
 
 export default async function GuestsPage({
   params,
@@ -14,13 +15,22 @@ export default async function GuestsPage({
   params: Promise<{ eventId: string }>;
 }) {
   const { eventId } = await params;
-  const [guests, groups, existingPhones, event, currentUser, initialInvitedIds] = await Promise.all([
+  const [
+    guests,
+    groups,
+    existingPhones,
+    event,
+    currentUser,
+    initialInvitedIds,
+    tables,
+  ] = await Promise.all([
     getEventGuestsWithGroups(eventId),
     getEventGroupsWithGuests(eventId),
     getEventGuestPhones(eventId),
     getEventById(eventId),
     getCurrentUser(),
     getGuestsWithInitialInvitation(eventId),
+    getEventTableOptions(eventId),
   ]);
 
   const showDietary = event?.guestExperience?.dietaryOptions ?? false;
@@ -34,6 +44,7 @@ export default async function GuestsPage({
       groups={groups}
       existingPhones={existingPhones}
       showDietary={showDietary}
+      tables={tables}
       currentUserId={currentUser?.id ?? null}
       initialInvitedGuestIds={[...initialInvitedIds]}
       capacity={capacity}

--- a/src/features/events/components/event-details/guest-experience-card.tsx
+++ b/src/features/events/components/event-details/guest-experience-card.tsx
@@ -63,6 +63,7 @@ export function GuestExperienceCard({ event }: GuestExperienceCardProps) {
         dietaryOptions: event.guestExperience?.dietaryOptions ?? false,
         dietaryTypes: event.guestExperience?.dietaryTypes ?? ['vegetarian', 'vegan', 'gluten_free', 'strictly_kosher'],
         lockGuestCount: event.guestExperience?.lockGuestCount ?? false,
+        sendTableNumbers: event.guestExperience?.sendTableNumbers ?? false,
       },
     },
   });
@@ -222,6 +223,27 @@ export function GuestExperienceCard({ event }: GuestExperienceCardProps) {
                     <ItemContent>
                       <ItemTitle>{t('lockGuestCount')}</ItemTitle>
                       <ItemDescription>{t('lockGuestCountDescription')}</ItemDescription>
+                    </ItemContent>
+                    <ItemActions>
+                      <FormControl>
+                        <Switch
+                          checked={field.value ?? false}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </ItemActions>
+                  </Item>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="guestExperience.sendTableNumbers"
+                render={({ field }) => (
+                  <Item>
+                    <ItemContent>
+                      <ItemTitle>{t('sendTableNumbers')}</ItemTitle>
+                      <ItemDescription>{t('sendTableNumbersDescription')}</ItemDescription>
                     </ItemContent>
                     <ItemActions>
                       <FormControl>

--- a/src/features/events/schemas/index.ts
+++ b/src/features/events/schemas/index.ts
@@ -84,6 +84,10 @@ export const GuestExperienceSchema = z.object({
   dietaryOptions: z.boolean().optional(),
   dietaryTypes: z.array(z.string()).optional(),
   lockGuestCount: z.boolean().optional(),
+  // Whether the event reminder carries each guest's table number. Controls
+  // message content only - the seating page and the guest form's table picker
+  // are available regardless.
+  sendTableNumbers: z.boolean().optional(),
 });
 
 export type GuestExperience = z.infer<typeof GuestExperienceSchema>;
@@ -93,6 +97,7 @@ export const GuestExperienceDbSchema = z.object({
   dietary_options: z.boolean().optional(),
   dietary_types: z.array(z.string()).optional(),
   lock_guest_count: z.boolean().optional(),
+  send_table_numbers: z.boolean().optional(),
 });
 
 export type GuestExperienceDb = z.infer<typeof GuestExperienceDbSchema>;
@@ -253,6 +258,7 @@ export function dbToAppTransformer(dbData: {
       dietaryOptions: dbData.guests_experience.dietary_options,
       dietaryTypes: dbData.guests_experience.dietary_types,
       lockGuestCount: dbData.guests_experience.lock_guest_count,
+      sendTableNumbers: dbData.guests_experience.send_table_numbers,
     }
     : undefined;
 

--- a/src/features/events/utils/event.transform.ts
+++ b/src/features/events/utils/event.transform.ts
@@ -11,6 +11,7 @@ type GuestsExperienceDb = {
   dietary_options?: boolean;
   dietary_types?: string[];
   lock_guest_count?: boolean;
+  send_table_numbers?: boolean;
 };
 
 // Type for event details update to DB
@@ -87,6 +88,7 @@ export function eventDetailsUpdateToDb(
       dietary_options: data.guestExperience.dietaryOptions,
       dietary_types: data.guestExperience.dietaryTypes,
       lock_guest_count: data.guestExperience.lockGuestCount,
+      send_table_numbers: data.guestExperience.sendTableNumbers,
     };
   }
 

--- a/src/features/guests/actions/guests.ts
+++ b/src/features/guests/actions/guests.ts
@@ -53,6 +53,10 @@ export async function upsertGuest(
     if (parsedData.side === 'null') {
       parsedData.side = null;
     }
+    // Explicit null for tableId unseats the guest
+    if (parsedData.tableId === 'null') {
+      parsedData.tableId = null;
+    }
     // Coerce boolean string from FormData
     if (parsedData.isOfflineRsvp !== undefined) {
       parsedData.isOfflineRsvp = parsedData.isOfflineRsvp === 'true';

--- a/src/features/guests/components/guest-directory.tsx
+++ b/src/features/guests/components/guest-directory.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/features/guests/components/filters';
 import { ImportGuestsDialog } from '@/features/guests/components/groups';
 import { GuestWithGroupApp, GroupInfo } from '@/features/guests/schemas';
+import type { TableOption } from '@/features/seating';
 import { useGuestFilters, GuestSortKey } from '@/features/guests/hooks';
 import { useDynamicPageSize } from '@/hooks/use-dynamic-page-size';
 import { deleteGuest, type DeleteGuestState } from '@/features/guests/actions';
@@ -42,6 +43,7 @@ interface GuestDirectoryProps {
   existingPhones: Map<string, string>;
   onSelectGuest: (guest: GuestWithGroupApp | null) => void;
   showDietary?: boolean;
+  tables?: TableOption[];
   selectedStatuses?: string[];
   onStatusToggle?: (status: string) => void;
   recentlyUpdatedGuestId?: string | null;
@@ -55,6 +57,7 @@ export function GuestDirectory({
   existingPhones,
   onSelectGuest,
   showDietary = false,
+  tables = [],
   selectedStatuses: externalStatuses,
   onStatusToggle: externalStatusToggle,
   recentlyUpdatedGuestId,
@@ -279,6 +282,7 @@ export function GuestDirectory({
             onUploadFile={() => setImportDialogOpen(true)}
             pageSize={pageSize}
             showDietary={showDietary}
+            tables={tables}
             recentlyUpdatedGuestId={recentlyUpdatedGuestId}
           />
         ) : null}

--- a/src/features/guests/components/guest-form.tsx
+++ b/src/features/guests/components/guest-form.tsx
@@ -34,6 +34,8 @@ import {
   GROUP_SIDES,
 } from '@/features/guests/schemas';
 import { GroupIcon } from './groups';
+import { GuestTableCombobox } from './guest-table-combobox';
+import type { TableOption } from '@/features/seating';
 import {
   IconAddressBook,
   IconCheck,
@@ -59,6 +61,7 @@ interface GuestFormProps {
   hideActions?: boolean;
   onPendingChange?: (pending: boolean) => void;
   showDietary?: boolean;
+  tables?: TableOption[];
   hasReceivedInitialInvitation?: boolean;
   nonOfflineCount?: number;
   capacity?: number | null;
@@ -75,6 +78,7 @@ export function GuestForm({
   hideActions = false,
   onPendingChange,
   showDietary = false,
+  tables = [],
   hasReceivedInitialInvitation = false,
   nonOfflineCount,
   capacity,
@@ -111,6 +115,7 @@ export function GuestForm({
       amount: guest?.amount || 1,
       notes: guest?.notes || '',
       side: guest?.side ?? null,
+      tableId: guest?.tableId ?? null,
       isOfflineRsvp: guest?.isOfflineRsvp ?? false,
     },
   });
@@ -133,6 +138,7 @@ export function GuestForm({
         amount: guest.amount || 1,
         notes: guest.notes || '',
         side: guest.side ?? null,
+        tableId: guest.tableId ?? null,
         isOfflineRsvp: guest.isOfflineRsvp ?? false,
       });
     }
@@ -194,7 +200,7 @@ export function GuestForm({
     }
 
     Object.entries(values).forEach(([key, value]) => {
-      if (key === 'groupId' || key === 'side') {
+      if (key === 'groupId' || key === 'side' || key === 'tableId') {
         formData.append(key, value ? String(value) : 'null');
         return;
       }
@@ -362,6 +368,22 @@ export function GuestForm({
                       ))}
                     </SelectContent>
                   </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tableId"
+              render={({ field }) => (
+                <FormItem className="col-span-2">
+                  <FormLabel>{t('form.table.label')}</FormLabel>
+                  <GuestTableCombobox
+                    eventId={eventId}
+                    tables={tables}
+                    value={field.value ?? null}
+                    onChange={field.onChange}
+                  />
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/features/guests/components/guest-table-combobox.tsx
+++ b/src/features/guests/components/guest-table-combobox.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import * as React from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { IconChevronDown, IconPlus } from '@tabler/icons-react';
+import { Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { createTable, type TableOption } from '@/features/seating';
+
+interface GuestTableComboboxProps {
+  eventId: string;
+  tables: TableOption[];
+  /** Selected table id, or null when the guest has no table */
+  value: string | null;
+  onChange: (tableId: string | null) => void;
+  disabled?: boolean;
+}
+
+const tableDisplayName = (
+  table: Pick<TableOption, 'tableNumber' | 'label'>,
+  numberLabel: (n: number) => string,
+) => (table.label ? `${numberLabel(table.tableNumber)} · ${table.label}` : numberLabel(table.tableNumber));
+
+/**
+ * Table picker for the guest form.
+ *
+ * Writes guests.table_id - the same assignment the seating canvas makes - so a
+ * host can seat a guest without opening the floor plan. Typing a number that
+ * has no table yet creates one on the spot (round, default capacity), which is
+ * why the created table persists even if the guest form is then cancelled.
+ */
+export function GuestTableCombobox({
+  eventId,
+  tables,
+  value,
+  onChange,
+  disabled = false,
+}: GuestTableComboboxProps) {
+  const t = useTranslations('guests.form.table');
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
+  const [isCreating, setIsCreating] = React.useState(false);
+  // Tables created from this combobox, kept locally so the new one is
+  // selectable immediately rather than after the page revalidates.
+  const [createdTables, setCreatedTables] = React.useState<TableOption[]>([]);
+
+  const numberLabel = React.useCallback(
+    (n: number) => t('tableNumber', { number: n }),
+    [t],
+  );
+
+  const allTables = React.useMemo(() => {
+    const byId = new Map<string, TableOption>();
+    for (const table of [...tables, ...createdTables]) byId.set(table.id, table);
+    return [...byId.values()].sort((a, b) => a.tableNumber - b.tableNumber);
+  }, [tables, createdTables]);
+
+  const selected = allTables.find((table) => table.id === value) ?? null;
+
+  // A bare number the host typed that no table claims yet
+  const typedNumber = /^\d+$/.test(search.trim())
+    ? Number(search.trim())
+    : null;
+  const canCreate =
+    typedNumber !== null &&
+    typedNumber >= 1 &&
+    typedNumber <= 999 &&
+    !allTables.some((table) => table.tableNumber === typedNumber);
+
+  const handleCreate = async () => {
+    if (typedNumber === null || isCreating) return;
+    setIsCreating(true);
+    try {
+      const formData = new FormData();
+      formData.append('tableNumber', String(typedNumber));
+      formData.append('shape', 'round');
+      formData.append('capacity', '8');
+
+      const result = await createTable(eventId, formData);
+      if (!result.success || !result.table) {
+        toast.error(result.message || t('createError'));
+        return;
+      }
+
+      const created: TableOption = {
+        id: result.table.id,
+        tableNumber: result.table.tableNumber,
+        label: result.table.label,
+        capacity: result.table.capacity,
+        seatedHeadCount: 0,
+      };
+      setCreatedTables((prev) => [...prev, created]);
+      onChange(created.id);
+      setSearch('');
+      setOpen(false);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-full justify-between font-normal"
+        >
+          <span className={cn(!selected && 'text-muted-foreground')}>
+            {selected ? tableDisplayName(selected, numberLabel) : t('placeholder')}
+          </span>
+          <IconChevronDown className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder={t('searchPlaceholder')}
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            {!canCreate && <CommandEmpty>{t('empty')}</CommandEmpty>}
+            {canCreate && (
+              <CommandGroup>
+                <CommandItem
+                  value={`create-${typedNumber}`}
+                  disabled={isCreating}
+                  onSelect={handleCreate}
+                >
+                  <IconPlus className="size-4" />
+                  {t('create', { number: typedNumber })}
+                </CommandItem>
+              </CommandGroup>
+            )}
+            <CommandGroup>
+              {value !== null && (
+                <CommandItem
+                  value="clear"
+                  onSelect={() => {
+                    onChange(null);
+                    setSearch('');
+                    setOpen(false);
+                  }}
+                >
+                  <span className="text-muted-foreground">{t('none')}</span>
+                </CommandItem>
+              )}
+              {allTables
+                .filter((table) => {
+                  const term = search.trim().toLowerCase();
+                  if (!term) return true;
+                  return (
+                    String(table.tableNumber).includes(term) ||
+                    (table.label ?? '').toLowerCase().includes(term)
+                  );
+                })
+                .map((table) => {
+                  const isFull = table.seatedHeadCount >= table.capacity;
+                  return (
+                    <CommandItem
+                      key={table.id}
+                      value={table.id}
+                      onSelect={() => {
+                        onChange(table.id);
+                        setSearch('');
+                        setOpen(false);
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          'size-4',
+                          value === table.id ? 'opacity-100' : 'opacity-0',
+                        )}
+                      />
+                      <span className="flex-1">
+                        {tableDisplayName(table, numberLabel)}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-xs tabular-nums',
+                          isFull ? 'text-destructive' : 'text-muted-foreground',
+                        )}
+                      >
+                        {table.seatedHeadCount}/{table.capacity}
+                      </span>
+                    </CommandItem>
+                  );
+                })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/features/guests/components/guests-page.tsx
+++ b/src/features/guests/components/guests-page.tsx
@@ -40,6 +40,7 @@ import {
   IconUsersGroup,
 } from '@tabler/icons-react';
 import { GuestWithGroupApp, GroupWithGuestsApp } from '../schemas';
+import type { TableOption } from '@/features/seating';
 import { useFeatureHeader } from '@/components/feature-layout';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
@@ -63,6 +64,7 @@ interface GuestsPageProps {
   groups: GroupWithGuestsApp[];
   existingPhones: Map<string, string>;
   showDietary?: boolean;
+  tables?: TableOption[];
   currentUserId?: string | null;
   initialInvitedGuestIds?: string[];
   capacity?: number | null;
@@ -101,6 +103,7 @@ export function GuestsPage({
   groups,
   existingPhones,
   showDietary = false,
+  tables = [],
   currentUserId = null,
   initialInvitedGuestIds = [],
   capacity = null,
@@ -421,6 +424,7 @@ export function GuestsPage({
               onUploadFile={() => setIsImportDialogOpen(true)}
               selectedStatuses={selectedStatuses}
               onStatusClick={handleStatCardClick}
+              tables={tables}
             />
           ) : (
             <GuestDirectory
@@ -431,6 +435,7 @@ export function GuestsPage({
               existingPhones={existingPhones}
               onSelectGuest={handleSelectGuest}
               showDietary={showDietary}
+              tables={tables}
               selectedStatuses={selectedStatuses}
               onStatusToggle={handleStatusToggle}
               recentlyUpdatedGuestId={recentlyUpdatedGuestId}
@@ -544,6 +549,7 @@ export function GuestsPage({
               hideActions
               onPendingChange={setIsSubmitting}
               showDietary={showDietary}
+              tables={tables}
               hasReceivedInitialInvitation={
                 selectedGuest
                   ? initialInvitedGuestIds.includes(selectedGuest.id)

--- a/src/features/guests/components/index.ts
+++ b/src/features/guests/components/index.ts
@@ -1,5 +1,6 @@
 export { GuestsPage } from './guests-page';
 export { GuestForm } from './guest-form';
+export { GuestTableCombobox } from './guest-table-combobox';
 export { GuestDirectory } from './guest-directory';
 export { GuestSearch } from './guest-search';
 export { GuestStats } from './guest-stats';

--- a/src/features/guests/components/mobile/guest-mobile-card.tsx
+++ b/src/features/guests/components/mobile/guest-mobile-card.tsx
@@ -20,13 +20,15 @@ import {
 import { GuestWithGroupApp } from '@/features/guests/schemas';
 import { GroupIcon } from '@/features/guests/components/groups';
 
-type TFn = (key: string) => string;
+type TFn = (key: string, values?: Record<string, string | number>) => string;
 
 interface GuestMobileCardProps {
   guest: GuestWithGroupApp;
   onSelect: (guest: GuestWithGroupApp) => void;
   onDelete: (guest: GuestWithGroupApp) => void;
   onMarkConfirmed: (guest: GuestWithGroupApp) => void;
+  /** Resolved from guest.tableId by the list - the number lives on the table row */
+  tableNumber?: number;
   t: TFn;
 }
 
@@ -48,6 +50,7 @@ export function GuestMobileCard({
   onSelect,
   onDelete,
   onMarkConfirmed,
+  tableNumber,
   t,
 }: GuestMobileCardProps) {
   const isRTL = useLocale() === 'he';
@@ -102,6 +105,11 @@ export function GuestMobileCard({
             <Badge variant="outline" className="gap-1.5">
               <GroupIcon iconName={guest.group.icon} size="sm" />
               {guest.group.name}
+            </Badge>
+          )}
+          {tableNumber !== undefined && (
+            <Badge variant="outline">
+              {t('table.tableNumber', { number: tableNumber })}
             </Badge>
           )}
         </div>

--- a/src/features/guests/components/mobile/guests-mobile.tsx
+++ b/src/features/guests/components/mobile/guests-mobile.tsx
@@ -22,6 +22,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { GuestWithGroupApp, GroupInfo } from '@/features/guests/schemas';
+import type { TableOption } from '@/features/seating';
 import { useGuestFilters } from '@/features/guests/hooks';
 import { filterAndSortGuests } from '@/features/guests/utils';
 import { GuestSearch } from '@/features/guests/components/guest-search';
@@ -41,6 +42,7 @@ interface GuestsMobileProps {
   onUploadFile: () => void;
   selectedStatuses: string[];
   onStatusClick: (status: string | null) => void;
+  tables?: TableOption[];
 }
 
 export function GuestsMobile({
@@ -52,9 +54,15 @@ export function GuestsMobile({
   onUploadFile,
   selectedStatuses,
   onStatusClick,
+  tables = [],
 }: GuestsMobileProps) {
   const t = useTranslations('guests');
   const isRTL = useLocale() === 'he';
+
+  const tableNumberById = useMemo(
+    () => new Map(tables.map((table) => [table.id, table.tableNumber])),
+    [tables],
+  );
 
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
@@ -193,6 +201,9 @@ export function GuestsMobile({
               onSelect={onSelectGuest}
               onDelete={onDeleteGuest}
               onMarkConfirmed={onMarkConfirmed}
+              tableNumber={
+                guest.tableId ? tableNumberById.get(guest.tableId) : undefined
+              }
               t={t}
             />
           ))}

--- a/src/features/guests/components/table/columns.tsx
+++ b/src/features/guests/components/table/columns.tsx
@@ -12,7 +12,7 @@ import { RowActions } from './row-actions';
 import { GroupIcon } from '../groups';
 import { IconMailOff } from '@tabler/icons-react';
 
-type TFn = (key: string) => string;
+type TFn = (key: string, values?: Record<string, string | number>) => string;
 
 const getStatusBadge = (status: GuestWithGroupApp['rsvpStatus'], t: TFn) => {
   const statusConfig = {
@@ -31,12 +31,15 @@ interface GuestColumnsOptions {
   showDietary?: boolean;
   t: TFn;
   dietaryLabelMap: Record<string, string>;
+  /** Guests carry table_id; the number lives on the table row */
+  tableNumberById?: Map<string, number>;
 }
 
 export const createGuestColumns = (
   options: GuestColumnsOptions,
 ): ColumnDef<GuestWithGroupApp>[] => {
-  const { t, dietaryLabelMap } = options;
+  const { t, dietaryLabelMap, tableNumberById = new Map<string, number>() } =
+    options;
 
   const cols: ColumnDef<GuestWithGroupApp>[] = [
     {
@@ -98,6 +101,19 @@ export const createGuestColumns = (
       },
       filterFn: (row, _id, value: string[]) => {
         return value.length === 0 || value.includes(row.original.side ?? '');
+      },
+    },
+    {
+      accessorKey: 'tableId',
+      header: () => <div>{t('table.tableColumn')}</div>,
+      cell: ({ row }) => {
+        const tableId = row.original.tableId;
+        const tableNumber = tableId ? tableNumberById.get(tableId) : undefined;
+        return tableNumber !== undefined ? (
+          <span className="text-sm">{t('table.tableNumber', { number: tableNumber })}</span>
+        ) : (
+          <span className="text-sm text-gray-400">-</span>
+        );
       },
     },
     {

--- a/src/features/guests/components/table/guests-table.tsx
+++ b/src/features/guests/components/table/guests-table.tsx
@@ -30,6 +30,7 @@ import {
 } from '@tabler/icons-react';
 import { GuestWithGroupApp, GroupSide } from '@/features/guests/schemas';
 import { useGuestsTable, GuestSortKey } from '@/features/guests/hooks';
+import type { TableOption } from '@/features/seating';
 import { cn } from '@/lib/utils';
 
 interface GuestsTableProps {
@@ -46,6 +47,7 @@ interface GuestsTableProps {
   onUploadFile?: () => void;
   pageSize?: number;
   showDietary?: boolean;
+  tables?: TableOption[];
   recentlyUpdatedGuestId?: string | null;
 }
 
@@ -63,6 +65,7 @@ export function GuestsTable({
   onUploadFile,
   pageSize,
   showDietary = false,
+  tables = [],
   recentlyUpdatedGuestId,
 }: GuestsTableProps) {
   const t = useTranslations('guests');
@@ -79,6 +82,7 @@ export function GuestsTable({
     onDeleteGuest,
     pageSize,
     showDietary,
+    tables,
   });
 
   const handleRowClick = (guest: GuestWithGroupApp) => {

--- a/src/features/guests/hooks/use-guests-table.ts
+++ b/src/features/guests/hooks/use-guests-table.ts
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-table';
 import { GuestWithGroupApp, GroupSide } from '@/features/guests/schemas';
 import { createGuestColumns } from '@/features/guests/components/table';
+import type { TableOption } from '@/features/seating';
 import { GuestSortKey } from './use-guest-filters';
 
 const RSVP_ORDER: Record<string, number> = {
@@ -34,6 +35,7 @@ interface UseGuestsTableProps {
   onDeleteGuest: (guest: GuestWithGroupApp) => void;
   pageSize?: number;
   showDietary?: boolean;
+  tables?: TableOption[];
 }
 
 export function useGuestsTable({
@@ -47,6 +49,7 @@ export function useGuestsTable({
   onDeleteGuest,
   pageSize = DEFAULT_PAGE_SIZE,
   showDietary = false,
+  tables = [],
 }: UseGuestsTableProps) {
   const t = useTranslations('guests');
 
@@ -163,11 +166,17 @@ export function useGuestsTable({
     );
   };
 
+  const tableNumberById = useMemo(
+    () => new Map(tables.map((table) => [table.id, table.tableNumber])),
+    [tables],
+  );
+
   const columns = createGuestColumns({
     onDelete: onDeleteGuest,
     showDietary,
     t,
     dietaryLabelMap,
+    tableNumberById,
   });
 
   const table = useReactTable({

--- a/src/features/seating/actions/tables.ts
+++ b/src/features/seating/actions/tables.ts
@@ -47,6 +47,9 @@ function parseFormDataAsUpsert(
   if (parsed.rotation && typeof parsed.rotation === 'string') {
     parsed.rotation = Number(parsed.rotation);
   }
+  if (parsed.tableNumber && typeof parsed.tableNumber === 'string') {
+    parsed.tableNumber = Number(parsed.tableNumber);
+  }
   // Empty label → null (use auto number as display fallback)
   if (typeof parsed.label === 'string' && parsed.label.trim() === '') {
     parsed.label = null;
@@ -118,8 +121,12 @@ export async function createTable(
       return max + 1;
     };
 
+    // An explicit number is the host's choice, so a collision is a real
+    // conflict rather than a race to retry past.
+    const hasExplicitNumber = validated.tableNumber !== undefined;
+
     let insertAttempts = 0;
-    let nextNumber = computeNextNumber();
+    let nextNumber = validated.tableNumber ?? computeNextNumber();
     while (insertAttempts < 2) {
       const { data, error } = await supabase
         .from('tables')
@@ -130,7 +137,16 @@ export async function createTable(
       if (!error) {
         const table = TableDbToAppTransformerSchema.parse(data);
         revalidatePath(`/app/${eventId}/seating`);
+        // The guests page renders the same tables in its table picker
+        revalidatePath(`/app/${eventId}/guests`);
         return { success: true, message: 'Table created', table };
+      }
+
+      if (error.code === '23505' && hasExplicitNumber) {
+        return {
+          success: false,
+          message: `Table ${nextNumber} already exists`,
+        };
       }
 
       // 23505 = unique violation on (event_id, table_number) — race; refetch and retry once

--- a/src/features/seating/index.ts
+++ b/src/features/seating/index.ts
@@ -35,6 +35,7 @@ export {
 export type {
   SeatingStatsView,
   SeatingPageData,
+  TableOption,
   TableOccupancy,
   DraggableGuestData,
   DraggableTableData,
@@ -51,6 +52,6 @@ export { tableOccupancy, rsvpSortKey } from './utils/occupancy';
 export { groupColor, type SeatColor } from './utils/group-color';
 export { nextFreePosition } from './utils/auto-place';
 
-// Note: getEventTables and getSeatingPageData are exported from
-// '@/features/seating/queries' to avoid importing server-only code into
-// client components
+// Note: getEventTables, getEventTableOptions and getSeatingPageData are
+// exported from '@/features/seating/queries' to avoid importing server-only
+// code into client components

--- a/src/features/seating/queries/index.ts
+++ b/src/features/seating/queries/index.ts
@@ -1,1 +1,5 @@
-export { getEventTables, getSeatingPageData } from './tables';
+export {
+  getEventTables,
+  getEventTableOptions,
+  getSeatingPageData,
+} from './tables';

--- a/src/features/seating/queries/tables.ts
+++ b/src/features/seating/queries/tables.ts
@@ -1,7 +1,12 @@
 import { getEffectiveClient } from '@/lib/supabase/admin';
 import { TableDbToAppTransformerSchema, type TableApp } from '../schemas';
 import { getEventGuestsWithGroups } from '@/features/guests/queries';
-import type { SeatingPageData, SeatingStatsView, TableWithGuestsApp } from '../types';
+import type {
+  SeatingPageData,
+  SeatingStatsView,
+  TableOption,
+  TableWithGuestsApp,
+} from '../types';
 
 export const getEventTables = async (eventId: string): Promise<TableApp[]> => {
   try {
@@ -30,6 +35,60 @@ export const getEventTables = async (eventId: string): Promise<TableApp[]> => {
     return tables;
   } catch (error) {
     console.error('Error fetching tables for event:', error);
+    return [];
+  }
+};
+
+/**
+ * Every table on an event with its seated head count, ordered by table number.
+ *
+ * Feeds the table picker on the guests page. Deliberately lighter than
+ * getSeatingPageData: it aggregates guests.amount instead of returning guest
+ * rows, because the picker only ever renders "seated / capacity".
+ */
+export const getEventTableOptions = async (
+  eventId: string,
+): Promise<TableOption[]> => {
+  try {
+    const { supabase } = await getEffectiveClient();
+    const [tablesResult, guestsResult] = await Promise.all([
+      supabase
+        .from('tables')
+        .select('id, table_number, label, capacity')
+        .eq('event_id', eventId)
+        .order('table_number', { ascending: true }),
+      supabase
+        .from('guests')
+        .select('table_id, amount')
+        .eq('event_id', eventId)
+        .not('table_id', 'is', null),
+    ]);
+
+    if (tablesResult.error) {
+      console.error('Error fetching table options:', tablesResult.error);
+      return [];
+    }
+    if (guestsResult.error) {
+      console.error('Error fetching seated head counts:', guestsResult.error);
+    }
+
+    const headCountByTable = new Map<string, number>();
+    for (const row of guestsResult.data ?? []) {
+      const tableId = row.table_id as string | null;
+      if (!tableId) continue;
+      const amount = (row.amount as number | null) ?? 1;
+      headCountByTable.set(tableId, (headCountByTable.get(tableId) ?? 0) + amount);
+    }
+
+    return (tablesResult.data ?? []).map((row) => ({
+      id: row.id as string,
+      tableNumber: row.table_number as number,
+      label: (row.label as string | null) ?? null,
+      capacity: row.capacity as number,
+      seatedHeadCount: headCountByTable.get(row.id as string) ?? 0,
+    }));
+  } catch (error) {
+    console.error('Error fetching table options:', error);
     return [];
   }
 };

--- a/src/features/seating/schemas/index.ts
+++ b/src/features/seating/schemas/index.ts
@@ -85,6 +85,15 @@ export const TableUpsertSchema = z.object({
     .min(1, 'Capacity must be at least 1')
     .max(100, 'Capacity must be 100 or less')
     .optional(),
+  // Explicit table number, for callers that let the host name the table rather
+  // than taking the next one in sequence (the guest form's table picker).
+  // Omitted by the seating canvas, which always appends max+1.
+  tableNumber: z
+    .number()
+    .int()
+    .min(1, 'Table number must be at least 1')
+    .max(999, 'Table number must be 999 or less')
+    .optional(),
   positionX: z.number().optional(),
   positionY: z.number().optional(),
   rotation: z.number().optional(),

--- a/src/features/seating/types.ts
+++ b/src/features/seating/types.ts
@@ -20,6 +20,17 @@ export interface SeatingPageData {
   stats: SeatingStatsView;
 }
 
+// A table reduced to what a picker needs: its identity, its number, and how
+// full it is. Carries head counts rather than guest rows so the guests page can
+// load every table without pulling the seating chart.
+export interface TableOption {
+  id: string;
+  tableNumber: number;
+  label: string | null;
+  capacity: number;
+  seatedHeadCount: number;
+}
+
 export interface TableOccupancy {
   seatedHeadCount: number;
   capacity: number;


### PR DESCRIPTION
Hosts could only seat guests by dragging them around the seating canvas. Add a table picker to the guest form so a table can be assigned while editing a guest, and surface the assignment in the guest list.

Reuses the existing seating model rather than adding a table number to guests: the picker writes guests.table_id, so the form and the canvas stay one source of truth.

createTable gains an optional explicit tableNumber. It previously always appended max+1, which would have made "create table 7" silently produce a differently numbered table. An explicit number that collides is a conflict, not a race, so it fails rather than renumbering the host's choice. The canvas omits the field and is unaffected.

Also adds the guests_experience.send_table_numbers flag and its toggle on event details. Nothing reads it yet - the reminder template variant and the send-time template swap are separate work.


Claude-Session: https://claude.ai/code/session_01LQAQ2RdnntzGZjuM58WwwY