### PR TITLE
Keep the team's own accounts out of the Back Office

### DIFF
--- a/src/features/admin/queries/operations.ts
+++ b/src/features/admin/queries/operations.ts
@@ -3,6 +3,7 @@
 import { assertAdmin } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
 import type { PlannedWorkGroup, PlannedWorkQueue, PlannedWorkRow } from '../types';
+import { excludeIds, getTestScope } from './test-accounts';
 
 const DAY_MS = 86_400_000;
 
@@ -83,21 +84,27 @@ type ScheduleRow = {
  * keeps an unbounded list scannable. See the brief, section 3.1.
  *
  * Draft Events are excluded: a Draft Event cannot have schedules, and it is
- * interest rather than an event.
+ * interest rather than an event. So are test accounts - rehearsal work in a
+ * queue of real work is worse than useless. See test-accounts.ts.
  */
 export async function getPlannedWork(): Promise<PlannedWorkQueue> {
   await assertAdmin();
   const supabase = createServiceClient();
+  const test = await getTestScope();
 
   const open = unwrap(
-    await supabase
-      .from('schedules')
-      .select(
-        'id, event_id, scheduled_date, scheduled_time, target_status, schedule_type_id, events!inner(title, status), schedule_types(name, execution_kind), message_templates(channel)',
-      )
-      .is('status', null)
-      .eq('events.status', 'published')
-      .order('scheduled_date', { ascending: true }),
+    await excludeIds(
+      supabase
+        .from('schedules')
+        .select(
+          'id, event_id, scheduled_date, scheduled_time, target_status, schedule_type_id, events!inner(title, status), schedule_types(name, execution_kind), message_templates(channel)',
+        )
+        .is('status', null)
+        .eq('events.status', 'published')
+        .order('scheduled_date', { ascending: true }),
+      'event_id',
+      test.eventIds,
+    ),
   ) as unknown as ScheduleRow[];
 
   if (!open.length) return { groups: [], callRounds: 0, messages: 0 };
@@ -227,13 +234,18 @@ export async function listEventsForPlanning(): Promise<
 > {
   await assertAdmin();
   const supabase = createServiceClient();
+  const test = await getTestScope();
 
   const events = unwrap(
-    await supabase
-      .from('events')
-      .select('id, title')
-      .eq('status', 'published')
-      .order('event_date', { ascending: true }),
+    await excludeIds(
+      supabase
+        .from('events')
+        .select('id, title')
+        .eq('status', 'published')
+        .order('event_date', { ascending: true }),
+      'user_id',
+      test.userIds,
+    ),
   );
 
   if (!events.length) return [];

--- a/src/features/admin/queries/overview.ts
+++ b/src/features/admin/queries/overview.ts
@@ -3,6 +3,7 @@
 import { assertAdmin } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
 import type { OverviewCounts, Signal, UpcomingEvent } from '../types';
+import { excludeIds, getTestScope } from './test-accounts';
 
 /**
  * A Call Round is ended by a deliberate act of Round Completion, so an old open
@@ -61,15 +62,32 @@ export async function getOverviewCounts(): Promise<OverviewCounts> {
   // Draft Events are interest, not events the user has, so they are excluded
   // from every business count. Guest Records are counted per row: `amount` is
   // how many humans a record covers and would be a different, larger number.
+  // Test accounts are excluded for the same reason - see test-accounts.ts.
+  const test = await getTestScope();
+
   const [users, events, publishedEvents] = await Promise.all([
-    supabase.from('profiles').select('id', { count: 'exact', head: true }),
-    supabase
-      .from('events')
-      .select('id', { count: 'exact', head: true })
-      .eq('status', 'published'),
-    supabase.from('events').select('id').eq('status', 'published'),
+    excludeIds(
+      supabase.from('profiles').select('id', { count: 'exact', head: true }),
+      'id',
+      test.userIds,
+    ),
+    excludeIds(
+      supabase
+        .from('events')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'published'),
+      'user_id',
+      test.userIds,
+    ),
+    excludeIds(
+      supabase.from('events').select('id').eq('status', 'published'),
+      'user_id',
+      test.userIds,
+    ),
   ]);
 
+  // Guest Records need no filter of their own: publishedIds no longer contains
+  // any test account's event.
   const publishedIds = unwrap(publishedEvents).map((e) => e.id);
 
   const guestRecords = publishedIds.length
@@ -93,30 +111,43 @@ export async function getSignals(): Promise<Signal[]> {
   const supabase = createServiceClient();
 
   const nowIso = new Date().toISOString();
+  const test = await getTestScope();
+  const testEventIds = new Set(test.eventIds);
 
   const [overdue, failed, stale] = await Promise.all([
     // Overdue Schedule: `schedules.status` only ever holds 'sent' or
     // 'cancelled', so NULL is the only representation of "not completed".
     // Overdue is therefore derived, never stored.
-    supabase
-      .from('schedules')
-      .select(
-        'id, scheduled_date, scheduled_time, event_id, events(title), schedule_types(name)',
-      )
-      .is('status', null)
-      .lt('scheduled_date', nowIso),
+    excludeIds(
+      supabase
+        .from('schedules')
+        .select(
+          'id, scheduled_date, scheduled_time, event_id, events(title), schedule_types(name)',
+        )
+        .is('status', null)
+        .lt('scheduled_date', nowIso),
+      'event_id',
+      test.eventIds,
+    ),
 
+    // The only read here with no event_id of its own - it reaches one through
+    // schedules - so its test accounts are dropped in the grouping loop below
+    // rather than by a filter.
     supabase
       .from('message_deliveries')
       .select('id, error_code, created_at, schedules!inner(event_id, events(title))')
       .eq('status', 'failed')
       .gte('created_at', daysAgo(FAILED_DELIVERY_LOOKBACK_DAYS)),
 
-    supabase
-      .from('call_rounds')
-      .select('id, round_number, created_at, event_id, events(title)')
-      .is('completed_at', null)
-      .lt('created_at', daysAgo(STALE_CALL_ROUND_DAYS)),
+    excludeIds(
+      supabase
+        .from('call_rounds')
+        .select('id, round_number, created_at, event_id, events(title)')
+        .is('completed_at', null)
+        .lt('created_at', daysAgo(STALE_CALL_ROUND_DAYS)),
+      'event_id',
+      test.eventIds,
+    ),
   ]);
 
   const signals: Signal[] = [];
@@ -148,7 +179,7 @@ export async function getSignals(): Promise<Signal[]> {
       event_id: string;
       events: { title: string | null } | null;
     } | null;
-    if (!schedule?.event_id) continue;
+    if (!schedule?.event_id || testEventIds.has(schedule.event_id)) continue;
 
     const entry = byEvent.get(schedule.event_id) ?? {
       title: schedule.events?.title ?? 'Untitled event',
@@ -239,14 +270,20 @@ export async function getUpcomingEvents(): Promise<UpcomingEvent[]> {
   await assertAdmin();
   const supabase = createServiceClient();
 
+  const test = await getTestScope();
+
   const events = unwrap(
-    await supabase
-      .from('events')
-      .select('id, title, event_date, user_id, event_types(name)')
-      .eq('status', 'published')
-      .gte('event_date', new Date().toISOString())
-      .lte('event_date', daysAhead(UPCOMING_WINDOW_DAYS))
-      .order('event_date', { ascending: true }),
+    await excludeIds(
+      supabase
+        .from('events')
+        .select('id, title, event_date, user_id, event_types(name)')
+        .eq('status', 'published')
+        .gte('event_date', new Date().toISOString())
+        .lte('event_date', daysAhead(UPCOMING_WINDOW_DAYS))
+        .order('event_date', { ascending: true }),
+      'user_id',
+      test.userIds,
+    ),
   );
 
   if (!events.length) return [];

--- a/src/features/admin/queries/search.ts
+++ b/src/features/admin/queries/search.ts
@@ -3,6 +3,7 @@
 import { assertAdmin } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
 import type { EventSearchResult } from '../types';
+import { excludeIds, getTestScope } from './test-accounts';
 
 /**
  * Enough rows to recognise the one you meant, few enough to scan without
@@ -33,6 +34,7 @@ export async function searchEvents(term: string): Promise<EventSearchResult[]> {
   if (trimmed.length < MIN_TERM_LENGTH) return [];
 
   const supabase = createServiceClient();
+  const test = await getTestScope();
   const pattern = `%${escapeLike(trimmed)}%`;
 
   // events.user_id points at auth.users and there is no foreign key to
@@ -52,12 +54,19 @@ export async function searchEvents(term: string): Promise<EventSearchResult[]> {
     filters.push(`user_id.in.(${matchedOwnerIds.join(',')})`);
   }
 
-  const { data: events, error: eventsError } = await supabase
-    .from('events')
-    .select('id, title, event_date, user_id, status')
-    .or(filters.join(','))
-    .order('event_date', { ascending: true })
-    .limit(SEARCH_LIMIT);
+  // Only the events read is filtered for test accounts. The owner lookup above
+  // feeds an `or`, and an owner whose events are all excluded contributes
+  // nothing to the result either way.
+  const { data: events, error: eventsError } = await excludeIds(
+    supabase
+      .from('events')
+      .select('id, title, event_date, user_id, status')
+      .or(filters.join(','))
+      .order('event_date', { ascending: true })
+      .limit(SEARCH_LIMIT),
+    'user_id',
+    test.userIds,
+  );
 
   if (eventsError) throw new Error(eventsError.message);
   if (!events?.length) return [];

--- a/src/features/admin/queries/test-accounts.ts
+++ b/src/features/admin/queries/test-accounts.ts
@@ -1,0 +1,73 @@
+import { cache } from 'react';
+import { createServiceClient } from '@/lib/supabase/service';
+
+/**
+ * The team runs its own accounts against production, and their events and guest
+ * records land in the same tables as everyone else's. Counting them tells the
+ * Operator the business is bigger than it is, and listing them puts rehearsal
+ * work in a queue of real work.
+ *
+ * `profiles.is_test_account` is the mark. It cannot be enforced in the database:
+ * the Back Office reads through createServiceClient(), which bypasses RLS by
+ * design, so the exclusion has to be applied by every admin query that reads a
+ * table users own. This module is the one place that knows how.
+ */
+export type TestScope = {
+  /** profiles.id of every flagged account. Also what events.user_id holds. */
+  userIds: string[];
+  /** Every event those accounts own, draft and published alike. */
+  eventIds: string[];
+};
+
+/**
+ * Two round-trips, cached per render so a page reading counts, signals and
+ * upcoming events pays for them once.
+ *
+ * The second trip exists because events.user_id points at auth.users with no
+ * foreign key to profiles - the flag cannot be joined or embedded, so ownership
+ * has to be resolved to a list of event ids up front. Everything the Back Office
+ * reads below an event (guests, schedules, call rounds, deliveries) is already
+ * scoped by event id, so those ids are all it takes to filter the rest.
+ */
+export const getTestScope = cache(async function getTestScope(): Promise<TestScope> {
+  const supabase = createServiceClient();
+
+  const { data: profiles, error: profilesError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('is_test_account', true);
+
+  if (profilesError) throw new Error(profilesError.message);
+
+  const userIds = (profiles ?? []).map((profile) => profile.id);
+  if (!userIds.length) return { userIds: [], eventIds: [] };
+
+  const { data: events, error: eventsError } = await supabase
+    .from('events')
+    .select('id')
+    .in('user_id', userIds);
+
+  if (eventsError) throw new Error(eventsError.message);
+
+  return { userIds, eventIds: (events ?? []).map((event) => event.id) };
+});
+
+type NotFilterable<Q> = {
+  not(column: string, operator: string, value: unknown): Q;
+};
+
+/**
+ * Adds `column not in (ids)` to a query, or nothing at all when the list is
+ * empty - `not in ()` is a Postgres syntax error, so the common case of no
+ * flagged accounts has to skip the filter rather than pass an empty list.
+ *
+ * Ids come from the database as uuids, so they need no quoting.
+ */
+export function excludeIds<Q extends NotFilterable<Q>>(
+  query: Q,
+  column: string,
+  ids: string[],
+): Q {
+  if (!ids.length) return query;
+  return query.not(column, 'in', `(${ids.join(',')})`);
+}

--- a/supabase/migrations/20260825000000_add_is_test_account_to_profiles.sql
+++ b/supabase/migrations/20260825000000_add_is_test_account_to_profiles.sql
@@ -1,0 +1,47 @@
+-- Several accounts running against production belong to the team rather than to
+-- customers: they exist to exercise the real app, and their events and guest
+-- records inflate every number the Back Office reports. An Operator reading
+-- "1,011 guest records" needs that to be 1,011 real ones.
+--
+-- The flag lives on profiles rather than in code because the set changes -
+-- marking a new test account is a row update, not a redeploy. It is deliberately
+-- not an email pattern: the accounts already exist and their addresses are not
+-- shaped alike.
+--
+-- This column is only the storage. The Back Office reads through
+-- createServiceClient(), which bypasses RLS, so the filtering it drives lives in
+-- src/features/admin/queries/test-accounts.ts. Nothing in the customer-facing
+-- app reads it.
+--
+-- Writable by service_role only, and it takes no new grant to get there:
+-- 20260824000001_enable_rls_on_profiles.sql re-granted profiles column by
+-- column, and its insert/update grants name columns explicitly, so a column
+-- added later is unwritable by authenticated. Readable like is_admin - a user
+-- learning their own account is flagged discloses nothing.
+
+alter table public.profiles
+  add column if not exists is_test_account boolean not null default false;
+
+comment on column public.profiles.is_test_account is
+  'Team-owned account used to exercise production. Excluded from Back Office counts and lists.';
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'profiles'
+      and column_name = 'is_test_account'
+  ) then
+    raise exception 'is_test_account was not added to public.profiles';
+  end if;
+
+  if exists (
+    select 1 from information_schema.column_privileges
+    where table_schema = 'public' and table_name = 'profiles'
+      and grantee = 'authenticated'
+      and privilege_type in ('INSERT', 'UPDATE')
+      and column_name = 'is_test_account'
+  ) then
+    raise exception 'authenticated can write is_test_account';
+  end if;
+end $$;


### PR DESCRIPTION
Adds `profiles.is_test_account` and filters flagged accounts out of every Back Office count and list, so Overview and Operations report the real business rather than the team's rehearsal data.

## The mark

A boolean column on `profiles`, mirroring `is_admin`. Chosen over a hardcoded id list or env var (both need a redeploy to change), a separate table (a join to store one boolean), and email patterns (the accounts already exist and their addresses are not shaped alike). Flagging an account is an `update` against the database.

RLS is not an option here - the Back Office reads through `createServiceClient()`, which bypasses RLS by design - so the exclusion lives in code.

## The filtering

`events.user_id` points at `auth.users` with no foreign key to `profiles`, so the flag can be neither joined nor embedded. `getTestScope()` (React `cache`, one pair of round-trips per render) resolves it to `{ userIds, eventIds }`, and `excludeIds()` applies a `not in` filter at each anchor - 8 call sites across `overview.ts`, `operations.ts` and `search.ts`.

Two things worth a reviewer's attention:

- **Empty list.** `not in ()` is a Postgres syntax error, so `excludeIds` returns the query untouched when nothing is flagged. Until a row is marked, every number is unchanged.
- **`message_deliveries`** has no `event_id`, reaching one only through `schedules`, so its rows drop in the grouping loop that was already there rather than by a query filter.

Guest records need no filter of their own - they were already scoped by event id, which is now filtered upstream. Call round detail reads are deliberately left unfiltered: that page is reachable only by link, and an Operator following one to a test event means to.

## Migration status

**Already applied to production.** Verified first on a fresh `npx supabase db reset`, then pushed with `npx supabase db push`; `migration list --linked` shows no drift, and the column is recorded under the file's own version. The migration ends with a guard asserting `authenticated` cannot write the column - it inherits that from the column-by-column grants in `20260824000001_enable_rls_on_profiles.sql` without needing a new one.

## Verification

- `npx supabase db reset` - migration replays clean from scratch, guard passes
- `npx tsc --noEmit` - clean
- `npm run build` - passes
- `npm run lint` - no findings in `features/admin`
- `not.in.(<uuid>)` checked against the local REST API (3 profiles to 2), confirming the filter string `excludeIds` builds
- Not exercised in a browser

## Follow-up

No accounts are flagged yet, so this is a no-op until an `update public.profiles set is_test_account = true where email in (...)` is run. Left out of the repo on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169RPLPauNg7KEy7gDunpbi