### PR TITLE
Store Bit gifting as a payment link instead of a phone number

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1305,9 +1305,9 @@
       "payboxPlaceholder": "Paste your PayBox group invite link",
       "payboxHelper": "How to: Open the PayBox app, create a new Group for your event, click Invite Friends, copy the link, and paste it here.",
       "payboxSubtitle": "Let guests send you a gift through PayBox",
-      "bitLabel": "Bit Phone Number",
-      "bitPlaceholder": "Enter phone number",
-      "bitHelper": "Enter the mobile phone number connected to your Bit account",
+      "bitLabel": "Bit Payment Link",
+      "bitPlaceholder": "https://www.bitpay.co.il/app/me/...",
+      "bitHelper": "How to: Open the Bit app, go to your personal payment QR, share it, and copy the link (it starts with https://www.bitpay.co.il). Paste it here.",
       "bitSubtitle": "Instant transfer via Bit"
     }
   },

--- a/messages/he.json
+++ b/messages/he.json
@@ -1305,9 +1305,9 @@
       "payboxPlaceholder": "https://payboxapp.page.link/...",
       "payboxHelper": "כיצד לעשות: פתח את אפליקציית PayBox, צור קבוצה חדשה לאירוע, לחץ על הזמן חברים, העתק את הקישור והדבק אותו כאן.",
       "payboxSubtitle": "אפשר לאורחים להעביר לכם מתנה דרך PayBox",
-      "bitLabel": "מספר טלפון Bit",
-      "bitPlaceholder": "050-000-0000",
-      "bitHelper": "הזן את מספר הטלפון הנייד המחובר לחשבון Bit שלך",
+      "bitLabel": "קישור תשלום Bit",
+      "bitPlaceholder": "https://www.bitpay.co.il/app/me/...",
+      "bitHelper": "כיצד לעשות: פתח את אפליקציית Bit, עבור ל-QR האישי לתשלום, שתף אותו והעתק את הקישור (מתחיל ב-https://www.bitpay.co.il). הדבק אותו כאן.",
       "bitSubtitle": "העברה מיידית דרך Bit"
     }
   },

--- a/src/features/events/components/event-details/digital-gift-card.tsx
+++ b/src/features/events/components/event-details/digital-gift-card.tsx
@@ -32,7 +32,7 @@ const DigitalGiftCardSchema = EventDetailsUpdateSchema.pick({ id: true, eventSet
 type DigitalGiftCardValues = z.infer<typeof DigitalGiftCardSchema>;
 
 const PAYBOX_REGEX = /^https?:\/\//;
-const BIT_REGEX = /^\+?[\d\s\-]{7,}$/;
+const BIT_REGEX = /^https?:\/\/(www\.)?bitpay\.co\.il\//i;
 
 function PayboxIcon() {
   return <Image src="/gift-paybox-logo.svg" alt="PayBox" width={28} height={28} className="rounded-sm" />;
@@ -62,7 +62,7 @@ export function DigitalGiftCard({ event }: DigitalGiftCardProps) {
         },
         bitConfig: {
           enabled: event.eventSettings?.bitConfig?.enabled || false,
-          phoneNumber: event.eventSettings?.bitConfig?.phoneNumber || '',
+          link: event.eventSettings?.bitConfig?.link || '',
         },
       },
     },
@@ -71,10 +71,10 @@ export function DigitalGiftCard({ event }: DigitalGiftCardProps) {
   const isDirty = form.formState.isDirty;
 
   const payboxLink = form.watch('eventSettings.payboxConfig.link');
-  const bitPhone = form.watch('eventSettings.bitConfig.phoneNumber');
+  const bitLink = form.watch('eventSettings.bitConfig.link');
 
   const isPayboxValid = !!payboxLink && PAYBOX_REGEX.test(payboxLink);
-  const isBitValid = !!bitPhone && BIT_REGEX.test(bitPhone);
+  const isBitValid = !!bitLink && BIT_REGEX.test(bitLink);
 
   const [, formAction, isPending] = useActionState(
     async (_prev: UpdateEventDetailsState | null, formData: FormData) => {
@@ -182,18 +182,18 @@ export function DigitalGiftCard({ event }: DigitalGiftCardProps) {
                   >
                     <FormField
                       control={form.control}
-                      name="eventSettings.bitConfig.phoneNumber"
-                      render={({ field: phoneField }) => (
+                      name="eventSettings.bitConfig.link"
+                      render={({ field: linkField }) => (
                         <FormItem>
                           <FormLabel>{t('bitLabel')}</FormLabel>
                           <FormControl>
                             <div className="relative">
                               <Input
-                                type="tel"
+                                type="url"
                                 dir="ltr"
                                 placeholder={t('bitPlaceholder')}
                                 className={isBitValid ? 'pr-9 border-emerald-500' : ''}
-                                {...phoneField}
+                                {...linkField}
                               />
                               {isBitValid && (
                                 <Check className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-emerald-500" />

--- a/src/features/events/schemas/index.ts
+++ b/src/features/events/schemas/index.ts
@@ -35,9 +35,14 @@ export type PayboxConfig = z.infer<typeof PayboxConfigSchema>;
 // organiser's personal Bit payment link (copied from the Bit app, e.g. its
 // "personal QR"), used verbatim - Bit resolves the recipient from an opaque
 // token in the URL, not from a phone number.
+//
+// `link` is optional so legacy rows configured before this change - which hold
+// a `phoneNumber` and no `link` - still parse instead of throwing on read. Zod
+// drops the unknown `phoneNumber`; downstream code treats a missing link as
+// "not configured".
 export const BitConfigSchema = z.object({
   enabled: z.boolean(),
-  link: z.string(),
+  link: z.string().optional(),
 });
 
 export type BitConfig = z.infer<typeof BitConfigSchema>;

--- a/src/features/events/schemas/index.ts
+++ b/src/features/events/schemas/index.ts
@@ -31,10 +31,13 @@ export const PayboxConfigSchema = z.object({
 
 export type PayboxConfig = z.infer<typeof PayboxConfigSchema>;
 
-// Bit configuration for phone-based digital gifting
+// Bit configuration for link-based digital gifting. The link is the
+// organiser's personal Bit payment link (copied from the Bit app, e.g. its
+// "personal QR"), used verbatim - Bit resolves the recipient from an opaque
+// token in the URL, not from a phone number.
 export const BitConfigSchema = z.object({
   enabled: z.boolean(),
-  phoneNumber: z.string(),
+  link: z.string(),
 });
 
 export type BitConfig = z.infer<typeof BitConfigSchema>;
@@ -316,7 +319,7 @@ export const EventDetailsUpdateSchema = z.object({
       bitConfig: z
         .object({
           enabled: z.boolean().optional(),
-          phoneNumber: z.string().optional(),
+          link: z.string().optional(),
         })
         .optional(),
     })

--- a/src/features/events/utils/event.transform.ts
+++ b/src/features/events/utils/event.transform.ts
@@ -70,7 +70,7 @@ export function eventDetailsUpdateToDb(
     if (data.eventSettings?.bitConfig !== undefined) {
       dbData.event_settings.bit_config = {
         enabled: data.eventSettings.bitConfig.enabled ?? false,
-        phoneNumber: data.eventSettings.bitConfig.phoneNumber || '',
+        link: data.eventSettings.bitConfig.link || '',
       };
     }
   }

--- a/src/features/schedules/components/reminder-page.tsx
+++ b/src/features/schedules/components/reminder-page.tsx
@@ -4,16 +4,6 @@ import { Calendar, Clock, Gift, MapPin } from 'lucide-react';
 
 import { getReminderPageEvent } from '../queries/reminder';
 
-/**
- * Base of the Bit payment deep link, with the recipient's phone appended.
- *
- * This has to match the base that was registered on the approved WhatsApp
- * template's gift button, which is the only place it previously existed - it
- * was never in this codebase. Verify it against Meta's template manager before
- * relying on it in production.
- */
-const BIT_LINK_BASE = 'https://www.bitpay.co.il/app/me/';
-
 /** Shared shape of the three actions - navigate, Bit, PayBox. */
 const ACTION_CLASS =
   'border-border box-border flex w-full items-center justify-center gap-3 rounded-xl border bg-white px-5 transition-colors hover:border-primary hover:bg-[#FFFCFD]';
@@ -193,7 +183,7 @@ export async function ReminderPage({ code }: { code: string }) {
             <div className="mt-[18px] flex flex-col gap-3">
               {event.bit ? (
                 <a
-                  href={`${BIT_LINK_BASE}${event.bit.phoneNumber.replace(/\D/g, '')}`}
+                  href={event.bit.link}
                   target="_blank"
                   rel="noopener noreferrer"
                   className={`${ACTION_CLASS} min-h-[58px] text-[17px] font-medium`}

--- a/src/features/schedules/queries/reminder.ts
+++ b/src/features/schedules/queries/reminder.ts
@@ -27,7 +27,7 @@ export type ReminderPageEvent = {
   receptionTime: string | null;
   location: { name?: string; coords?: { lat: number; lng: number } } | null;
   paybox: { link: string } | null;
-  bit: { phoneNumber: string } | null;
+  bit: { link: string } | null;
 };
 
 export async function getReminderPageEvent(
@@ -47,7 +47,7 @@ export async function getReminderPageEvent(
 
   const settings = data.event_settings as {
     paybox_config?: { enabled: boolean; link: string };
-    bit_config?: { enabled: boolean; phoneNumber: string };
+    bit_config?: { enabled: boolean; link: string };
   } | null;
 
   const paybox = settings?.paybox_config;
@@ -77,9 +77,6 @@ export async function getReminderPageEvent(
     // toggle and its value are separate fields, and a button pointing at an
     // empty link is worse than no button.
     paybox: paybox?.enabled && paybox.link.trim() ? { link: paybox.link } : null,
-    bit:
-      bit?.enabled && bit.phoneNumber.trim()
-        ? { phoneNumber: bit.phoneNumber }
-        : null,
+    bit: bit?.enabled && bit.link.trim() ? { link: bit.link } : null,
   };
 }

--- a/src/features/schedules/queries/reminder.ts
+++ b/src/features/schedules/queries/reminder.ts
@@ -47,7 +47,10 @@ export async function getReminderPageEvent(
 
   const settings = data.event_settings as {
     paybox_config?: { enabled: boolean; link: string };
-    bit_config?: { enabled: boolean; link: string };
+    // `link` is optional: legacy rows configured before Bit moved from a phone
+    // number to a link have `phoneNumber` and no `link`. Such a row must read
+    // as "not configured", never crash - hence the optional chaining below.
+    bit_config?: { enabled: boolean; link?: string };
   } | null;
 
   const paybox = settings?.paybox_config;
@@ -77,6 +80,6 @@ export async function getReminderPageEvent(
     // toggle and its value are separate fields, and a button pointing at an
     // empty link is worse than no button.
     paybox: paybox?.enabled && paybox.link.trim() ? { link: paybox.link } : null,
-    bit: bit?.enabled && bit.link.trim() ? { link: bit.link } : null,
+    bit: bit?.enabled && bit.link?.trim() ? { link: bit.link } : null,
   };
 }

--- a/src/features/schedules/services/send-schedule.ts
+++ b/src/features/schedules/services/send-schedule.ts
@@ -91,7 +91,8 @@ function mapEventRow(rawEvent: Record<string, unknown>) {
   const invitations = rawEvent.invitations as Record<string, string> | null;
   const settings = rawEvent.event_settings as {
     paybox_config?: { enabled: boolean; link: string };
-    bit_config?: { enabled: boolean; link: string };
+    // Optional `link`: legacy rows still hold `phoneNumber` and no `link`.
+    bit_config?: { enabled: boolean; link?: string };
   } | null;
   const guestExperience = rawEvent.guests_experience as {
     send_table_numbers?: boolean;

--- a/src/features/schedules/services/send-schedule.ts
+++ b/src/features/schedules/services/send-schedule.ts
@@ -91,7 +91,7 @@ function mapEventRow(rawEvent: Record<string, unknown>) {
   const invitations = rawEvent.invitations as Record<string, string> | null;
   const settings = rawEvent.event_settings as {
     paybox_config?: { enabled: boolean; link: string };
-    bit_config?: { enabled: boolean; phoneNumber: string };
+    bit_config?: { enabled: boolean; link: string };
   } | null;
   const guestExperience = rawEvent.guests_experience as {
     send_table_numbers?: boolean;

--- a/src/features/schedules/utils/event-config.ts
+++ b/src/features/schedules/utils/event-config.ts
@@ -8,7 +8,7 @@
 export type GiftingSettings =
   | {
       payboxConfig?: { enabled: boolean; link: string };
-      bitConfig?: { enabled: boolean; phoneNumber: string };
+      bitConfig?: { enabled: boolean; link: string };
     }
   | null
   | undefined;
@@ -28,7 +28,7 @@ export function isGiftingEnabled(settings: GiftingSettings): boolean {
 
   return Boolean(
     (paybox?.enabled && paybox.link.trim()) ||
-      (bit?.enabled && bit.phoneNumber.trim()),
+      (bit?.enabled && bit.link.trim()),
   );
 }
 

--- a/src/features/schedules/utils/event-config.ts
+++ b/src/features/schedules/utils/event-config.ts
@@ -8,7 +8,9 @@
 export type GiftingSettings =
   | {
       payboxConfig?: { enabled: boolean; link: string };
-      bitConfig?: { enabled: boolean; link: string };
+      // `link` is optional so legacy rows still holding `phoneNumber` and no
+      // `link` read as "not configured" rather than crashing on `.trim()`.
+      bitConfig?: { enabled: boolean; link?: string };
     }
   | null
   | undefined;
@@ -28,7 +30,7 @@ export function isGiftingEnabled(settings: GiftingSettings): boolean {
 
   return Boolean(
     (paybox?.enabled && paybox.link.trim()) ||
-      (bit?.enabled && bit.link.trim()),
+      (bit?.enabled && bit.link?.trim()),
   );
 }
 


### PR DESCRIPTION
The Bit gift button on the reminder landing page opened the Bit app but never resolved a recipient: Bit's payment links are per-user, token-based URLs (the organiser's personal QR/link), not phone numbers. The old code built `https://www.bitpay.co.il/app/me/<digits>` from the stored phone number and additionally stripped every non-digit, so no phone value could ever produce a working link.

Model Bit like PayBox: store the organiser's full personal Bit link and use it verbatim on the landing page - no base construction, no digit stripping.

- BitConfig: `phoneNumber` -> `link` (schema, update schema, transform)
- Reminder page renders `event.bit.link` directly; drop BIT_LINK_BASE
- Settings card validates a bitpay.co.il URL and relabels the field
- Update en/he copy for the link-based field
- Rename the field in the gifting-enabled predicate and send-path row map

No message template references the Bit config (the reminder template's buttons were emptied when gifting moved to the landing page), so nothing on the WhatsApp/SMS send path needs a matching change.


Claude-Session: https://claude.ai/code/session_017BJ17fot4s8uXimPD7wB5t