### PR TITLE
feat(admin): quick-send a message to one guest

### DIFF
--- a/src/features/admin/actions/index.ts
+++ b/src/features/admin/actions/index.ts
@@ -1,3 +1,9 @@
 export { enableScheduleSending, type AdminEventActionResult } from './events';
 export { startImpersonation, stopImpersonation } from './impersonation';
+export {
+  getQuickSendGuests,
+  sendScheduleToGuest,
+  type QuickSendGuest,
+  type QuickSendResult,
+} from './quick-send';
 export { setTestAccountsVisible } from './test-accounts';

--- a/src/features/admin/actions/quick-send.ts
+++ b/src/features/admin/actions/quick-send.ts
@@ -1,0 +1,174 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { revalidateOutreach } from '@/features/schedules/services/revalidate-outreach';
+import { sendSchedule } from '@/features/schedules/services/send-schedule';
+
+export type QuickSendGuest = {
+  id: string;
+  name: string;
+  phone: string | null;
+  rsvpStatus: string;
+  groupName: string | null;
+  /** Already received this schedule - the Operator is about to send it twice. */
+  alreadySent: boolean;
+};
+
+export type QuickSendResult = { success: boolean; message: string };
+
+type ScheduleGate = {
+  eventId: string;
+  scheduleTitle: string;
+};
+
+/**
+ * Shared gate for both entry points: the schedule has to exist, be a message
+ * schedule, and belong to an event with sending enabled. Returns the event id
+ * so callers can scope their own guest lookups to it.
+ */
+async function gateSchedule(
+  supabase: ReturnType<typeof createServiceClient>,
+  scheduleId: string,
+): Promise<{ ok: true; gate: ScheduleGate } | { ok: false; message: string }> {
+  const { data, error } = await supabase
+    .from('schedules')
+    .select(
+      'id, event_id, schedule_types!inner(name, execution_kind), events!inner(can_create_schedules)',
+    )
+    .eq('id', scheduleId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return { ok: false, message: 'That schedule no longer exists' };
+
+  const scheduleType = (Array.isArray(data.schedule_types)
+    ? data.schedule_types[0]
+    : data.schedule_types) as { name: string; execution_kind: string } | null;
+  if (scheduleType?.execution_kind !== 'message') {
+    return { ok: false, message: 'Call rounds are not sent from here' };
+  }
+
+  const event = (Array.isArray(data.events) ? data.events[0] : data.events) as
+    | { can_create_schedules: boolean }
+    | null;
+  if (!event?.can_create_schedules) {
+    return { ok: false, message: 'Sending is not enabled for this event' };
+  }
+
+  return {
+    ok: true,
+    gate: { eventId: data.event_id, scheduleTitle: scheduleType.name },
+  };
+}
+
+/**
+ * The guest list behind the quick-send picker, fetched when the dialog opens
+ * rather than shipped with the page - a full guest list on every workspace
+ * render is a large RSC payload nobody asked for.
+ *
+ * Guests without a usable phone are returned rather than filtered out: an
+ * Operator looking for someone and not finding them has no way to tell a
+ * missing guest from an unreachable one, so the picker shows them disabled.
+ */
+export async function getQuickSendGuests(
+  scheduleId: string,
+): Promise<QuickSendGuest[]> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const gate = await gateSchedule(supabase, scheduleId);
+  if (!gate.ok) return [];
+
+  const [guestsResult, deliveriesResult] = await Promise.all([
+    supabase
+      .from('guests')
+      .select('id, name, phone_number, rsvp_status, groups(name)')
+      .eq('event_id', gate.gate.eventId)
+      .order('name', { ascending: true }),
+    supabase
+      .from('message_deliveries')
+      .select('guest_id')
+      .eq('schedule_id', scheduleId)
+      .in('status', ['sent', 'delivered', 'read']),
+  ]);
+  if (guestsResult.error) throw guestsResult.error;
+  if (deliveriesResult.error) throw deliveriesResult.error;
+
+  const delivered = new Set(
+    (deliveriesResult.data ?? []).map((row) => row.guest_id),
+  );
+
+  return (guestsResult.data ?? []).map((guest) => {
+    const group = (Array.isArray(guest.groups) ? guest.groups[0] : guest.groups) as
+      | { name: string }
+      | null;
+    return {
+      id: guest.id,
+      name: guest.name,
+      phone: guest.phone_number,
+      rsvpStatus: guest.rsvp_status,
+      groupName: group?.name ?? null,
+      alreadySent: delivered.has(guest.id),
+    };
+  });
+}
+
+/**
+ * Sends one schedule's message to one guest, now.
+ *
+ * Deliberately indifferent to the schedule's own status and target audience:
+ * this is the Operator picking a person on the phone who never got the message
+ * or lost it, so `claim: 'none'` skips the sent/cancelled guard and
+ * `markSentOnSuccess: false` leaves a still-pending schedule pending for the
+ * cron to run on its own date.
+ */
+export async function sendScheduleToGuest(
+  scheduleId: string,
+  guestId: string,
+): Promise<QuickSendResult> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  try {
+    const gate = await gateSchedule(supabase, scheduleId);
+    if (!gate.ok) return { success: false, message: gate.message };
+
+    // Scoped to the event the schedule belongs to, so a guest id from another
+    // event cannot be sent someone else's message.
+    const { data: guest, error: guestError } = await supabase
+      .from('guests')
+      .select('id, name')
+      .eq('id', guestId)
+      .eq('event_id', gate.gate.eventId)
+      .maybeSingle();
+    if (guestError) throw guestError;
+    if (!guest) {
+      return { success: false, message: 'That guest is not on this event' };
+    }
+
+    const outcome = await sendSchedule(scheduleId, {
+      supabase,
+      triggeredBy: 'manual',
+      claim: 'none',
+      guestIds: [guestId],
+      markSentOnSuccess: false,
+    });
+
+    revalidateOutreach(gate.gate.eventId);
+
+    if (!outcome.success) {
+      return {
+        success: false,
+        message:
+          outcome.message === 'No guests with valid phone numbers'
+            ? `${guest.name} has no usable phone number`
+            : outcome.message,
+      };
+    }
+
+    return { success: true, message: `Sent to ${guest.name}` };
+  } catch (error) {
+    console.error('sendScheduleToGuest failed:', error);
+    return { success: false, message: 'Failed to send the message' };
+  }
+}

--- a/src/features/admin/components/event-workspace.tsx
+++ b/src/features/admin/components/event-workspace.tsx
@@ -16,6 +16,7 @@ import {
   PublicEventActions,
   WorkspaceSignals,
 } from './event-workspace-client';
+import { QuickSendDialog } from './quick-send-dialog';
 import { RetryButton } from './retry-button';
 import {
   getEventGuestSummary,
@@ -317,14 +318,24 @@ export async function EventOutreachBand({ eventId }: { eventId: string }) {
     }
     const [rows, guestSummary] = await Promise.all([getEventTimeline(event.id), getEventGuestSummary(event.id)]);
     const canPlanCalls = guestSummary.pending + guestSummary.confirmed > 0;
+    // Cancelled messages are excluded: the schedule was called off, and a
+    // one-off send of it is the Operator resurrecting a decision, not helping a
+    // guest. Status is otherwise ignored - a planned message is exactly what a
+    // guest on the phone is usually asking for early.
+    const sendableMessages = rows
+      .filter((row) => row.kind === 'message' && row.status !== 'cancelled')
+      .map((row) => ({ id: row.id, title: row.title, scheduledDate: row.scheduledDate, status: row.status }));
     return (
       <Band
         id="outreach-timeline"
         title="Outreach timeline"
         className="scroll-mt-20"
-        action={canPlanCalls
-          ? <AddCallRoundDialog events={[{ id: event.id, title: event.title, pending: guestSummary.pending, confirmed: guestSummary.confirmed }]} eventId={event.id} />
-          : null}
+        action={(sendableMessages.length > 0 || canPlanCalls) ? (
+          <div className="flex shrink-0 gap-2">
+            {sendableMessages.length > 0 && <QuickSendDialog schedules={sendableMessages} />}
+            {canPlanCalls && <AddCallRoundDialog events={[{ id: event.id, title: event.title, pending: guestSummary.pending, confirmed: guestSummary.confirmed }]} eventId={event.id} />}
+          </div>
+        ) : null}
       >
         <BandRow>
           {rows.length ? (

--- a/src/features/admin/components/quick-send-dialog.tsx
+++ b/src/features/admin/components/quick-send-dialog.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { toast } from 'sonner';
+import { Send } from 'lucide-react';
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { AdminDialogContent } from './admin-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getQuickSendGuests, sendScheduleToGuest } from '../actions/quick-send';
+import type { QuickSendGuest } from '../actions/quick-send';
+import { cn } from '@/lib/utils';
+
+export type QuickSendSchedule = {
+  id: string;
+  title: string;
+  scheduledDate: string;
+  status: 'planned' | 'sent' | 'cancelled' | 'in_progress' | 'completed';
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+  });
+}
+
+/**
+ * One message, one guest, now.
+ *
+ * The Operator's case is a guest on the phone who never got the message or
+ * deleted it, so everything here is scoped to a single send: no multi-select,
+ * no audience filter, and no effect on the schedule's own status. Sending twice
+ * is allowed - the guest asking for it is the authority on whether it arrived -
+ * but a guest who already has a delivery is marked so it is a decision rather
+ * than an accident.
+ */
+export function QuickSendDialog({ schedules }: { schedules: QuickSendSchedule[] }) {
+  const [open, setOpen] = useState(false);
+  const [scheduleId, setScheduleId] = useState('');
+  const [guests, setGuests] = useState<QuickSendGuest[]>([]);
+  const [loadingGuests, setLoadingGuests] = useState(false);
+  const [query, setQuery] = useState('');
+  const [guestId, setGuestId] = useState('');
+  const [pending, startTransition] = useTransition();
+
+  const matches = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    const filtered = term
+      ? guests.filter(
+          (guest) =>
+            guest.name.toLowerCase().includes(term) ||
+            (guest.phone ?? '').includes(term),
+        )
+      : guests;
+    return filtered.slice(0, 50);
+  }, [guests, query]);
+
+  const selected = guests.find((guest) => guest.id === guestId) ?? null;
+
+  async function handleScheduleChange(value: string) {
+    setScheduleId(value);
+    setGuestId('');
+    setQuery('');
+    setGuests([]);
+    setLoadingGuests(true);
+    try {
+      setGuests(await getQuickSendGuests(value));
+    } catch (error) {
+      console.error('Quick send guest load failed:', error);
+      toast.error('Could not load the guest list');
+    } finally {
+      setLoadingGuests(false);
+    }
+  }
+
+  function reset() {
+    setScheduleId('');
+    setGuests([]);
+    setQuery('');
+    setGuestId('');
+  }
+
+  function submit() {
+    if (!scheduleId || !guestId) return;
+    startTransition(async () => {
+      const result = await sendScheduleToGuest(scheduleId, guestId);
+      if (result.success) {
+        toast.success(result.message);
+        setOpen(false);
+        reset();
+      } else {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="shrink-0 text-[13px]">
+          <Send className="size-[15px]" />
+          Quick send
+        </Button>
+      </DialogTrigger>
+
+      <AdminDialogContent className="sm:max-w-[460px]">
+        <DialogHeader>
+          <DialogTitle>Quick send</DialogTitle>
+          <DialogDescription>
+            Sends one message to one guest right now. The schedule itself is left alone
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="quick-send-schedule">Message</Label>
+            <Select value={scheduleId} onValueChange={handleScheduleChange}>
+              <SelectTrigger id="quick-send-schedule" className="w-full">
+                <SelectValue placeholder="Pick a message" />
+              </SelectTrigger>
+              <SelectContent>
+                {schedules.map((schedule) => (
+                  <SelectItem key={schedule.id} value={schedule.id}>
+                    {schedule.title}
+                    <span className="text-muted-foreground ml-2">
+                      {formatDate(schedule.scheduledDate)}
+                      {schedule.status === 'sent' ? ' · sent' : ''}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {scheduleId && (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="quick-send-guest">Guest</Label>
+              <Input
+                id="quick-send-guest"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search by name or phone"
+                autoComplete="off"
+              />
+
+              <div className="mt-1 max-h-56 overflow-y-auto rounded-md border">
+                {loadingGuests ? (
+                  <div className="flex flex-col gap-2 p-2.5">
+                    {[0, 1, 2].map((row) => (
+                      <Skeleton key={row} className="h-8 w-full" />
+                    ))}
+                  </div>
+                ) : matches.length === 0 ? (
+                  <p className="text-muted-foreground p-3 text-[12.5px]">
+                    {guests.length === 0
+                      ? 'This event has no guest records'
+                      : 'No guest matches that search'}
+                  </p>
+                ) : (
+                  matches.map((guest) => (
+                    <button
+                      key={guest.id}
+                      type="button"
+                      disabled={!guest.phone}
+                      onClick={() => setGuestId(guest.id)}
+                      className={cn(
+                        'flex w-full items-center justify-between gap-3 border-b px-3 py-2 text-left last:border-b-0',
+                        'disabled:cursor-not-allowed disabled:opacity-45',
+                        guest.id === guestId ? 'bg-accent' : 'hover:bg-accent/60',
+                      )}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-[13px] font-medium">
+                          {guest.name}
+                        </span>
+                        <span className="text-muted-foreground block truncate text-[12px]">
+                          {guest.phone ?? 'No phone number'}
+                          {guest.groupName ? ` · ${guest.groupName}` : ''}
+                        </span>
+                      </span>
+                      {guest.alreadySent && (
+                        <Badge variant="secondary" className="shrink-0 text-[11px]">
+                          Already sent
+                        </Badge>
+                      )}
+                    </button>
+                  ))
+                )}
+              </div>
+
+              {guests.length > matches.length && (
+                <p className="text-muted-foreground text-[12px]">
+                  Showing {matches.length} of {guests.length} guests - search to narrow it down
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="sm:items-center sm:justify-between">
+          <p className="text-muted-foreground text-[12.5px]">
+            {selected
+              ? selected.alreadySent
+                ? `${selected.name} already received this message`
+                : `Sending to ${selected.name}`
+              : 'Pick a message and a guest'}
+          </p>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={pending}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={submit} disabled={pending || !guestId}>
+              {pending ? 'Sending' : 'Send now'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </AdminDialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -18,6 +18,7 @@ export {
 } from './components/event-workspace';
 export { Band, BandRow } from './components/band';
 export { EnableSendingButton } from './components/enable-sending-button';
+export { QuickSendDialog, type QuickSendSchedule } from './components/quick-send-dialog';
 export { BackOfficeNav } from './components/back-office-nav';
 export { CountStrip } from './components/count-strip';
 export { SignalList } from './components/signal-list';


### PR DESCRIPTION
Restores the per-guest send the old Back Office had: an Operator with a guest on the phone who never got the message, or deleted it, had no way to resend it. The existing admin path only resends an already-sent schedule to guests that already have a delivery row.

Reuses the send engine with claim 'none' and markSentOnSuccess false, so the send is indifferent to the schedule's own status and audience and leaves a planned schedule for the cron to run on its own date.


Claude-Session: https://claude.ai/code/session_01TWboEaDwVSGuXdmXmhuM7k