### PR TITLE
Add batch send dialog for paced message delivery

### DIFF
--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -7,6 +7,7 @@ export {
   ExternalLink,
   Eye,
   Info,
+  Layers,
   Link2,
   MapPin,
   MessageSquare,

--- a/src/features/admin/actions/batch-send.ts
+++ b/src/features/admin/actions/batch-send.ts
@@ -1,0 +1,257 @@
+'use server';
+
+import { assertAdmin } from '@/lib/supabase/admin';
+import { createServiceClient } from '@/lib/supabase/service';
+import { validatePhoneNumber } from '@/features/schedules';
+import { revalidateOutreach } from '@/features/schedules/services/revalidate-outreach';
+import { sendSchedule } from '@/features/schedules/services/send-schedule';
+import { gateScheduleForSend } from '../services/schedule-send-gate';
+import { MAX_BATCH_SIZE } from '../utils/batch-send';
+
+export type BatchSendRecipient = {
+  id: string;
+  name: string;
+  phone: string;
+  groupName: string | null;
+  rsvpStatus: string;
+};
+
+export type BatchSendPlan = {
+  scheduleId: string;
+  scheduleTitle: string;
+  /** null = still planned; the first successful batch claims it as sent */
+  status: 'sent' | 'cancelled' | null;
+  targetStatus: 'pending' | 'confirmed' | null;
+  /** Guest records in the schedule's target audience, reachable or not */
+  audienceCount: number;
+  /** Audience records with no usable phone - they can never receive this */
+  unreachableCount: number;
+  /** Reachable records that already have a successful delivery for this schedule */
+  deliveredCount: number;
+  /** Reachable records still waiting, in the order batches consume them */
+  remaining: BatchSendRecipient[];
+};
+
+export type BatchSendPlanResult =
+  | { ok: true; plan: BatchSendPlan }
+  | { ok: false; message: string };
+
+export type BatchSendResult = {
+  success: boolean;
+  message: string;
+  sentCount?: number;
+  failedCount?: number;
+  /** The plan as it stands after the batch, so the dialog can go straight into the next one */
+  plan?: BatchSendPlan;
+};
+
+type GuestRow = {
+  id: string;
+  name: string;
+  phone_number: string | null;
+  rsvp_status: string;
+  groups: unknown;
+};
+
+function groupName(value: unknown): string | null {
+  const group = (Array.isArray(value) ? value[0] : value) as { name: string } | null;
+  return group?.name ?? null;
+}
+
+/**
+ * Rebuilds the audience the send engine would have targeted, then splits it the
+ * way a batched send needs it.
+ *
+ * The engine's own targeting is bypassed when a caller passes `guestIds`, which
+ * a batch always does - so the target-status filter has to be reproduced here
+ * or a batch would happily include guests the schedule was never meant for.
+ * Same predicate as the outreach timeline: a null target means everyone.
+ */
+async function buildPlan(
+  supabase: ReturnType<typeof createServiceClient>,
+  scheduleId: string,
+  gate: {
+    eventId: string;
+    scheduleTitle: string;
+    status: 'sent' | 'cancelled' | null;
+    targetStatus: 'pending' | 'confirmed' | null;
+  },
+): Promise<BatchSendPlan> {
+  const [guestsResult, deliveriesResult] = await Promise.all([
+    supabase
+      .from('guests')
+      .select('id, name, phone_number, rsvp_status, groups(name)')
+      .eq('event_id', gate.eventId)
+      // Deterministic order so "the first 100" means the same list on every
+      // reload, and so consecutive batches walk the guest list front to back.
+      .order('name', { ascending: true })
+      .order('id', { ascending: true }),
+    supabase
+      .from('message_deliveries')
+      .select('guest_id')
+      .eq('schedule_id', scheduleId)
+      .in('status', ['sent', 'delivered', 'read']),
+  ]);
+  if (guestsResult.error) throw guestsResult.error;
+  if (deliveriesResult.error) throw deliveriesResult.error;
+
+  const audience = ((guestsResult.data ?? []) as GuestRow[]).filter(
+    (guest) => !gate.targetStatus || guest.rsvp_status === gate.targetStatus,
+  );
+  const reachable = audience.filter((guest) => validatePhoneNumber(guest.phone_number));
+  const delivered = new Set((deliveriesResult.data ?? []).map((row) => row.guest_id));
+
+  return {
+    scheduleId,
+    scheduleTitle: gate.scheduleTitle,
+    status: gate.status,
+    targetStatus: gate.targetStatus,
+    audienceCount: audience.length,
+    unreachableCount: audience.length - reachable.length,
+    deliveredCount: reachable.filter((guest) => delivered.has(guest.id)).length,
+    remaining: reachable
+      .filter((guest) => !delivered.has(guest.id))
+      .map((guest) => ({
+        id: guest.id,
+        name: guest.name,
+        phone: guest.phone_number!,
+        groupName: groupName(guest.groups),
+        rsvpStatus: guest.rsvp_status,
+      })),
+  };
+}
+
+/**
+ * What is left to send, and to whom.
+ *
+ * Fetched when the dialog opens rather than shipped with the page: a full guest
+ * list on every workspace render is a large RSC payload nobody asked for, and
+ * the numbers go stale the moment a batch lands anyway.
+ */
+export async function getBatchSendPlan(scheduleId: string): Promise<BatchSendPlanResult> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  try {
+    const gate = await gateScheduleForSend(supabase, scheduleId);
+    if (!gate.ok) return gate;
+    return { ok: true, plan: await buildPlan(supabase, scheduleId, gate.gate) };
+  } catch (error) {
+    console.error('getBatchSendPlan failed:', error);
+    return { ok: false, message: 'Could not work out who is left to send to' };
+  }
+}
+
+/**
+ * Sends one message to part of its audience, now.
+ *
+ * The case is a WhatsApp sending limit that will not carry the whole list in
+ * one go: the Operator sends a few hundred, waits out the window, and comes
+ * back for the rest. Every batch writes the same `message_deliveries` rows and
+ * confirmation tokens a single send would have, so the owner's schedule page
+ * fills in as the batches land rather than all at once at the end.
+ *
+ * The first successful batch marks the schedule sent. That is a claim on the
+ * row rather than a statement that everyone has it: a schedule left at
+ * `status IS NULL` past its date is picked up by the cron, which would send the
+ * entire remainder in one blast and undo the pacing this feature exists to
+ * provide. `schedule_completion_status` has only `sent` and `cancelled`, so
+ * there is no third state to park it in. The dialog says as much, and both it
+ * and the outreach timeline show how much of the audience is still waiting.
+ */
+export async function sendScheduleBatch(
+  scheduleId: string,
+  guestIds: string[],
+): Promise<BatchSendResult> {
+  await assertAdmin();
+  const supabase = createServiceClient();
+
+  const selected = [...new Set(guestIds)];
+  if (!selected.length) {
+    return { success: false, message: 'Select at least one guest' };
+  }
+  if (selected.length > MAX_BATCH_SIZE) {
+    return {
+      success: false,
+      message: `A batch can carry at most ${MAX_BATCH_SIZE} guests`,
+    };
+  }
+
+  try {
+    const gate = await gateScheduleForSend(supabase, scheduleId);
+    if (!gate.ok) return { success: false, message: gate.message };
+    if (gate.gate.status === 'cancelled') {
+      return { success: false, message: 'This message was cancelled by the owner' };
+    }
+
+    const before = await buildPlan(supabase, scheduleId, gate.gate);
+    const queued = new Set(before.remaining.map((recipient) => recipient.id));
+    // A guest id from another event, from outside the target audience, or one
+    // that was already delivered while the dialog sat open. Refusing the whole
+    // batch is right: the Operator picked a list, and silently sending a
+    // different one is worse than making them re-pick.
+    if (selected.some((id) => !queued.has(id))) {
+      return {
+        success: false,
+        message: 'Some selected guests are no longer waiting for this message - reload and pick again',
+      };
+    }
+
+    const outcome = await sendSchedule(scheduleId, {
+      supabase,
+      triggeredBy: 'manual',
+      claim: 'none',
+      guestIds: selected,
+      // The batch decides when the schedule closes out, below - the engine
+      // would otherwise mark it sent on the first batch and move `sent_at`
+      // forward on every one after it.
+      markSentOnSuccess: false,
+      // Belt and braces against a double submit: the engine drops anyone who
+      // already has a successful delivery for this schedule.
+      skipAlreadyDelivered: true,
+    });
+
+    const after = await buildPlan(supabase, scheduleId, gate.gate);
+
+    if (outcome.sentCount > 0 && gate.gate.status === null) {
+      const { error: claimError } = await supabase
+        .from('schedules')
+        .update({ status: 'sent', sent_at: new Date().toISOString() })
+        .eq('id', scheduleId)
+        .is('status', null);
+      if (claimError) {
+        console.error('sendScheduleBatch could not mark the schedule sent:', claimError);
+      } else {
+        after.status = 'sent';
+      }
+    }
+
+    revalidateOutreach(gate.gate.eventId);
+
+    if (!outcome.success) {
+      return { success: false, message: outcome.message, plan: after };
+    }
+
+    const sent = outcome.sentCount;
+    // The engine reports success having sent nothing when every guest in the
+    // batch picked up a delivery between the plan being built and the send -
+    // a second Operator working the same list. Say so rather than claiming a
+    // batch of zero went out.
+    if (sent === 0) {
+      return { success: false, message: outcome.message, plan: after };
+    }
+    const left = after.remaining.length;
+    return {
+      success: true,
+      message: left
+        ? `Sent to ${sent} ${sent === 1 ? 'guest' : 'guests'} - ${left} still to go`
+        : `Sent to ${sent} ${sent === 1 ? 'guest' : 'guests'} - everyone has now received this message`,
+      sentCount: outcome.sentCount,
+      failedCount: outcome.failedCount,
+      plan: after,
+    };
+  } catch (error) {
+    console.error('sendScheduleBatch failed:', error);
+    return { success: false, message: 'Failed to send the batch' };
+  }
+}

--- a/src/features/admin/actions/index.ts
+++ b/src/features/admin/actions/index.ts
@@ -1,3 +1,11 @@
+export {
+  getBatchSendPlan,
+  sendScheduleBatch,
+  type BatchSendPlan,
+  type BatchSendPlanResult,
+  type BatchSendRecipient,
+  type BatchSendResult,
+} from './batch-send';
 export { enableScheduleSending, type AdminEventActionResult } from './events';
 export { startImpersonation, stopImpersonation } from './impersonation';
 export {

--- a/src/features/admin/actions/quick-send.ts
+++ b/src/features/admin/actions/quick-send.ts
@@ -4,6 +4,7 @@ import { assertAdmin } from '@/lib/supabase/admin';
 import { createServiceClient } from '@/lib/supabase/service';
 import { revalidateOutreach } from '@/features/schedules/services/revalidate-outreach';
 import { sendSchedule } from '@/features/schedules/services/send-schedule';
+import { gateScheduleForSend } from '../services/schedule-send-gate';
 
 export type QuickSendGuest = {
   id: string;
@@ -16,50 +17,6 @@ export type QuickSendGuest = {
 };
 
 export type QuickSendResult = { success: boolean; message: string };
-
-type ScheduleGate = {
-  eventId: string;
-  scheduleTitle: string;
-};
-
-/**
- * Shared gate for both entry points: the schedule has to exist, be a message
- * schedule, and belong to an event with sending enabled. Returns the event id
- * so callers can scope their own guest lookups to it.
- */
-async function gateSchedule(
-  supabase: ReturnType<typeof createServiceClient>,
-  scheduleId: string,
-): Promise<{ ok: true; gate: ScheduleGate } | { ok: false; message: string }> {
-  const { data, error } = await supabase
-    .from('schedules')
-    .select(
-      'id, event_id, schedule_types!inner(name, execution_kind), events!inner(can_create_schedules)',
-    )
-    .eq('id', scheduleId)
-    .maybeSingle();
-  if (error) throw error;
-  if (!data) return { ok: false, message: 'That schedule no longer exists' };
-
-  const scheduleType = (Array.isArray(data.schedule_types)
-    ? data.schedule_types[0]
-    : data.schedule_types) as { name: string; execution_kind: string } | null;
-  if (scheduleType?.execution_kind !== 'message') {
-    return { ok: false, message: 'Call rounds are not sent from here' };
-  }
-
-  const event = (Array.isArray(data.events) ? data.events[0] : data.events) as
-    | { can_create_schedules: boolean }
-    | null;
-  if (!event?.can_create_schedules) {
-    return { ok: false, message: 'Sending is not enabled for this event' };
-  }
-
-  return {
-    ok: true,
-    gate: { eventId: data.event_id, scheduleTitle: scheduleType.name },
-  };
-}
 
 /**
  * The guest list behind the quick-send picker, fetched when the dialog opens
@@ -76,7 +33,7 @@ export async function getQuickSendGuests(
   await assertAdmin();
   const supabase = createServiceClient();
 
-  const gate = await gateSchedule(supabase, scheduleId);
+  const gate = await gateScheduleForSend(supabase, scheduleId);
   if (!gate.ok) return [];
 
   const [guestsResult, deliveriesResult] = await Promise.all([
@@ -130,7 +87,7 @@ export async function sendScheduleToGuest(
   const supabase = createServiceClient();
 
   try {
-    const gate = await gateSchedule(supabase, scheduleId);
+    const gate = await gateScheduleForSend(supabase, scheduleId);
     if (!gate.ok) return { success: false, message: gate.message };
 
     // Scoped to the event the schedule belongs to, so a guest id from another

--- a/src/features/admin/components/batch-send-dialog.tsx
+++ b/src/features/admin/components/batch-send-dialog.tsx
@@ -1,0 +1,420 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { AdminDialogContent } from './admin-dialog';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronDown, Layers } from '@/components/icons';
+import { getBatchSendPlan, sendScheduleBatch } from '../actions/batch-send';
+import { MAX_BATCH_SIZE } from '../utils/batch-send';
+import type { BatchSendPlan } from '../actions/batch-send';
+import type { QuickSendSchedule } from './quick-send-dialog';
+import { cn } from '@/lib/utils';
+
+/** Offered as one-tap batch sizes; anything else is typed into the field. */
+const PRESETS = [50, 100, 250];
+const DEFAULT_BATCH_SIZE = 100;
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+}
+
+function Stat({ label, value, tone }: { label: string; value: number; tone?: 'muted' }) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <span className="text-muted-foreground text-[11.5px]">{label}</span>
+      <span
+        className={cn(
+          'text-[17px] font-semibold tabular-nums',
+          tone === 'muted' && 'text-muted-foreground',
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * One message, part of its audience, now - then the rest later.
+ *
+ * The Operator's case is a WhatsApp sending limit that will not carry the whole
+ * list in one go. So the primary control is a number, not a list: type 100 and
+ * the first hundred still waiting are selected. The list underneath is there to
+ * be checked and adjusted, not to be worked through.
+ *
+ * Which guests are "still waiting" is the server's answer, recomputed after
+ * every batch, so coming back a day later needs no memory of where the last one
+ * stopped.
+ */
+export function BatchSendDialog({ schedules }: { schedules: QuickSendSchedule[] }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [scheduleId, setScheduleId] = useState('');
+  const [plan, setPlan] = useState<BatchSendPlan | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [size, setSize] = useState(String(DEFAULT_BATCH_SIZE));
+  const [deselected, setDeselected] = useState<Set<string>>(() => new Set());
+  const [query, setQuery] = useState('');
+  const [pending, startTransition] = useTransition();
+
+  const remaining = useMemo(() => plan?.remaining ?? [], [plan]);
+
+  /**
+   * The batch is the first N still waiting, minus anyone explicitly unticked.
+   * Unticking therefore shortens the batch rather than pulling the next guest
+   * up into it - a batch of "100" that quietly became 100 different people is
+   * exactly the surprise a sending limit cannot absorb.
+   */
+  const batch = useMemo(() => {
+    const count = Math.min(Number(size) || 0, remaining.length, MAX_BATCH_SIZE);
+    return remaining.slice(0, count).filter((recipient) => !deselected.has(recipient.id));
+  }, [remaining, size, deselected]);
+
+  const batchIds = useMemo(() => new Set(batch.map((recipient) => recipient.id)), [batch]);
+
+  const listed = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return remaining;
+    return remaining.filter(
+      (recipient) =>
+        recipient.name.toLowerCase().includes(term) || recipient.phone.includes(term),
+    );
+  }, [remaining, query]);
+
+  // `wanted` is passed rather than read from state: the caller has just reset
+  // the batch size, and this closure still holds the previous render's value.
+  async function loadPlan(id: string, wanted: number) {
+    setLoading(true);
+    try {
+      const result = await getBatchSendPlan(id);
+      if (result.ok) {
+        setPlan(result.plan);
+        // A short tail is not worth a second visit, so default to sending it all.
+        if (result.plan.remaining.length <= wanted) {
+          setSize(String(result.plan.remaining.length));
+        }
+      } else {
+        setPlan(null);
+        toast.error(result.message);
+      }
+    } catch (error) {
+      console.error('Batch send plan failed:', error);
+      setPlan(null);
+      toast.error('Could not work out who is left to send to');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleScheduleChange(value: string) {
+    setScheduleId(value);
+    setPlan(null);
+    setDeselected(new Set());
+    setQuery('');
+    setSize(String(DEFAULT_BATCH_SIZE));
+    await loadPlan(value, DEFAULT_BATCH_SIZE);
+  }
+
+  function reset() {
+    setScheduleId('');
+    setPlan(null);
+    setDeselected(new Set());
+    setQuery('');
+    setSize(String(DEFAULT_BATCH_SIZE));
+  }
+
+  function toggle(id: string, checked: boolean) {
+    setDeselected((current) => {
+      const next = new Set(current);
+      if (checked) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function send() {
+    if (!scheduleId || !batch.length) return;
+    startTransition(async () => {
+      const result = await sendScheduleBatch(
+        scheduleId,
+        batch.map((recipient) => recipient.id),
+      );
+      if (result.success) {
+        toast.success(result.message);
+        // The dialog stays open on the refreshed plan: the next batch is the
+        // same three taps, and the numbers are the receipt for this one.
+        if (result.plan) {
+          setPlan(result.plan);
+          setSize(String(Math.min(Number(size) || 0, result.plan.remaining.length)));
+        }
+        setDeselected(new Set());
+        setQuery('');
+        router.refresh();
+      } else {
+        toast.error(result.message);
+        if (result.plan) setPlan(result.plan);
+      }
+    });
+  }
+
+  const reachable = plan ? plan.deliveredCount + plan.remaining.length : 0;
+  const done = plan !== null && plan.remaining.length === 0;
+  const claimsOnSend = plan?.status === null && !done;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="shrink-0 text-[13px]">
+          <Layers className="size-[15px]" />
+          Send in batches
+        </Button>
+      </DialogTrigger>
+
+      <AdminDialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Send in batches</DialogTitle>
+          <DialogDescription>
+            Send a message to part of its audience now and the rest later, for when a
+            WhatsApp sending limit will not carry the whole list at once
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="batch-send-schedule">Message</Label>
+            <Select value={scheduleId} onValueChange={handleScheduleChange}>
+              <SelectTrigger id="batch-send-schedule" className="w-full">
+                <SelectValue placeholder="Pick a message" />
+              </SelectTrigger>
+              <SelectContent>
+                {schedules.map((schedule) => (
+                  <SelectItem key={schedule.id} value={schedule.id}>
+                    {schedule.title}
+                    <span className="text-muted-foreground ml-2">
+                      {formatDate(schedule.scheduledDate)}
+                      {schedule.status === 'sent' ? ' · sent' : ''}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {loading && (
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-14 w-full" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+          )}
+
+          {plan && !loading && (
+            <>
+              <div className="bg-muted/40 flex flex-col gap-3 rounded-lg border px-3.5 py-3">
+                <div className="flex gap-3">
+                  <Stat label="Audience" value={plan.audienceCount} />
+                  <Stat label="Already sent" value={plan.deliveredCount} />
+                  <Stat label="Still to go" value={plan.remaining.length} />
+                  <Stat label="No phone" value={plan.unreachableCount} tone="muted" />
+                </div>
+                <div className="bg-background h-1.5 overflow-hidden rounded-full">
+                  <div
+                    className="bg-success h-full rounded-full transition-[width]"
+                    style={{
+                      width: `${reachable ? Math.round((plan.deliveredCount / reachable) * 100) : 0}%`,
+                    }}
+                  />
+                </div>
+              </div>
+
+              {done ? (
+                <Alert>
+                  <AlertTitle>
+                    {reachable === 0
+                      ? 'Nobody to send this to'
+                      : 'Everyone reachable has this message'}
+                  </AlertTitle>
+                  <AlertDescription>
+                    {reachable === 0
+                      ? plan.audienceCount === 0
+                        ? 'No guest record matches this message\u2019s audience'
+                        : `All ${plan.audienceCount} records in the audience have no usable phone number`
+                      : plan.unreachableCount > 0
+                        ? `${plan.unreachableCount} records have no usable phone number and were never sendable`
+                        : 'Nothing is left to send for this message'}
+                  </AlertDescription>
+                </Alert>
+              ) : (
+                <>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="batch-send-size">How many to send now</Label>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        id="batch-send-size"
+                        type="number"
+                        min={1}
+                        max={Math.min(plan.remaining.length, MAX_BATCH_SIZE)}
+                        value={size}
+                        onChange={(event) => setSize(event.target.value)}
+                        className="w-[104px]"
+                      />
+                      {PRESETS.filter((preset) => preset < plan.remaining.length).map((preset) => (
+                        <Button
+                          key={preset}
+                          type="button"
+                          variant={Number(size) === preset ? 'secondary' : 'outline'}
+                          size="sm"
+                          onClick={() => setSize(String(preset))}
+                        >
+                          {preset}
+                        </Button>
+                      ))}
+                      <Button
+                        type="button"
+                        variant={
+                          Number(size) === Math.min(plan.remaining.length, MAX_BATCH_SIZE)
+                            ? 'secondary'
+                            : 'outline'
+                        }
+                        size="sm"
+                        onClick={() =>
+                          setSize(String(Math.min(plan.remaining.length, MAX_BATCH_SIZE)))
+                        }
+                      >
+                        All {Math.min(plan.remaining.length, MAX_BATCH_SIZE)}
+                      </Button>
+                    </div>
+                    <p className="text-muted-foreground text-[12px]">
+                      Takes the first {batch.length} guests still waiting, in guest-list order.
+                      Each batch picks up where the last one stopped
+                      {plan.remaining.length > MAX_BATCH_SIZE
+                        ? ` · ${MAX_BATCH_SIZE} is the most one batch can carry`
+                        : ''}
+                    </p>
+                  </div>
+
+                  <Collapsible>
+                    <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-[12.5px] font-medium">
+                      Review the {batch.length} selected <ChevronDown />
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="mt-2 flex flex-col gap-2">
+                      <Input
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                        placeholder="Search by name or phone"
+                        autoComplete="off"
+                      />
+                      <div className="max-h-56 overflow-y-auto rounded-md border">
+                        {listed.length === 0 ? (
+                          <p className="text-muted-foreground p-3 text-[12.5px]">
+                            No waiting guest matches that search
+                          </p>
+                        ) : (
+                          listed.map((recipient) => {
+                            const inBatch = batchIds.has(recipient.id);
+                            return (
+                              <label
+                                key={recipient.id}
+                                className={cn(
+                                  'flex items-center gap-2.5 border-b px-3 py-2 text-[12.5px] last:border-b-0',
+                                  !inBatch && 'opacity-55',
+                                )}
+                              >
+                                <Checkbox
+                                  checked={inBatch}
+                                  disabled={!inBatch && !deselected.has(recipient.id)}
+                                  onCheckedChange={(value) =>
+                                    toggle(recipient.id, value === true)
+                                  }
+                                />
+                                <span className="min-w-0 flex-1">
+                                  <span className="block truncate font-medium">
+                                    {recipient.name}
+                                  </span>
+                                  <span className="text-muted-foreground block truncate text-[12px]">
+                                    {recipient.phone}
+                                    {recipient.groupName ? ` · ${recipient.groupName}` : ''}
+                                  </span>
+                                </span>
+                              </label>
+                            );
+                          })
+                        )}
+                      </div>
+                      <p className="text-muted-foreground text-[11.5px]">
+                        Guests past the batch size are shown greyed out - raise the number to
+                        include them. Unticking one shortens this batch rather than pulling the
+                        next guest into it
+                      </p>
+                    </CollapsibleContent>
+                  </Collapsible>
+
+                  {claimsOnSend && (
+                    <p className="text-muted-foreground text-[12px]">
+                      This message is still waiting on its scheduled date. The first batch marks
+                      it as sent so the automatic send cannot fire the rest in one go - what is
+                      left stays here until you send it
+                    </p>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </div>
+
+        <DialogFooter className="sm:items-center sm:justify-between">
+          <p className="text-muted-foreground text-[12.5px]">
+            {!plan
+              ? 'Pick a message'
+              : done
+                ? 'Nothing left to send'
+                : `${batch.length} of ${plan.remaining.length} waiting guests`}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              {done ? 'Close' : 'Cancel'}
+            </Button>
+            {!done && (
+              <Button type="button" onClick={send} disabled={pending || !batch.length}>
+                {pending ? 'Sending' : `Send ${batch.length}`}
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </AdminDialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/components/event-workspace-client.tsx
+++ b/src/features/admin/components/event-workspace-client.tsx
@@ -156,7 +156,7 @@ function TimelineRow({ row, eventId }: { row: EventTimelineRow; eventId: string 
               {row.kind === 'call'
                 ? row.roundId ? `${row.calledCount} of ${row.roundGuestCount} guest records called` : audienceLabel
                 : row.status === 'cancelled' ? 'Cancelled by owner'
-                  : `${channelLabel ? `${channelLabel} · ` : ''}${attempted ? `${successful.length} sent${failed.length ? `, ${failed.length} failed` : ''}${includesManualResends ? ' · Includes manual resends' : ''}` : audienceLabel}`}
+                  : `${channelLabel ? `${channelLabel} · ` : ''}${attempted ? `${successful.length} of ${row.audienceCount} sent${failed.length ? `, ${failed.length} failed` : ''}${includesManualResends ? ' · Includes manual resends' : ''}` : audienceLabel}`}
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">

--- a/src/features/admin/components/event-workspace.tsx
+++ b/src/features/admin/components/event-workspace.tsx
@@ -16,6 +16,7 @@ import {
   PublicEventActions,
   WorkspaceSignals,
 } from './event-workspace-client';
+import { BatchSendDialog } from './batch-send-dialog';
 import { QuickSendDialog } from './quick-send-dialog';
 import { RetryButton } from './retry-button';
 import {
@@ -332,6 +333,7 @@ export async function EventOutreachBand({ eventId }: { eventId: string }) {
         className="scroll-mt-20"
         action={(sendableMessages.length > 0 || canPlanCalls) ? (
           <div className="flex shrink-0 gap-2">
+            {sendableMessages.length > 0 && <BatchSendDialog schedules={sendableMessages} />}
             {sendableMessages.length > 0 && <QuickSendDialog schedules={sendableMessages} />}
             {canPlanCalls && <AddCallRoundDialog events={[{ id: event.id, title: event.title, pending: guestSummary.pending, confirmed: guestSummary.confirmed }]} eventId={event.id} />}
           </div>

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -20,6 +20,8 @@ export { Band, BandRow } from './components/band';
 export { RetryButton } from './components/retry-button';
 export { EnableSendingButton } from './components/enable-sending-button';
 export { QuickSendDialog, type QuickSendSchedule } from './components/quick-send-dialog';
+export { BatchSendDialog } from './components/batch-send-dialog';
+export { MAX_BATCH_SIZE } from './utils/batch-send';
 export { BackOfficeNav } from './components/back-office-nav';
 export { StatCards } from './components/stat-cards';
 export { SignalList } from './components/signal-list';

--- a/src/features/admin/services/schedule-send-gate.ts
+++ b/src/features/admin/services/schedule-send-gate.ts
@@ -1,0 +1,64 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type ScheduleSendGate = {
+  eventId: string;
+  /** The schedule type's catalog name - used as the message's label in the UI */
+  scheduleTitle: string;
+  /** null = still planned; the batch send claims it on its first successful batch */
+  status: 'sent' | 'cancelled' | null;
+  targetStatus: 'pending' | 'confirmed' | null;
+};
+
+export type ScheduleSendGateResult =
+  | { ok: true; gate: ScheduleSendGate }
+  | { ok: false; message: string };
+
+/**
+ * Shared gate for every Back Office send entry point: the schedule has to
+ * exist, be a message schedule, and belong to an event with sending enabled.
+ * Returns the event id so callers can scope their own guest lookups to it, and
+ * the targeting fields so a caller that picks its own recipients can reproduce
+ * the audience the engine would have selected.
+ *
+ * Lives in services/ rather than in either action file because quick send and
+ * batch send both need it and it takes its client as a parameter, so it is not
+ * itself a Server Action.
+ */
+export async function gateScheduleForSend(
+  supabase: SupabaseClient,
+  scheduleId: string,
+): Promise<ScheduleSendGateResult> {
+  const { data, error } = await supabase
+    .from('schedules')
+    .select(
+      'id, event_id, status, target_status, schedule_types!inner(name, execution_kind), events!inner(can_create_schedules)',
+    )
+    .eq('id', scheduleId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return { ok: false, message: 'That schedule no longer exists' };
+
+  const scheduleType = (Array.isArray(data.schedule_types)
+    ? data.schedule_types[0]
+    : data.schedule_types) as { name: string; execution_kind: string } | null;
+  if (scheduleType?.execution_kind !== 'message') {
+    return { ok: false, message: 'Call rounds are not sent from here' };
+  }
+
+  const event = (Array.isArray(data.events) ? data.events[0] : data.events) as
+    | { can_create_schedules: boolean }
+    | null;
+  if (!event?.can_create_schedules) {
+    return { ok: false, message: 'Sending is not enabled for this event' };
+  }
+
+  return {
+    ok: true,
+    gate: {
+      eventId: data.event_id,
+      scheduleTitle: scheduleType.name,
+      status: data.status,
+      targetStatus: data.target_status,
+    },
+  };
+}

--- a/src/features/admin/utils/batch-send.ts
+++ b/src/features/admin/utils/batch-send.ts
@@ -1,0 +1,8 @@
+/**
+ * The largest number of guests one batch may carry.
+ *
+ * Lives here rather than beside the Server Action that enforces it: a
+ * `'use server'` module may only export async functions, and the dialog needs
+ * the same number to cap its input.
+ */
+export const MAX_BATCH_SIZE = 500;


### PR DESCRIPTION
## Summary

Adds a new batch send feature that allows operators to send scheduled messages to part of their audience now and the rest later, addressing WhatsApp sending limits that prevent sending entire lists in one go.

## Key Changes

- **New `BatchSendDialog` component** (`src/features/admin/components/batch-send-dialog.tsx`): A comprehensive dialog for selecting a schedule, choosing batch size (with presets of 50/100/250 or custom), reviewing and adjusting the recipient list, and sending. Displays progress stats (audience size, already sent, remaining, unreachable) and prevents sending the same guest twice by tracking deselections.

- **New batch send server actions** (`src/features/admin/actions/batch-send.ts`):
  - `getBatchSendPlan()`: Rebuilds the target audience and splits it into remaining/delivered recipients, fetched when the dialog opens
  - `sendScheduleBatch()`: Sends to a selected subset of guests, marks the schedule as sent on first successful batch (preventing the cron from sending the remainder in one blast), and returns the updated plan for the next batch

- **Shared schedule send gate** (`src/features/admin/services/schedule-send-gate.ts`): Extracted common validation logic (schedule exists, is a message type, event has sending enabled) used by both quick send and batch send, returning event ID and targeting fields needed for audience reconstruction.

- **Batch size constant** (`src/features/admin/utils/batch-send.ts`): `MAX_BATCH_SIZE = 500` shared between the dialog (input cap) and server action (validation).

- **Updated quick send** (`src/features/admin/actions/quick-send.ts`): Refactored to use the new shared `gateScheduleForSend()` instead of its own inline gate logic.

- **UI integration**: Added `BatchSendDialog` to the event workspace and exported new types/actions via the admin feature barrel.

## Notable Implementation Details

- **Deterministic ordering**: Guest list is ordered by name then ID so "the first 100" means the same recipients on every reload and consecutive batches walk the list front-to-back.
- **Deselection model**: Unticking a guest shortens the batch rather than pulling the next guest into it, preventing silent audience changes.
- **First batch claims the schedule**: Only the first successful batch marks `status = 'sent'` to prevent the cron from sending the remainder in one go, preserving the pacing intent.
- **Plan refresh after each batch**: Dialog stays open and immediately shows the updated remaining count, enabling rapid successive batches.
- **Audience reconstruction**: Batch send rebuilds the same audience the send engine would target (respecting `target_status` filter) rather than relying on a pre-computed list, so it stays accurate across multiple batches and operator sessions.

https://claude.ai/code/session_01Hx4cnB911uZLAbqo916bPc