### PR TITLE
Improve event timeline date label alignment and wrapping

### DIFF
--- a/src/features/admin/components/event-workspace-client.tsx
+++ b/src/features/admin/components/event-workspace-client.tsx
@@ -139,9 +139,9 @@ function TimelineRow({ row, eventId }: { row: EventTimelineRow; eventId: string 
     ? null
     : formatScheduleDateTime(row.scheduledDate, row.scheduledTime).split(',')[0];
   return (
-    <div id={`schedule-${row.id}`} className="grid scroll-mt-20 grid-cols-[76px_minmax(0,1fr)] gap-3.5">
-      <div className="text-muted-foreground flex flex-col items-end gap-0.5 pt-3 text-[11.5px] tabular-nums">
-        {dateLabel && <span className="text-foreground text-[12.5px] font-medium">{dateLabel}</span>}
+    <div id={`schedule-${row.id}`} className="grid scroll-mt-20 grid-cols-[86px_minmax(0,1fr)] gap-3.5">
+      <div className="text-muted-foreground flex flex-col items-start gap-0.5 pt-3 text-[11.5px] tabular-nums">
+        {dateLabel && <span className="text-foreground text-[12.5px] font-medium whitespace-nowrap">{dateLabel}</span>}
         {dateLabel && <span>{row.scheduledTime?.slice(0, 5) ?? 'No time'}</span>}
       </div>
       <div className={cn('bg-card min-w-0 overflow-hidden rounded-lg border border-l-[3px] shadow-xs', rail)}>


### PR DESCRIPTION
## Summary
Adjusts the layout and styling of the event timeline date labels to improve visual alignment and prevent text wrapping issues.

## Changes
- **Grid column width**: Increased the first column width from `76px` to `86px` to accommodate date labels with better spacing
- **Text alignment**: Changed the date/time label container from `items-end` to `items-start` for top alignment
- **Text wrapping**: Added `whitespace-nowrap` to the date label span to prevent unwanted line breaks

## Details
These changes ensure that date labels in the event timeline display with proper alignment and don't wrap unexpectedly, improving the overall readability and visual consistency of the timeline view.

https://claude.ai/code/session_017HMXrj9wm7si6Ybe6CrV2t