### PR TITLE
Implement /admin/users - the Back Office directory

### DIFF
--- a/src/app/(admin)/admin/users/loading.tsx
+++ b/src/app/(admin)/admin/users/loading.tsx
@@ -1,0 +1,5 @@
+import { UsersIndexSkeleton } from '@/features/admin';
+
+export default function Loading() {
+  return <UsersIndexSkeleton />;
+}

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,8 +1,50 @@
-export default function UsersPage() {
-  return (
-    <div className="flex flex-col gap-2">
-      <h1 className="text-lg font-semibold tracking-tight">Users</h1>
-      <p className="text-muted-foreground text-sm">Not built yet - the Operator&apos;s view of every account will live here</p>
-    </div>
-  );
+import { TriangleAlert } from '@/components/icons';
+import { RetryButton, UsersIndex, UserSheet } from '@/features/admin';
+import { getUserDetail, getUsersIndex } from '@/features/admin/queries/users';
+import { areTestAccountsVisible } from '@/features/admin/queries/test-accounts';
+
+export const dynamic = 'force-dynamic';
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function UsersPage({ searchParams }: { searchParams: SearchParams }) {
+  const params = await searchParams;
+  const filters = {
+    q: typeof params.q === 'string' ? params.q.slice(0, 100) : '',
+    page: Math.max(1, Number.parseInt(typeof params.page === 'string' ? params.page : '1', 10) || 1),
+  };
+  const openUserId = typeof params.user === 'string' ? params.user : null;
+
+  try {
+    const [data, testAccountsVisible, detail] = await Promise.all([
+      getUsersIndex(filters),
+      areTestAccountsVisible(),
+      openUserId ? getUserDetail(openUserId) : Promise.resolve(undefined),
+    ]);
+
+    return (
+      <>
+        <UsersIndex
+          data={data}
+          filters={filters}
+          openUserId={openUserId}
+          testAccountsVisible={testAccountsVisible}
+        />
+        {detail !== undefined && <UserSheet detail={detail ?? 'not-found'} />}
+      </>
+    );
+  } catch (error) {
+    console.error('Users index failed:', error);
+    return (
+      <div className="bg-card flex flex-col items-center gap-2 rounded-xl border px-6 py-14 text-center">
+        <TriangleAlert className="text-destructive size-6" />
+        <h1 className="text-destructive text-[14.5px] font-medium">Users didn&apos;t load</h1>
+        <p className="text-muted-foreground max-w-sm text-[13px] leading-relaxed text-balance">
+          The directory is unavailable right now, so there is no count to show. Nothing here means
+          zero users
+        </p>
+        <RetryButton />
+      </div>
+    );
+  }
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -72,7 +72,10 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rtl:right-auto rtl:left-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close
+          data-slot="sheet-close"
+          className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rtl:right-auto rtl:left-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+        >
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>

--- a/src/features/admin/actions/index.ts
+++ b/src/features/admin/actions/index.ts
@@ -7,3 +7,4 @@ export {
   type QuickSendResult,
 } from './quick-send';
 export { setTestAccountsVisible } from './test-accounts';
+export { setUserTestAccountFlag, type SetTestAccountResult } from './users';

--- a/src/features/admin/actions/users.ts
+++ b/src/features/admin/actions/users.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+
+export type SetTestAccountResult = { success: boolean; message: string };
+
+/**
+ * `profiles.is_test_account` marks accounts that belong to the team - see
+ * queries/test-accounts.ts. Every Back Office read runs through
+ * `getTestScope()`, so flipping this flag silently changes every count in the
+ * Back Office: Overview cards, the events index, search, drill-downs.
+ *
+ * Today nothing can write this flag (it is a manual SQL update) and the brief
+ * names this page as where that action belongs. The confirm flow above this
+ * action is real and wired end to end; the write itself is deliberately left
+ * out pending an explicit go-ahead, since it is the one action here that
+ * changes numbers everywhere else in the Back Office. Once that sign-off
+ * happens, this becomes:
+ *
+ *   const supabase = createServiceClient();
+ *   const { error } = await supabase
+ *     .from('profiles')
+ *     .update({ is_test_account: value })
+ *     .eq('id', userId);
+ *   if (error) return { success: false, message: error.message };
+ *   revalidatePath('/admin', 'layout');
+ *   return {
+ *     success: true,
+ *     message: value ? 'Marked as a test account' : 'Test account mark removed',
+ *   };
+ */
+export async function setUserTestAccountFlag(
+  userId: string,
+  value: boolean,
+): Promise<SetTestAccountResult> {
+  void userId;
+  void value;
+  await assertAdmin();
+
+  return {
+    success: false,
+    message: 'Marking test accounts is not wired to the database yet',
+  };
+}

--- a/src/features/admin/components/admin-sheet.tsx
+++ b/src/features/admin/components/admin-sheet.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { SheetContent } from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+
+/**
+ * SheetContent for the Back Office, for exactly the reason AdminDialogContent
+ * exists (see that file): the Sheet portals to <body>, escaping the admin
+ * layout's `dir="ltr"`, and Tailwind's `rtl:` variant compiles to
+ * `[dir="rtl"] *`, which matches every descendant of the RTL <html> regardless
+ * of a nearer `dir="ltr"`. Both the direction and the close button's position
+ * have to be re-declared here rather than relied on from the portal root.
+ */
+export function AdminSheetContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SheetContent>) {
+  return (
+    <SheetContent
+      dir="ltr"
+      className={cn(
+        '[&_[data-slot=sheet-close]]:right-4 [&_[data-slot=sheet-close]]:left-auto',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </SheetContent>
+  );
+}

--- a/src/features/admin/components/back-office-nav.tsx
+++ b/src/features/admin/components/back-office-nav.tsx
@@ -27,7 +27,7 @@ import {
  */
 const NAV_ITEMS = [
   { label: 'Overview', href: '/admin', icon: LayoutDashboard, stub: false },
-  { label: 'Users', href: '/admin/users', icon: Users, stub: true },
+  { label: 'Users', href: '/admin/users', icon: Users, stub: false },
   { label: 'Events', href: '/admin/events', icon: CalendarDays, stub: false },
   { label: 'Operations', href: '/admin/operations', icon: Wrench, stub: false },
   {

--- a/src/features/admin/components/impersonate-owner-button.tsx
+++ b/src/features/admin/components/impersonate-owner-button.tsx
@@ -13,15 +13,18 @@ import { startImpersonation } from '../actions/impersonation';
 export function ImpersonateOwnerButton({
   ownerId,
   ownerName,
+  label = 'View as owner',
 }: {
   ownerId: string;
   ownerName: string;
+  /** "View as owner" on the event workspace; the Users sheet says "View as user" instead. */
+  label?: string;
 }) {
   return (
     <form action={startImpersonation.bind(null, ownerId)}>
       <Button type="submit" variant="outline" size="sm" title={`Open the app as ${ownerName}`}>
         <Eye className="size-3.5" />
-        View as owner
+        {label}
       </Button>
     </form>
   );

--- a/src/features/admin/components/mark-test-account-dialog.tsx
+++ b/src/features/admin/components/mark-test-account-dialog.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { AdminDialogContent } from './admin-dialog';
+import { Button } from '@/components/ui/button';
+import { setUserTestAccountFlag } from '../actions/users';
+
+/**
+ * Lives in the sheet's footer, not the row - nothing this consequential sits
+ * under a stray click. Marking and unmarking share one dialog because they
+ * are the same act in both directions: a confirm that names, in plain words,
+ * every count in the Back Office the flag controls. See the brief section 8.
+ */
+export function MarkTestAccountDialog({
+  userId,
+  userName,
+  isTestAccount,
+  children,
+}: {
+  userId: string;
+  userName: string;
+  isTestAccount: boolean;
+  children: (open: () => void) => React.ReactNode;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  function confirm() {
+    startTransition(async () => {
+      const result = await setUserTestAccountFlag(userId, !isTestAccount);
+      if (!result.success) {
+        toast.error(result.message);
+        return;
+      }
+      toast.success(result.message);
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      {children(() => setOpen(true))}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <AdminDialogContent className="sm:max-w-[428px]">
+          <DialogHeader>
+            <DialogTitle>
+              {isTestAccount ? 'Remove test account mark?' : 'Mark as test account?'}
+            </DialogTitle>
+            <DialogDescription>
+              {isTestAccount ? (
+                <>
+                  {userName} returns to every count in the Back Office, including the Overview
+                  cards and the events index
+                </>
+              ) : (
+                <>
+                  {userName} will be treated as a Kululu account, not a customer. This removes
+                  them from every count in the Back Office
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={pending}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={confirm} disabled={pending}>
+              {isTestAccount ? 'Remove the mark' : 'Mark as test account'}
+            </Button>
+          </DialogFooter>
+        </AdminDialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/admin/components/toggle-test-accounts-link.tsx
+++ b/src/features/admin/components/toggle-test-accounts-link.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { setTestAccountsVisible } from '../actions/test-accounts';
+
+/**
+ * The Users hidden-accounts footer flips the same global cookie as the top
+ * bar's `TestAccountsToggle` - a page-local switch here would fork the state
+ * two controls disagree about. Text rather than a track-and-knob because this
+ * sits inline in a sentence, not in the top bar.
+ */
+export function ToggleTestAccountsLink({ visible }: { visible: boolean }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      disabled={isPending}
+      onClick={() =>
+        startTransition(async () => {
+          await setTestAccountsVisible(!visible);
+          router.refresh();
+        })
+      }
+      className="text-primary decoration-primary/35 underline decoration-1 underline-offset-[3px] disabled:opacity-60"
+    >
+      {visible ? 'Hide them' : 'Show them'}
+    </button>
+  );
+}

--- a/src/features/admin/components/user-sheet.tsx
+++ b/src/features/admin/components/user-sheet.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+import { ChevronRight, Copy } from '@/components/icons';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetDescription, SheetTitle } from '@/components/ui/sheet';
+import { AdminSheetContent } from './admin-sheet';
+import { ImpersonateOwnerButton } from './impersonate-owner-button';
+import { MarkTestAccountDialog } from './mark-test-account-dialog';
+import type { UserDetail } from '../types';
+import { formatEventDate, formatFullDate } from '@/lib/date-time';
+import { ROLE_LABELS } from '@/features/collaborate/schemas';
+import { avatarTint, initialsFor } from '../utils/avatar';
+import { cn } from '@/lib/utils';
+
+const OWNS_VISIBLE_LIMIT = 6;
+
+export function UserSheet({ detail }: { detail: UserDetail | 'not-found' }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  function close() {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('user');
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname);
+  }
+
+  const isNotFound = detail === 'not-found';
+  const title = isNotFound ? 'User not found' : detail.fullName || detail.email;
+  const tint = avatarTint(isNotFound ? 'not-found' : detail.id);
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && close()}>
+      <AdminSheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-[452px]">
+        <div className="flex items-start gap-3 border-b px-5 py-4 pe-12">
+          <span
+            className="flex size-[38px] shrink-0 items-center justify-center rounded-full text-[13px] font-semibold"
+            style={{ background: tint.background, color: tint.color }}
+          >
+            {isNotFound ? '?' : initialsFor(detail.fullName, detail.email)}
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <SheetTitle className="truncate text-[16px] font-semibold tracking-tight">{title}</SheetTitle>
+              {!isNotFound && detail.isAdmin && (
+                <Badge variant="outline" className="text-muted-foreground shrink-0 px-1.5 py-0 text-[10px] tracking-[0.05em]">
+                  ADMIN
+                </Badge>
+              )}
+              {!isNotFound && detail.isTestAccount && (
+                <Badge variant="outline" className="text-muted-foreground shrink-0 px-1.5 py-0 text-[10px] tracking-[0.05em]">
+                  TEST
+                </Badge>
+              )}
+            </div>
+            <SheetDescription className="truncate text-[13px]">
+              {isNotFound
+                ? 'It may have been hidden by the test accounts toggle'
+                : detail.fullName
+                  ? detail.email
+                  : 'No name provided'}
+            </SheetDescription>
+          </div>
+          {!isNotFound && (
+            <ImpersonateOwnerButton ownerId={detail.id} ownerName={title} label="View as user" />
+          )}
+        </div>
+
+        {isNotFound ? (
+          <div className="flex-1 px-5 py-6 text-[13.5px] text-muted-foreground">
+            This user no longer exists, or is a test account currently hidden by the top bar toggle
+          </div>
+        ) : (
+          <UserSheetBody detail={detail} title={title} />
+        )}
+      </AdminSheetContent>
+    </Sheet>
+  );
+}
+
+function UserSheetBody({ detail, title }: { detail: UserDetail; title: string }) {
+  const hasOwns = detail.ownedEvents.length > 0;
+  const hasShared = detail.sharedEvents.length > 0;
+  const ownsVisible = detail.ownedEvents.slice(0, OWNS_VISIBLE_LIMIT);
+  const ownsHiddenCount = detail.ownedEvents.length - ownsVisible.length;
+
+  async function copyUserId() {
+    await navigator.clipboard.writeText(detail.id);
+    toast.success('User ID copied');
+  }
+
+  return (
+    <>
+      <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-5 py-4">
+        <SheetSection label="Contact">
+          <SheetField label="Email" value={detail.email} />
+          <SheetField
+            label="Phone"
+            value={detail.phone || 'Not provided'}
+            muted={!detail.phone}
+          />
+        </SheetSection>
+
+        <SheetSection label="Account">
+          <SheetField label="Joined" value={formatFullDate(detail.createdAt)} />
+          <SheetField
+            label="Onboarding"
+            value={detail.onboardingFinished ? 'Finished' : 'Not finished'}
+            muted={!detail.onboardingFinished}
+          />
+          <div className="grid grid-cols-[96px_1fr] items-baseline gap-3">
+            <span className="text-muted-foreground text-[12.5px]">User ID</span>
+            <div className="flex min-w-0 items-baseline gap-2">
+              <span className="text-muted-foreground truncate font-mono text-[12.5px]">{detail.id}</span>
+              <Button type="button" variant="link" size="xs" className="text-muted-foreground h-auto shrink-0 p-0" onClick={copyUserId}>
+                <Copy className="size-3" />
+                Copy
+              </Button>
+            </div>
+          </div>
+        </SheetSection>
+
+        {hasOwns && (
+          <SheetSection label={`Owns (${detail.ownedEvents.length})`}>
+            <div className="overflow-hidden rounded-lg border">
+              {ownsVisible.map((event, index) => (
+                <Link
+                  key={event.id}
+                  href={`/admin/events/${event.id}`}
+                  className={cn(
+                    'hover:bg-accent flex items-center gap-2.5 px-3 py-2.5',
+                    index > 0 && 'border-t',
+                  )}
+                >
+                  <span className="min-w-0 flex-1 truncate text-[13.5px]">{event.title}</span>
+                  <span className="text-muted-foreground shrink-0 text-[12.5px] tabular-nums">
+                    {event.eventDate ? formatEventDate(event.eventDate) : 'no date'}
+                  </span>
+                  <span
+                    className={cn(
+                      'w-[62px] shrink-0 text-right text-[12.5px]',
+                      event.status === 'draft' ? 'text-muted-foreground/70' : 'text-muted-foreground',
+                    )}
+                  >
+                    {event.status === 'draft' ? 'Draft' : 'Published'}
+                  </span>
+                  <ChevronRight className="text-muted-foreground/70 size-4 shrink-0" />
+                </Link>
+              ))}
+            </div>
+            {ownsHiddenCount > 0 && (
+              <span className="text-muted-foreground/70 text-[12px]">
+                {ownsHiddenCount} more, scroll for the rest
+              </span>
+            )}
+          </SheetSection>
+        )}
+
+        {hasShared && (
+          <SheetSection label={`Shared with them (${detail.sharedEvents.length})`}>
+            <div className="overflow-hidden rounded-lg border">
+              {detail.sharedEvents.map((event, index) => (
+                <Link
+                  key={event.id}
+                  href={`/admin/events/${event.id}`}
+                  className={cn(
+                    'hover:bg-accent flex items-center gap-2.5 px-3 py-2.5',
+                    index > 0 && 'border-t',
+                  )}
+                >
+                  <span className="min-w-0 flex-1 truncate text-[13.5px]">{event.title}</span>
+                  <span className="text-muted-foreground shrink-0 text-[12.5px]">{ROLE_LABELS[event.role]}</span>
+                  <ChevronRight className="text-muted-foreground/70 size-4 shrink-0" />
+                </Link>
+              ))}
+            </div>
+          </SheetSection>
+        )}
+
+        {!hasOwns && !hasShared && (
+          <SheetSection label="Events">
+            <span className="text-muted-foreground text-[13.5px]">No events yet</span>
+          </SheetSection>
+        )}
+      </div>
+
+      <div className="bg-muted flex items-center gap-2.5 border-t px-5 py-3">
+        <span className="text-muted-foreground/70 text-[12px]">
+          {detail.isTestAccount ? 'Excluded from every Back Office count' : 'Counted everywhere in the Back Office'}
+        </span>
+        <MarkTestAccountDialog userId={detail.id} userName={title} isTestAccount={detail.isTestAccount}>
+          {(open) => (
+            <Button type="button" variant="outline" size="sm" className="text-muted-foreground ms-auto shrink-0" onClick={open}>
+              {detail.isTestAccount ? 'Remove test account mark' : 'Mark as test account'}
+            </Button>
+          )}
+        </MarkTestAccountDialog>
+      </div>
+    </>
+  );
+}
+
+function SheetSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-muted-foreground text-[10.5px] font-semibold tracking-[0.08em] uppercase">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function SheetField({ label, value, muted }: { label: string; value: string; muted?: boolean }) {
+  return (
+    <div className="grid grid-cols-[96px_1fr] items-baseline gap-3">
+      <span className="text-muted-foreground text-[12.5px]">{label}</span>
+      <span className={cn('text-[13.5px] break-words', muted ? 'text-muted-foreground' : 'text-foreground')}>{value}</span>
+    </div>
+  );
+}

--- a/src/features/admin/components/users-index-skeleton.tsx
+++ b/src/features/admin/components/users-index-skeleton.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * Server rendered per request (see docs/admin/ADMIN-CONTEXT.md), so this is
+ * what actually paints while the query runs - a real skeleton, not a spinner.
+ * Row rhythm and column widths already match the populated table.
+ */
+export function UsersIndexSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-baseline gap-2.5">
+        <Skeleton className="h-6 w-16" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+      <Skeleton className="h-9 w-[320px]" />
+      <div className="bg-card overflow-hidden rounded-xl border">
+        <div className="flex items-center gap-3.5 border-b px-4 py-2.5">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="ms-auto h-3 w-16" />
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-3 w-12" />
+        </div>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <div key={index} className="flex items-center gap-3.5 border-b px-4 py-2.5 last:border-0">
+            <Skeleton className="size-[30px] shrink-0 rounded-full" />
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-2.5 w-44" />
+            </div>
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-3 w-14" />
+            <Skeleton className="h-3 w-11" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/components/users-index.tsx
+++ b/src/features/admin/components/users-index.tsx
@@ -1,0 +1,239 @@
+import Link from 'next/link';
+import { Search, Users as UsersIcon, X } from '@/components/icons';
+import { EyeOff } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@/components/ui/input-group';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { UserRow, UsersIndexFilters, UsersIndexPage } from '../types';
+import { formatEventDate } from '@/lib/date-time';
+import { avatarTint, initialsFor } from '../utils/avatar';
+import { cn } from '@/lib/utils';
+import { ToggleTestAccountsLink } from './toggle-test-accounts-link';
+
+function hrefFor(filters: UsersIndexFilters, patch: Partial<UsersIndexFilters & { user: string | null }>) {
+  const next = { ...filters, user: null as string | null, ...patch };
+  const params = new URLSearchParams();
+  if (next.q) params.set('q', next.q);
+  if (next.page > 1) params.set('page', String(next.page));
+  if (next.user) params.set('user', next.user);
+  const query = params.toString();
+  return query ? `/admin/users?${query}` : '/admin/users';
+}
+
+function countLabel(value: number, singular: string, plural = `${singular}s`) {
+  return `${value.toLocaleString('en-GB')} ${value === 1 ? singular : plural}`;
+}
+
+export function UsersIndex({
+  data,
+  filters,
+  openUserId,
+  testAccountsVisible,
+}: {
+  data: UsersIndexPage;
+  filters: UsersIndexFilters;
+  openUserId: string | null;
+  testAccountsVisible: boolean;
+}) {
+  const hasAnyUsers = data.totalUsers > 0;
+  const hasQuery = !!filters.q;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-baseline gap-2.5">
+        <h1 className="text-lg font-semibold tracking-tight">Users</h1>
+        <p className="text-muted-foreground text-[13px]">Everyone with an account, newest first</p>
+        {hasAnyUsers && (
+          <span className="text-muted-foreground ms-auto shrink-0 text-[13px] tabular-nums">
+            {countLabel(data.totalUsers, 'user')}
+          </span>
+        )}
+      </div>
+
+      {hasAnyUsers && (
+        <div className="flex items-center gap-2.5">
+          <form action="/admin/users" className="w-full max-w-[320px]">
+            {openUserId && <input type="hidden" name="user" value={openUserId} />}
+            <InputGroup>
+              <InputGroupAddon><Search /></InputGroupAddon>
+              <InputGroupInput name="q" defaultValue={filters.q} placeholder="Search name, email or phone" />
+            </InputGroup>
+          </form>
+          {hasQuery && (
+            <Button asChild variant="link" size="sm" className="text-muted-foreground h-auto p-1">
+              <Link href={hrefFor(filters, { q: '', page: 1, user: openUserId })}>Clear search</Link>
+            </Button>
+          )}
+        </div>
+      )}
+
+      {!hasAnyUsers ? (
+        <Empty className="bg-card min-h-80 border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon"><UsersIcon /></EmptyMedia>
+            <EmptyTitle>No users yet</EmptyTitle>
+            <EmptyDescription>
+              Accounts appear here the moment someone signs in for the first time
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : data.rows.length === 0 ? (
+        <Empty className="bg-card min-h-72 border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon"><Search /></EmptyMedia>
+            <EmptyTitle>No users match &quot;{filters.q.trim()}&quot;</EmptyTitle>
+            <EmptyDescription>
+              Search covers name, email and phone. {countLabel(data.totalUsers, 'user')} exist
+            </EmptyDescription>
+          </EmptyHeader>
+          <Button asChild variant="outline" size="sm">
+            <Link href={hrefFor(filters, { q: '', page: 1, user: openUserId })}>
+              <X data-icon="inline-start" />Clear search
+            </Link>
+          </Button>
+        </Empty>
+      ) : (
+        <div className="bg-card overflow-hidden rounded-xl border shadow-xs">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-muted/35 hover:bg-muted/35">
+                <TableHead className="px-4 text-[11px] tracking-[0.06em] uppercase">User</TableHead>
+                <TableHead className="w-[168px] text-[11px] tracking-[0.06em] uppercase">Phone</TableHead>
+                <TableHead className="w-[128px] text-[11px] tracking-[0.06em] uppercase">Events</TableHead>
+                <TableHead className="w-[84px] px-4 text-right text-[11px] tracking-[0.06em] uppercase">
+                  Joined
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.rows.map((row) => (
+                <UserTableRow key={row.id} row={row} filters={filters} isOpen={row.id === openUserId} />
+              ))}
+            </TableBody>
+          </Table>
+          <div className="text-muted-foreground flex items-center gap-2.5 border-t px-4 py-2.5 text-[12px] tabular-nums">
+            <span>
+              {data.totalRows === 0
+                ? 'No rows on this page'
+                : `Showing ${(data.page - 1) * data.pageSize + 1}-${Math.min(data.page * data.pageSize, data.totalRows)} of ${data.totalRows}, 50 per page`}
+            </span>
+            <span className="text-muted-foreground/70 ms-auto">Rows open the user sheet</span>
+            {data.pageCount > 1 && (
+              <div className="flex gap-2">
+                <Button asChild={data.page > 1} variant="outline" size="sm" disabled={data.page <= 1}>
+                  {data.page > 1 ? (
+                    <Link href={hrefFor(filters, { page: data.page - 1, user: openUserId })}>Previous</Link>
+                  ) : (
+                    <span>Previous</span>
+                  )}
+                </Button>
+                <Button asChild={data.page < data.pageCount} variant="outline" size="sm" disabled={data.page >= data.pageCount}>
+                  {data.page < data.pageCount ? (
+                    <Link href={hrefFor(filters, { page: data.page + 1, user: openUserId })}>Next</Link>
+                  ) : (
+                    <span>Next</span>
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {data.testAccountsTotal > 0 && (
+        <div className="flex items-center gap-1.5 px-0.5 text-[12.5px]">
+          <EyeOff className="text-muted-foreground size-3.5" />
+          <span className="text-muted-foreground tabular-nums">
+            {testAccountsVisible
+              ? `${countLabel(data.testAccountsTotal, 'test account')} shown, counted nowhere else`
+              : `${countLabel(data.testAccountsTotal, 'test account')} hidden`}
+          </span>
+          <ToggleTestAccountsLink visible={testAccountsVisible} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UserTableRow({
+  row,
+  filters,
+  isOpen,
+}: {
+  row: UserRow;
+  filters: UsersIndexFilters;
+  isOpen: boolean;
+}) {
+  const tint = avatarTint(row.id);
+  const hasName = !!row.fullName;
+
+  return (
+    <TableRow className={cn('group relative', isOpen && 'bg-accent hover:bg-accent')}>
+      <TableCell className="relative px-4 py-2.5">
+        <Link href={hrefFor(filters, { user: row.id })} className="flex min-w-0 items-center gap-2.5 after:absolute after:inset-0">
+          <span
+            className="flex size-[30px] shrink-0 items-center justify-center rounded-full text-[11.5px] font-semibold"
+            style={{ background: tint.background, color: tint.color }}
+          >
+            {initialsFor(row.fullName, row.email)}
+          </span>
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span className="truncate text-[14px] font-medium group-hover:underline">
+                {row.fullName || row.email}
+              </span>
+              {row.isAdmin && (
+                <Badge variant="outline" className="text-muted-foreground shrink-0 px-1.5 py-0 text-[10px] tracking-[0.05em]">
+                  ADMIN
+                </Badge>
+              )}
+              {row.isTestAccount && (
+                <Badge variant="outline" className="text-muted-foreground shrink-0 px-1.5 py-0 text-[10px] tracking-[0.05em]">
+                  TEST
+                </Badge>
+              )}
+            </span>
+            <span className={cn('truncate text-[12.5px]', hasName ? 'text-muted-foreground' : 'text-muted-foreground/70')}>
+              {hasName ? row.email : 'No name provided'}
+            </span>
+          </span>
+        </Link>
+      </TableCell>
+      <TableCell className={cn('text-[13px] tabular-nums', !row.phone && 'text-muted-foreground/70')}>
+        {row.phone || 'not provided'}
+      </TableCell>
+      <TableCell>
+        <span className={cn('block text-[13px] tabular-nums', row.ownedEvents === 0 && 'text-muted-foreground')}>
+          {row.ownedEvents > 0 ? countLabel(row.ownedEvents, 'owned', 'owned') : 'None'}
+        </span>
+        {row.sharedEvents > 0 && (
+          <span className="text-muted-foreground block text-[12px] tabular-nums">
+            +{row.sharedEvents} shared
+          </span>
+        )}
+      </TableCell>
+      <TableCell className="px-4 text-right text-[13px] tabular-nums">
+        {formatEventDate(row.createdAt, { year: false })}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -17,6 +17,7 @@ export {
   EventSignalsBand,
 } from './components/event-workspace';
 export { Band, BandRow } from './components/band';
+export { RetryButton } from './components/retry-button';
 export { EnableSendingButton } from './components/enable-sending-button';
 export { QuickSendDialog, type QuickSendSchedule } from './components/quick-send-dialog';
 export { BackOfficeNav } from './components/back-office-nav';
@@ -28,4 +29,10 @@ export { ImpersonationBanner } from './components/impersonation-banner';
 export { ImpersonateOwnerButton } from './components/impersonate-owner-button';
 export { OperatorSearch } from './components/operator-search';
 export { TestAccountsToggle } from './components/test-accounts-toggle';
+export { ToggleTestAccountsLink } from './components/toggle-test-accounts-link';
+export { UsersIndex } from './components/users-index';
+export { UsersIndexSkeleton } from './components/users-index-skeleton';
+export { UserSheet } from './components/user-sheet';
+export { MarkTestAccountDialog } from './components/mark-test-account-dialog';
+export { AdminSheetContent } from './components/admin-sheet';
 export { resolveAdminTopBar, type AdminTopBarMode } from './utils/topbar';

--- a/src/features/admin/queries/index.ts
+++ b/src/features/admin/queries/index.ts
@@ -8,3 +8,4 @@ export {
   getEventTimeline,
   getEventsIndex,
 } from './events';
+export { getUsersIndex, getUserDetail } from './users';

--- a/src/features/admin/queries/users.ts
+++ b/src/features/admin/queries/users.ts
@@ -1,0 +1,186 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import type { CollaboratorRole } from '@/features/collaborate/schemas';
+import type { UserDetail, UserRow, UserSharedEvent, UsersIndexFilters, UsersIndexPage } from '../types';
+import { excludeIds, getTestScope } from './test-accounts';
+
+const PAGE_SIZE = 50;
+
+function unwrap<T>(result: { data: T | null; error: { message: string } | null }): T {
+  if (result.error) throw new Error(result.error.message);
+  if (result.data === null) throw new Error('Query returned no data');
+  return result.data;
+}
+
+type ProfileRow = {
+  id: string;
+  full_name: string | null;
+  email: string;
+  phone_number: string | null;
+  is_admin: boolean | null;
+  is_test_account: boolean | null;
+  created_at: string;
+};
+
+/**
+ * The whole directory, filtered and paged in memory rather than in SQL - the
+ * documented snapshot is 13 rows and the brief only asks this to survive a few
+ * hundred (section 11), which is well inside what one query and an array
+ * filter can hold. `getEventsIndex` takes the same shape for the same reason.
+ */
+export async function getUsersIndex(filters: UsersIndexFilters): Promise<UsersIndexPage> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+  const test = await getTestScope();
+
+  const [profilesResult, testAccountsCount] = await Promise.all([
+    excludeIds(
+      supabase
+        .from('profiles')
+        .select('id, full_name, email, phone_number, is_admin, is_test_account, created_at')
+        .order('created_at', { ascending: false }),
+      'id',
+      test.userIds,
+    ),
+    // Independent of the toggle: the hidden-accounts footer needs "how many
+    // exist" regardless of whether they are showing right now.
+    supabase.from('profiles').select('id', { count: 'exact', head: true }).eq('is_test_account', true),
+  ]);
+
+  const profiles = unwrap(profilesResult) as unknown as ProfileRow[];
+  if (testAccountsCount.error) throw new Error(testAccountsCount.error.message);
+
+  const profileIds = profiles.map((profile) => profile.id);
+  const ownedByUser = new Map<string, number>();
+  const sharedByUser = new Map<string, number>();
+
+  if (profileIds.length) {
+    const [eventsResult, collaboratorsResult] = await Promise.all([
+      supabase.from('events').select('user_id').in('user_id', profileIds),
+      supabase
+        .from('event_collaborators')
+        .select('user_id')
+        .eq('is_creator', false)
+        .in('user_id', profileIds),
+    ]);
+    if (eventsResult.error) throw new Error(eventsResult.error.message);
+    if (collaboratorsResult.error) throw new Error(collaboratorsResult.error.message);
+
+    for (const row of eventsResult.data ?? []) {
+      ownedByUser.set(row.user_id, (ownedByUser.get(row.user_id) ?? 0) + 1);
+    }
+    for (const row of collaboratorsResult.data ?? []) {
+      if (!row.user_id) continue;
+      sharedByUser.set(row.user_id, (sharedByUser.get(row.user_id) ?? 0) + 1);
+    }
+  }
+
+  const allRows: UserRow[] = profiles.map((profile) => ({
+    id: profile.id,
+    fullName: profile.full_name?.trim() || null,
+    email: profile.email,
+    phone: profile.phone_number,
+    isAdmin: !!profile.is_admin,
+    isTestAccount: !!profile.is_test_account,
+    ownedEvents: ownedByUser.get(profile.id) ?? 0,
+    sharedEvents: sharedByUser.get(profile.id) ?? 0,
+    createdAt: profile.created_at,
+  }));
+
+  // Matches name, email and phone, ignoring whitespace so a spaced-out phone
+  // number like "052 123 4567" is findable by its digits alone.
+  const needle = filters.q.trim().toLocaleLowerCase('en').replace(/\s/g, '');
+  const filtered = needle
+    ? allRows.filter((row) => {
+        const haystack = `${row.fullName ?? ''} ${row.email} ${row.phone ?? ''}`
+          .toLocaleLowerCase('en')
+          .replace(/\s/g, '');
+        return haystack.includes(needle);
+      })
+    : allRows;
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const page = Math.min(Math.max(1, filters.page), pageCount);
+  const start = (page - 1) * PAGE_SIZE;
+
+  return {
+    rows: filtered.slice(start, start + PAGE_SIZE),
+    totalRows: filtered.length,
+    page,
+    pageSize: PAGE_SIZE,
+    pageCount,
+    totalUsers: allRows.length,
+    testAccountsTotal: testAccountsCount.count ?? 0,
+  };
+}
+
+/**
+ * The sheet's data. Returns null both when the id does not exist and when it
+ * belongs to a test account currently hidden by the global toggle - the same
+ * "not reachable while hidden" rule `getEventRouteState` applies to Events, so
+ * a direct `?user=` link cannot resurrect a User the toggle is hiding.
+ */
+export async function getUserDetail(userId: string): Promise<UserDetail | null> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+  const test = await getTestScope();
+  if (test.userIds.includes(userId)) return null;
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('id, full_name, email, phone_number, is_admin, is_test_account, created_at, initial_setup_complete')
+    .eq('id', userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!profile) return null;
+
+  const [ownedResult, sharedResult] = await Promise.all([
+    supabase
+      .from('events')
+      .select('id, title, event_date, status')
+      .eq('user_id', userId)
+      .order('event_date', { ascending: true, nullsFirst: false }),
+    // event_collaborators.event_id has exactly one foreign key to events, so
+    // it embeds unqualified - see getEventIdentity for where two paths to the
+    // same table force the `!constraint_name` form instead.
+    supabase
+      .from('event_collaborators')
+      .select('role, events(id, title, event_date)')
+      .eq('user_id', userId)
+      .eq('is_creator', false),
+  ]);
+  if (ownedResult.error) throw new Error(ownedResult.error.message);
+  if (sharedResult.error) throw new Error(sharedResult.error.message);
+
+  return {
+    id: profile.id,
+    fullName: profile.full_name?.trim() || null,
+    email: profile.email,
+    phone: profile.phone_number,
+    isAdmin: !!profile.is_admin,
+    isTestAccount: !!profile.is_test_account,
+    createdAt: profile.created_at,
+    onboardingFinished: !!profile.initial_setup_complete,
+    ownedEvents: (ownedResult.data ?? []).map((event) => ({
+      id: event.id,
+      title: event.title?.trim() || 'Untitled event',
+      eventDate: event.event_date,
+      status: event.status === 'draft' ? 'draft' : 'published',
+    })),
+    sharedEvents: (sharedResult.data ?? [])
+      .map((row) => {
+        const event = row.events as unknown as
+          | { id: string; title: string | null; event_date: string | null }
+          | null;
+        if (!event) return null;
+        return {
+          id: event.id,
+          title: event.title?.trim() || 'Untitled event',
+          role: row.role as CollaboratorRole,
+        };
+      })
+      .filter((row): row is UserSharedEvent => row !== null),
+  };
+}

--- a/src/features/admin/types.ts
+++ b/src/features/admin/types.ts
@@ -1,3 +1,5 @@
+import type { CollaboratorRole } from '@/features/collaborate/schemas';
+
 /**
  * Back Office view models. Vocabulary is defined in CONTEXT.md - in particular
  * Signal, Operator and the Guest Record / Guest distinction.
@@ -243,4 +245,73 @@ export type PlannedWorkQueue = {
   groups: PlannedWorkGroup[];
   callRounds: number;
   messages: number;
+};
+
+/**
+ * A directory, not a scoreboard - see docs/design/back-office-users-brief.md
+ * section 3. Most rows are partly empty and that is ordinary, not a defect, so
+ * nothing here is a completeness score or a judgement about the User.
+ */
+export type UserRow = {
+  id: string;
+  /** null when the profile has no full_name - the email becomes the primary line instead. */
+  fullName: string | null;
+  email: string;
+  phone: string | null;
+  isAdmin: boolean;
+  isTestAccount: boolean;
+  /** Events where this User is the creator, draft and published alike. */
+  ownedEvents: number;
+  /** Non-creator collaborations - Owner or Seating Manager on someone else's Event. */
+  sharedEvents: number;
+  createdAt: string;
+};
+
+export type UsersIndexFilters = {
+  q: string;
+  page: number;
+};
+
+export type UsersIndexPage = {
+  rows: UserRow[];
+  totalRows: number;
+  page: number;
+  pageSize: number;
+  pageCount: number;
+  /** Every User the toggle currently shows, unfiltered - the "N users" headline. */
+  totalUsers: number;
+  /** profiles.is_test_account = true, regardless of the toggle - drives the hidden-accounts footer. */
+  testAccountsTotal: number;
+};
+
+export type UserOwnedEvent = {
+  id: string;
+  title: string;
+  eventDate: string | null;
+  status: 'published' | 'draft';
+};
+
+export type UserSharedEvent = {
+  id: string;
+  title: string;
+  role: CollaboratorRole;
+};
+
+export type UserDetail = {
+  id: string;
+  fullName: string | null;
+  email: string;
+  phone: string | null;
+  isAdmin: boolean;
+  isTestAccount: boolean;
+  createdAt: string;
+  /**
+   * `profiles.initial_setup_complete`, labelled honestly. Set unconditionally
+   * the moment the setup form is submitted, even with a null phone number, so
+   * it means "passed through setup" and never "profile complete" - see the
+   * brief section 4. Never render it as a completeness signal.
+   */
+  onboardingFinished: boolean;
+  ownedEvents: UserOwnedEvent[];
+  sharedEvents: UserSharedEvent[];
 };

--- a/src/features/admin/utils/avatar.ts
+++ b/src/features/admin/utils/avatar.ts
@@ -1,0 +1,42 @@
+/**
+ * The Users table and sheet share one avatar treatment: a tinted initials
+ * circle, no photos. The tint is derived from the User's id so it is stable
+ * across a render rather than reshuffling on every page load.
+ */
+const TINTS = [
+  ['oklch(0.94 0.03 333)', 'oklch(0.45 0.16 333)'],
+  ['oklch(0.94 0.02 250)', 'oklch(0.44 0.09 250)'],
+  ['oklch(0.94 0.03 160)', 'oklch(0.42 0.08 160)'],
+  ['oklch(0.94 0.035 70)', 'oklch(0.44 0.09 70)'],
+  ['oklch(0.945 0.004 286)', 'oklch(0.45 0.01 286)'],
+] as const;
+
+function hash(seed: string): number {
+  let value = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    value = (value * 31 + seed.charCodeAt(index)) >>> 0;
+  }
+  return value;
+}
+
+export function avatarTint(id: string): { background: string; color: string } {
+  const [background, color] = TINTS[hash(id) % TINTS.length];
+  return { background, color };
+}
+
+/**
+ * Two letters from the name, or from the email when `full_name` is null - a
+ * User is never rendered as "Unknown user". Hebrew names are supported: the
+ * check is "is this a letter", not "is this ASCII".
+ */
+// Escapes rather than a literal range: U+0590 to U+05FF is the Hebrew block.
+const NAME_LETTER = new RegExp('[A-Za-z\\u0590-\\u05FF]');
+
+export function initialsFor(name: string | null, email: string): string {
+  if (name) {
+    const parts = name.trim().split(/\s+/).filter((part) => NAME_LETTER.test(part[0]));
+    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  }
+  return email.slice(0, 2).toUpperCase();
+}

--- a/src/lib/date-time.ts
+++ b/src/lib/date-time.ts
@@ -26,6 +26,16 @@ export function formatEventDate(
   return options?.weekday ? formatted.replace(',', '') : formatted;
 }
 
+/** "12 August 2026" - the full-month form used where a date stands alone, e.g. the Users sheet. */
+export function formatFullDate(iso: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'UTC',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(iso));
+}
+
 export function formatScheduleDateTime(iso: string, time?: string | null): string {
   const value = new Date(iso);
   const date = new Intl.DateTimeFormat('en-GB', {


### PR DESCRIPTION
Builds the Users tab per docs/design/back-office-users-brief.md and the Claude Design handoff (Back Office Users.dc.html): a table of every User (search, pagination at 50/page, absence rendered as words per section 7) and a side sheet driven by ?user=<id> (contact/account/owns/shared, View as user, mark/unmark test account).

- src/features/admin/queries/users.ts: getUsersIndex, getUserDetail - read-only, gated by assertAdmin, respecting the global test-accounts scope like every other admin query.
- src/features/admin/actions/users.ts: setUserTestAccountFlag is deliberately stubbed (returns "not wired yet") - the confirm/cancel flow is real, the profiles.is_test_account write is left commented out pending explicit sign-off, since it changes every count in the Back Office. View as user instead reuses the existing, already-real startImpersonation action.
- New AdminSheetContent fixes the same RTL close-button trap AdminDialogContent already fixes for Dialog (Sheet portals to <body> and needs its own dir="ltr" and a re-pinned close control).
- back-office-nav.tsx: Users no longer shows the Stub badge.

Verified: tsc --noEmit, eslint, and next build all clean.