### PR TITLE
Restrict collaborator invites to Gmail addresses only

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1126,7 +1126,8 @@
       "descriptionSuccessEmail": "An invitation email has been sent. You can also share the link manually.",
       "descriptionSuccessLink": "Share this link with the person you invited.",
       "emailLabel": "Email Address",
-      "emailPlaceholder": "partner@example.com",
+      "emailPlaceholder": "partner@gmail.com",
+      "emailHint": "Gmail addresses only (@gmail.com)",
       "roleLabel": "Role",
       "ownerLabel": "Owner",
       "ownerBadge": "Full Access",
@@ -1146,6 +1147,7 @@
       "done": "Done",
       "toast": {
         "emailRequired": "Please enter an email address",
+        "gmailOnly": "Only Gmail addresses (@gmail.com) can be invited",
         "createFailed": "Failed to create invitation",
         "created": "Invitation created",
         "linkCopied": "Link copied to clipboard"

--- a/messages/he.json
+++ b/messages/he.json
@@ -1126,7 +1126,8 @@
       "descriptionSuccessEmail": "נשלח מייל הזמנה. תוכל גם לשתף את הקישור ידנית.",
       "descriptionSuccessLink": "שתף את הקישור הזה עם האדם שהזמנת.",
       "emailLabel": "כתובת מייל",
-      "emailPlaceholder": "partner@example.com",
+      "emailPlaceholder": "partner@gmail.com",
+      "emailHint": "כתובות Gmail בלבד (‎@gmail.com)",
       "roleLabel": "תפקיד",
       "ownerLabel": "בעלים",
       "ownerBadge": "גישה מלאה",
@@ -1146,6 +1147,7 @@
       "done": "סיום",
       "toast": {
         "emailRequired": "אנא הזן כתובת מייל",
+        "gmailOnly": "ניתן להזמין כתובות Gmail בלבד (‎@gmail.com)",
         "createFailed": "יצירת ההזמנה נכשלה",
         "created": "ההזמנה נוצרה",
         "linkCopied": "הקישור הועתק ללוח"

--- a/src/features/collaborate/components/invite-collaborator-dialog.tsx
+++ b/src/features/collaborate/components/invite-collaborator-dialog.tsx
@@ -27,7 +27,7 @@ import { createInvitation } from '../actions';
 import { ScopePicker } from './scope-picker';
 import { cn } from '@/lib/utils';
 import type { GroupApp, GuestApp } from '@/features/guests/schemas';
-import type { CollaboratorRole } from '../schemas';
+import { isGmailAddress, type CollaboratorRole } from '../schemas';
 import posthog from 'posthog-js';
 
 interface InviteCollaboratorDialogProps {
@@ -180,6 +180,7 @@ export function InviteCollaboratorDialog({
 
   // Form state
   const [email, setEmail] = React.useState('');
+  const [emailError, setEmailError] = React.useState<string | null>(null);
   const [role, setRole] = React.useState<CollaboratorRole>('owner');
   const [selectedGroups, setSelectedGroups] = React.useState<string[]>([]);
   const [selectedGuests, setSelectedGuests] = React.useState<string[]>([]);
@@ -189,6 +190,7 @@ export function InviteCollaboratorDialog({
   const resetForm = () => {
     setStep('form');
     setEmail('');
+    setEmailError(null);
     setRole('owner');
     setSelectedGroups([]);
     setSelectedGuests([]);
@@ -198,10 +200,22 @@ export function InviteCollaboratorDialog({
   };
 
   const handleNext = () => {
-    if (!email) {
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail) {
+      setEmailError(t('toast.emailRequired'));
       toast.error(t('toast.emailRequired'));
       return;
     }
+
+    if (!isGmailAddress(trimmedEmail)) {
+      setEmailError(t('toast.gmailOnly'));
+      toast.error(t('toast.gmailOnly'));
+      return;
+    }
+
+    setEmailError(null);
+    setEmail(trimmedEmail);
 
     if (role === 'seating_manager') {
       setStep('scope');
@@ -214,7 +228,7 @@ export function InviteCollaboratorDialog({
     setIsPending(true);
 
     const formData = new FormData();
-    formData.set('email', email);
+    formData.set('email', email.trim());
     formData.set('role', role);
     formData.set('scopeGroups', JSON.stringify(selectedGroups));
     formData.set('scopeGuests', JSON.stringify(selectedGuests));
@@ -290,12 +304,28 @@ export function InviteCollaboratorDialog({
                   <Input
                     id="email"
                     type="email"
+                    inputMode="email"
+                    autoComplete="email"
                     placeholder={t('emailPlaceholder')}
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="pl-9"
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (emailError) setEmailError(null);
+                    }}
+                    aria-invalid={!!emailError}
+                    aria-describedby="email-hint"
+                    className={cn('pl-9', emailError && 'border-destructive')}
                   />
                 </div>
+                <p
+                  id="email-hint"
+                  className={cn(
+                    'text-xs',
+                    emailError ? 'text-destructive' : 'text-muted-foreground',
+                  )}
+                >
+                  {emailError ?? t('emailHint')}
+                </p>
               </div>
 
               <div className="space-y-2">

--- a/src/features/collaborate/schemas/index.ts
+++ b/src/features/collaborate/schemas/index.ts
@@ -129,8 +129,18 @@ export type ScopeItem = z.infer<typeof ScopeItemSchema>;
 // Form / Action Schemas
 // ============================================================================
 
+// Collaborators sign in with Google, so invites are limited to Gmail addresses
+export const GMAIL_EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@gmail\.com$/i;
+
+export const isGmailAddress = (email: string) =>
+  GMAIL_EMAIL_REGEX.test(email.trim());
+
 export const InviteFormSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+  email: z
+    .string()
+    .trim()
+    .email('Please enter a valid email address')
+    .regex(GMAIL_EMAIL_REGEX, 'Only Gmail addresses (@gmail.com) can be invited'),
   role: z.enum(collaboratorRoles, {
     message: 'Please select a role',
   }),


### PR DESCRIPTION
## Summary

Updates the invite collaborator dialog to enforce Gmail-only invitations, since collaborators sign in via Google authentication. Adds client-side and server-side validation, improved UX with real-time error feedback, and updated messaging across supported languages.

## Key Changes

- **Validation**: Added `isGmailAddress()` helper and `GMAIL_EMAIL_REGEX` to `schemas/index.ts` to validate Gmail addresses (`@gmail.com` only)
- **Server-side**: Updated `InviteFormSchema` to include email regex validation alongside existing email format check
- **Client-side validation**: 
  - Added `emailError` state to track validation errors
  - Enhanced `handleNext()` to validate email format and Gmail domain before proceeding
  - Real-time error clearing when user modifies the email input
- **UX improvements**:
  - Added `inputMode="email"` and `autoComplete="email"` attributes for better mobile experience
  - Email input now shows red border (`border-destructive`) when invalid
  - Added persistent error hint below email field that displays validation message or helpful text
  - Improved accessibility with `aria-invalid` and `aria-describedby` attributes
  - Email is trimmed before validation and submission
- **Messaging**:
  - Updated email placeholder from `partner@example.com` to `partner@gmail.com`
  - Added new `emailHint` translation key with Gmail-only guidance
  - Added new `gmailOnly` toast message for validation failures
  - Updated both English and Hebrew message catalogs

## Implementation Details

- Email validation happens in `handleNext()` before form submission, with both toast notification and persistent error state
- Error state is cleared when user starts typing, providing immediate feedback
- Form submission trims whitespace from email to ensure consistency
- Validation uses the same regex pattern on both client and server for consistency

https://claude.ai/code/session_01UNrKDsADE8MiaFFx9t4A3x