### PR TITLE
feat(admin): act on events from the Back Office

### DIFF
--- a/src/app/(admin)/admin/@topbar/[...segments]/page.tsx
+++ b/src/app/(admin)/admin/@topbar/[...segments]/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { OperatorSearch, resolveAdminTopBar } from '@/features/admin';
+import { ImpersonateOwnerButton, OperatorSearch, resolveAdminTopBar } from '@/features/admin';
 import { getEventIdentity } from '@/features/admin/queries/events';
 import { getRoundDetail } from '@/features/admin/queries/call-round';
 
@@ -16,11 +16,18 @@ export default async function AdminTopBarRoute({
   if (mode.kind === 'event') {
     const event = await getEventIdentity(mode.eventId);
     return (
-      <TopBarBreadcrumb>
-        <Link href="/admin/events" className="hover:text-foreground">Events</Link>
-        <BreadcrumbSeparator />
-        <span className="text-foreground truncate font-medium">{event?.title ?? 'Event'}</span>
-      </TopBarBreadcrumb>
+      <>
+        <TopBarBreadcrumb>
+          <Link href="/admin/events" className="hover:text-foreground">Events</Link>
+          <BreadcrumbSeparator />
+          <span className="text-foreground truncate font-medium">{event?.title ?? 'Event'}</span>
+        </TopBarBreadcrumb>
+        {event && (
+          <div className="ms-auto shrink-0">
+            <ImpersonateOwnerButton ownerId={event.ownerId} ownerName={event.owner.name} />
+          </div>
+        )}
+      </>
     );
   }
 

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,9 +1,11 @@
 export {
   CalendarDays,
   ChevronDown,
+  ChevronRight,
   Clock3,
   Copy,
   ExternalLink,
+  Eye,
   Info,
   Link2,
   MapPin,

--- a/src/features/admin/actions/events.ts
+++ b/src/features/admin/actions/events.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { revalidateOutreach } from '@/features/schedules/services/revalidate-outreach';
+
+export type AdminEventActionResult = { success: boolean; message: string };
+
+/**
+ * Opens the sending gate on an event. Until this flag is on, the event can hold
+ * no schedules at all - the owner app hides outreach and every send path
+ * refuses - so this is the one switch that turns a paid-for event into a
+ * workable one.
+ *
+ * A Draft Event is deliberately refused: it is interest, not an event, and it
+ * has no guest list or workspace for outreach to act on.
+ */
+export async function enableScheduleSending(eventId: string): Promise<AdminEventActionResult> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  try {
+    const { data: event, error: readError } = await supabase
+      .from('events')
+      .select('status, can_create_schedules')
+      .eq('id', eventId)
+      .maybeSingle();
+    if (readError) throw readError;
+
+    if (!event) return { success: false, message: 'That event no longer exists' };
+    if (event.status !== 'published') return { success: false, message: 'That event is not published' };
+    if (event.can_create_schedules) return { success: true, message: 'Sending is already enabled' };
+
+    const { error } = await supabase
+      .from('events')
+      .update({ can_create_schedules: true })
+      .eq('id', eventId);
+    if (error) throw error;
+
+    revalidateOutreach(eventId);
+    return { success: true, message: 'Sending enabled' };
+  } catch (error) {
+    console.error('enableScheduleSending failed:', error);
+    return { success: false, message: 'Failed to enable sending' };
+  }
+}

--- a/src/features/admin/actions/index.ts
+++ b/src/features/admin/actions/index.ts
@@ -1,1 +1,2 @@
+export { enableScheduleSending, type AdminEventActionResult } from './events';
 export { startImpersonation, stopImpersonation } from './impersonation';

--- a/src/features/admin/components/back-office-top-bar.tsx
+++ b/src/features/admin/components/back-office-top-bar.tsx
@@ -17,9 +17,14 @@ export function BackOfficeTopBar({ children }: { children?: ReactNode }) {
   });
 
   return (
-    <header className="bg-card flex h-14 flex-none items-center gap-3 border-b px-6">
-      {children ?? <OperatorSearch />}
-      <span className="text-muted-foreground ml-auto shrink-0 text-[12.5px]">{today}</span>
+    <header className="bg-card flex h-14 flex-none items-center gap-4 border-b px-6">
+      {/*
+       * The slot owns the whole left region, so a route that carries an action
+       * can push it right with an auto margin instead of the bar having to know
+       * which routes have one.
+       */}
+      <div className="flex min-w-0 flex-1 items-center gap-3">{children ?? <OperatorSearch />}</div>
+      <span className="text-muted-foreground shrink-0 text-[12.5px]">{today}</span>
     </header>
   );
 }

--- a/src/features/admin/components/band.tsx
+++ b/src/features/admin/components/band.tsx
@@ -26,9 +26,14 @@ export function Band({
         className,
       )}
     >
-      <div className="relative">
-        <h2 className="text-muted-foreground px-4 pt-3.5 pb-2.5 text-[11.5px] font-semibold tracking-[0.07em] uppercase">{title}</h2>
-        {action && <div className="absolute top-1/2 right-4 -translate-y-1/2">{action}</div>}
+      {/*
+       * The action sits in the flow rather than absolutely over the heading, so
+       * the header is sized by its tallest child. Centring a 32px control inside
+       * a header cut for 11.5px text left it 4px of air and reading as cramped.
+       */}
+      <div className={cn('flex items-center justify-between gap-3 px-4', action ? 'py-2' : 'pt-3.5 pb-2.5')}>
+        <h2 className="text-muted-foreground text-[11.5px] font-semibold tracking-[0.07em] uppercase">{title}</h2>
+        {action}
       </div>
       {children}
     </section>

--- a/src/features/admin/components/calling-surface.tsx
+++ b/src/features/admin/components/calling-surface.tsx
@@ -43,6 +43,27 @@ const RSVP_STYLES: Record<RoundGuestRow['currentRsvpStatus'], string> = {
   declined: 'border-red-300 text-red-700',
 };
 
+function Tally({
+  label,
+  value,
+  hint,
+  className,
+}: {
+  label: string;
+  value: number;
+  /** Secondary line - e.g. the headcount behind a count of guest records */
+  hint?: string;
+  className: string;
+}) {
+  return (
+    <div className="bg-muted/50 flex min-w-[104px] flex-1 flex-col gap-0.5 rounded-lg px-3 py-2">
+      <span className={cn('text-[11.5px] font-medium', className)}>{label}</span>
+      <span className="text-foreground text-lg font-semibold tabular-nums">{value}</span>
+      {hint && <span className="text-muted-foreground text-[11px] tabular-nums">{hint}</span>}
+    </div>
+  );
+}
+
 export function CallingSurface({ round }: { round: RoundDetail }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -54,6 +75,14 @@ export function CallingSurface({ round }: { round: RoundDetail }) {
 
   const called = round.guests.filter((guest) => guest.outcome !== null).length;
   const total = round.guests.length;
+  const tally = round.guests.reduce(
+    (counts, guest) => {
+      if (guest.outcome) counts[guest.outcome] += 1;
+      if (guest.outcome === 'confirmed') counts.confirmedGuests += guest.amount;
+      return counts;
+    },
+    { confirmed: 0, declined: 0, no_answer: 0, confirmedGuests: 0 },
+  );
 
   const visible = useMemo(() => {
     const needle = term.trim().toLowerCase();
@@ -141,24 +170,26 @@ export function CallingSurface({ round }: { round: RoundDetail }) {
         </div>
 
         <div className="flex shrink-0 gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={pending}
-            onClick={() => roundAction(() => deleteCallRound(round.id), true)}
-          >
-            Delete round
-          </Button>
           {inProgress ? (
-            <Button
-              type="button"
-              size="sm"
-              disabled={pending}
-              onClick={() => roundAction(() => finishCallRound(round.id))}
-            >
-              Finish round
-            </Button>
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={pending}
+                onClick={() => roundAction(() => deleteCallRound(round.id), true)}
+              >
+                Delete round
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={pending}
+                onClick={() => roundAction(() => finishCallRound(round.id))}
+              >
+                Finish round
+              </Button>
+            </>
           ) : (
             <Button
               type="button"
@@ -178,6 +209,25 @@ export function CallingSurface({ round }: { round: RoundDetail }) {
         <span className="text-foreground font-semibold tabular-nums">{called}</span> of{' '}
         <span className="tabular-nums">{total}</span> called
       </p>
+
+      {/*
+       * What the round produced, in the Owner app's own three categories, so a
+       * finished round reads as results rather than a frozen worklist. Held
+       * back until the first outcome lands - three zeros say nothing.
+       */}
+      {called > 0 && (
+        <div className="flex flex-wrap gap-2">
+          <Tally
+            label="Confirmed"
+            value={tally.confirmed}
+            hint={`${tally.confirmedGuests} ${tally.confirmedGuests === 1 ? 'guest' : 'guests'}`}
+            className="text-emerald-700"
+          />
+          <Tally label="Declined" value={tally.declined} className="text-red-700" />
+          <Tally label="No answer" value={tally.no_answer} className="text-amber-700" />
+          <Tally label="Not called" value={total - called} className="text-muted-foreground" />
+        </div>
+      )}
 
       <div className="flex flex-wrap items-center gap-2">
         <div className="border-input bg-card flex w-full max-w-[280px] items-center gap-2 rounded-md border px-2.5 py-1.5">

--- a/src/features/admin/components/enable-sending-button.tsx
+++ b/src/features/admin/components/enable-sending-button.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useTransition } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { enableScheduleSending } from '../actions/events';
+
+/**
+ * The only way to open the sending gate from the Back Office. It sits inside
+ * the outreach gate itself so the Operator acts where the blockage is stated.
+ */
+export function EnableSendingButton({ eventId }: { eventId: string }) {
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      className="shrink-0 text-[13px]"
+      onClick={() =>
+        startTransition(async () => {
+          const result = await enableScheduleSending(eventId);
+          if (result.success) toast.success(result.message);
+          else toast.error(result.message);
+        })
+      }
+    >
+      {pending ? 'Enabling' : 'Enable sending'}
+    </Button>
+  );
+}

--- a/src/features/admin/components/event-workspace-client.tsx
+++ b/src/features/admin/components/event-workspace-client.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { ChevronDown, Link2, MessageSquare, Phone, PhoneOff, TriangleAlert } from '@/components/icons';
+import { ChevronDown, ChevronRight, Link2, MessageSquare, Phone, PhoneOff, TriangleAlert } from '@/components/icons';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -105,16 +105,16 @@ export function WorkspaceSignals({ signals }: { signals: EventWorkspaceSignal[] 
   );
 }
 
-export function EventTimeline({ rows }: { rows: EventTimelineRow[] }) {
+export function EventTimeline({ rows, eventId }: { rows: EventTimelineRow[]; eventId: string }) {
   if (!rows.length) return null;
   return (
     <div className="flex flex-col gap-2">
-      {rows.map((row) => <TimelineRow key={row.id} row={row} />)}
+      {rows.map((row) => <TimelineRow key={row.id} row={row} eventId={eventId} />)}
     </div>
   );
 }
 
-function TimelineRow({ row }: { row: EventTimelineRow }) {
+function TimelineRow({ row, eventId }: { row: EventTimelineRow; eventId: string }) {
   const failed = row.deliveries.filter((delivery) => delivery.status === 'failed');
   const successful = row.deliveries.filter((delivery) => delivery.status === 'sent');
   const attempted = row.deliveries.length;
@@ -166,8 +166,24 @@ function TimelineRow({ row }: { row: EventTimelineRow }) {
           {row.status === 'planned' ? (
             <QueueRowAction row={actionRow} />
           ) : row.roundId ? (
-            <Button asChild variant={row.status === 'in_progress' ? 'default' : 'outline'} size="sm">
-              <Link href={`rounds/${row.roundId}`}>{row.status === 'in_progress' ? 'Complete round' : 'Open round'}</Link>
+            /*
+             * A link, not a button: this navigates to the round, it does not do
+             * anything to it. Only the planned row carries a button, because
+             * Start is the one control here that changes the world.
+             */
+            <Button
+              asChild
+              variant="link"
+              size="sm"
+              className={cn(
+                'h-auto shrink-0 gap-0.5 px-0 text-[13px]',
+                row.status !== 'in_progress' && 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Link href={`/admin/events/${eventId}/rounds/${row.roundId}`}>
+                {row.status === 'in_progress' ? 'Complete round' : 'Open round'}
+                <ChevronRight className="size-3.5" />
+              </Link>
             </Button>
           ) : null}
         </div>

--- a/src/features/admin/components/event-workspace.tsx
+++ b/src/features/admin/components/event-workspace.tsx
@@ -3,11 +3,13 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from '@/components/ui/item';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { AddCallRoundDialog } from './add-call-round-dialog';
 import { Band, BandRow } from './band';
+import { EnableSendingButton } from './enable-sending-button';
 import {
   EventTimeline,
   PhoneQualityDisclosure,
@@ -302,7 +304,13 @@ export async function EventOutreachBand({ eventId }: { eventId: string }) {
       return (
         <Band id="outreach-timeline" title="Outreach timeline" className="scroll-mt-20">
           <BandRow>
-            <Alert id="outreach-gate"><AlertTitle>Sending is not enabled for this event</AlertTitle><AlertDescription>Outreach remains unavailable until payment is completed and Kululu enables sending</AlertDescription></Alert>
+            <Item id="outreach-gate" variant="muted">
+              <ItemContent>
+                <ItemTitle>Sending is not enabled for this event</ItemTitle>
+                <ItemDescription>Outreach remains unavailable until payment is completed and Kululu enables sending</ItemDescription>
+              </ItemContent>
+              <ItemActions><EnableSendingButton eventId={event.id} /></ItemActions>
+            </Item>
           </BandRow>
         </Band>
       );
@@ -320,7 +328,7 @@ export async function EventOutreachBand({ eventId }: { eventId: string }) {
       >
         <BandRow>
           {rows.length ? (
-            <EventTimeline rows={rows} />
+            <EventTimeline rows={rows} eventId={event.id} />
           ) : (
             <Empty className="min-h-44 border-0 p-4"><EmptyHeader><EmptyTitle>No outreach planned</EmptyTitle><EmptyDescription>{canPlanCalls ? 'Add a call round or wait for the owner to configure messages' : 'Outreach can be planned as soon as the guest list has an eligible audience'}</EmptyDescription></EmptyHeader></Empty>
           )}

--- a/src/features/admin/components/impersonate-owner-button.tsx
+++ b/src/features/admin/components/impersonate-owner-button.tsx
@@ -1,0 +1,28 @@
+import { Eye } from '@/components/icons';
+import { Button } from '@/components/ui/button';
+import { startImpersonation } from '../actions/impersonation';
+
+/**
+ * Drops the Operator into the Owner app as this event's owner, which is the
+ * fastest way to answer "what is the couple actually looking at". The session
+ * is read-only and `ImpersonationBanner` carries the way back out.
+ *
+ * A plain form rather than a client component: the same shape the banner's Exit
+ * already uses, and it keeps the top bar free of client JavaScript.
+ */
+export function ImpersonateOwnerButton({
+  ownerId,
+  ownerName,
+}: {
+  ownerId: string;
+  ownerName: string;
+}) {
+  return (
+    <form action={startImpersonation.bind(null, ownerId)}>
+      <Button type="submit" variant="outline" size="sm" title={`Open the app as ${ownerName}`}>
+        <Eye className="size-3.5" />
+        View as owner
+      </Button>
+    </form>
+  );
+}

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -17,11 +17,13 @@ export {
   EventSignalsBand,
 } from './components/event-workspace';
 export { Band, BandRow } from './components/band';
+export { EnableSendingButton } from './components/enable-sending-button';
 export { BackOfficeNav } from './components/back-office-nav';
 export { CountStrip } from './components/count-strip';
 export { SignalList } from './components/signal-list';
 export { SignalRow } from './components/signal-row';
 export { UpcomingEvents } from './components/upcoming-events';
 export { ImpersonationBanner } from './components/impersonation-banner';
+export { ImpersonateOwnerButton } from './components/impersonate-owner-button';
 export { OperatorSearch } from './components/operator-search';
 export { resolveAdminTopBar, type AdminTopBarMode } from './utils/topbar';

--- a/src/features/admin/queries/events.ts
+++ b/src/features/admin/queries/events.ts
@@ -240,6 +240,7 @@ export const getEventIdentity = cache(async function getEventIdentity(eventId: s
     canCreateSchedules: event.can_create_schedules ?? false,
     onboardingStep: event.onboarding_step,
     createdAt: event.created_at,
+    ownerId: event.user_id,
     owner: {
       name: owner?.full_name || owner?.email || 'Unknown owner',
       email: owner?.email ?? null,

--- a/src/features/admin/types.ts
+++ b/src/features/admin/types.ts
@@ -116,6 +116,8 @@ export type EventIdentity = {
   canCreateSchedules: boolean;
   onboardingStep: string | null;
   createdAt: string;
+  /** The account the event belongs to - the identity an Operator impersonates. */
+  ownerId: string;
   owner: { name: string; email: string | null; phone: string | null };
   collaborators: { id: string; name: string; email: string | null; role: string }[];
   hostNames: string[];


### PR DESCRIPTION
The event workspace could describe an event but not change one, so every blockage an Operator found ended in a handoff.

- Enable sending on a gated event, the flag nothing could set
- Impersonate the owner from the event top bar
- Repair the round link, which resolved relatively and always 404'd
- Show a round's outcome tally, and hide Delete once it is finished, where it would destroy the call log rather than undo a misclick


Claude-Session: https://claude.ai/code/session_01TszQ5F5vxfqpCSpbbcaNEK