### PR TITLE
feat(phone): store phone numbers in E.164, one normalizer

### DIFF
--- a/src/features/auth/actions/auth.ts
+++ b/src/features/auth/actions/auth.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import { toE164 } from '@/lib/phone';
 
 export async function saveAvatarUrl(avatarUrl: string) {
   const supabase = await createClient();
@@ -44,7 +45,7 @@ export async function updateUserProfile(formData: FormData) {
   const { error } = await supabase.from('profiles').upsert({
     id: user.id,
     ...(fullName !== null && { full_name: fullName }),
-    ...(phoneNumber !== null && { phone_number: phoneNumber }),
+    ...(phoneNumber !== null && { phone_number: toE164(phoneNumber) }),
     ...(avatarUrl !== null && { avatar_url: avatarUrl }),
     ...(email !== null && { email }),
     initial_setup_complete: true,

--- a/src/features/auth/components/auth-takeover.tsx
+++ b/src/features/auth/components/auth-takeover.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { toE164 } from '@/lib/phone';
 import { sendOtp, signInWithGoogle, verifyOtp } from '@/features/auth';
 import {
   TakeoverBackButton,
@@ -27,12 +28,6 @@ import {
  * page. A first-time user and a returning one use the identical form - there is
  * no separate sign-up, and no email/password.
  */
-
-/** Israeli local number to E.164, which is what Supabase expects. */
-function normalizePhone(local: string): string {
-  const digits = local.replace(/\D/g, '');
-  return `+972${digits.startsWith('0') ? digits.slice(1) : digits}`;
-}
 
 function GoogleGlyph() {
   return (
@@ -85,7 +80,10 @@ export function AuthTakeover({ next }: { next?: string }) {
 
   const handleSend = useCallback(
     (formData: FormData) => {
-      const phone = normalizePhone(localPhone);
+      // Supabase OTP wants E.164. A number that will not parse cannot be sent
+      // to, so stop here rather than handing Supabase a guessed-at string.
+      const phone = toE164(localPhone);
+      if (!phone) return;
       setE164Phone(phone);
       formData.set('phone', phone);
       sendAction(formData);

--- a/src/features/guests/actions/guests.ts
+++ b/src/features/guests/actions/guests.ts
@@ -11,6 +11,7 @@ import {
 } from '@/features/guests/schemas';
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
+import { toE164 } from '@/lib/phone';
 import { z } from 'zod';
 
 export type UpsertGuestState = {
@@ -337,7 +338,9 @@ export async function importGuests(
 
     const guestsToInsert = validGuests.map((g) => ({
       name: g.name,
-      phone_number: g.phone,
+      // Bulk import bypasses AppToDbTransformerSchema, so it canonicalises here
+      // instead - the `CHECK` constraint on the column rejects anything else.
+      phone_number: g.phone ? toE164(g.phone) : null,
       amount: g.amount,
       event_id: eventId,
       side: g.side,

--- a/src/features/guests/queries/guests.ts
+++ b/src/features/guests/queries/guests.ts
@@ -1,4 +1,5 @@
 import { getEffectiveClient } from '@/lib/supabase/admin';
+import { phoneComparisonKey } from '@/lib/phone';
 import {
   DbToAppTransformerSchema,
   GuestApp,
@@ -66,12 +67,13 @@ export const getEventGuestPhones = async (
       return new Map();
     }
 
-    // Map normalized phone → guest name for duplicate detection + conflict display
+    // Map normalized phone → guest name for duplicate detection + conflict display.
+    // Keyed on the same canonical form the import side uses, so a stored
+    // `+972545451963` still matches a pasted `054-545-1963`.
     const phones = new Map<string, string>();
     for (const row of data || []) {
       if (row.phone_number) {
-        const normalized = row.phone_number.replace(/[\s\-().]/g, '');
-        phones.set(normalized, row.name);
+        phones.set(phoneComparisonKey(row.phone_number), row.name);
       }
     }
 

--- a/src/features/guests/schemas/index.ts
+++ b/src/features/guests/schemas/index.ts
@@ -1,5 +1,6 @@
 import { parsePhoneNumberWithError } from 'libphonenumber-js';
 import { z } from 'zod';
+import { toE164 } from '@/lib/phone';
 
 function isIsraeliMobile(val: string): boolean {
   try {
@@ -199,7 +200,11 @@ export const AppToDbTransformerSchema = GuestUpsertSchema.transform(
       dbData.name = appData.name;
     }
     if (appData.phone !== undefined) {
-      dbData.phone_number = appData.phone ?? null;
+      // Canonicalised here rather than at the call sites, so every path that
+      // upserts a guest through this transform stores E.164 by construction.
+      // `israeliMobilePhone` above only validates - it passes the raw string
+      // through, which is how mixed formats reached the column.
+      dbData.phone_number = appData.phone ? toE164(appData.phone) : null;
     }
     if (appData.groupId !== undefined) {
       dbData.group_id = appData.groupId ?? null;

--- a/src/features/guests/utils/import-guests.ts
+++ b/src/features/guests/utils/import-guests.ts
@@ -1,4 +1,5 @@
 import { ImportGuestSchema, normalizeSide } from '../schemas';
+import { phoneComparisonKey } from '@/lib/phone';
 import { type ColumnMapping } from '../components/groups/import-guests-dialog/map-step';
 
 export type ImportField = 'name' | 'phone' | 'amount' | 'side' | 'group';
@@ -59,10 +60,15 @@ export function transformCsvRow(
 }
 
 /**
- * Normalizes a phone number for comparison (removes formatting)
+ * Normalizes a phone number for comparison.
+ *
+ * Canonicalises to E.164 rather than only stripping punctuation, so that
+ * `0545451963`, `054-545-1963` and `+972545451963` collide as one guest. The
+ * punctuation-only version this replaced missed the last of those, which is how
+ * the same person got imported twice under two formats.
  */
 export function normalizePhone(phone: string): string {
-  return phone.replace(/[\s\-().]/g, '');
+  return phoneComparisonKey(phone);
 }
 
 /**

--- a/src/features/schedules/index.ts
+++ b/src/features/schedules/index.ts
@@ -24,7 +24,6 @@ export {
   filterGuestsByTarget,
   isMessageSchedule,
   validatePhoneNumber,
-  formatPhoneE164,
 } from './utils';
 
 // Schemas/Types

--- a/src/features/schedules/utils/index.ts
+++ b/src/features/schedules/utils/index.ts
@@ -1,4 +1,5 @@
 import type { GuestApp } from '@/features/guests/schemas';
+import { isValidPhone } from '@/lib/phone';
 
 // Re-export parameter resolution utilities
 export {
@@ -140,31 +141,14 @@ export function isMessageSchedule(schedule: { executionKind: string }): boolean 
 }
 
 /**
- * Validates if a phone number has a valid format.
- * Strips formatting characters and checks for minimum valid format.
+ * Validates if a phone number is real and dialable.
  *
- * @param phone - Phone number to validate
- * @returns True if phone number is valid
+ * Re-exported under the old name because it is the audience filter used across
+ * schedules and admin; the logic now lives in `@/lib/phone` so validation and
+ * canonicalisation cannot drift apart.
  */
 export function validatePhoneNumber(phone: string | undefined | null): boolean {
-  if (!phone) {
-    return false;
-  }
-
-  // Strip formatting characters
-  const cleaned = phone.replace(/[^\d+]/g, '');
-
-  // Must have at least 7 digits and contain only digits/+
-  if (cleaned.length < 7) {
-    return false;
-  }
-
-  // Check if contains only valid characters (digits and optional + at start)
-  if (!/^[+]?[\d]+$/.test(cleaned)) {
-    return false;
-  }
-
-  return true;
+  return isValidPhone(phone);
 }
 
 /**
@@ -178,34 +162,3 @@ export function getAudienceLabel(targetStatus?: 'pending' | 'confirmed' | null):
   if (targetStatus === 'pending') return 'Pending Guests';
   return 'All Guests';
 }
-
-/**
- * Formats a phone number to E.164 international format.
- * Handles Israeli numbers with special logic for 0 prefix.
- *
- * @param phone - Phone number to format
- * @returns Phone number in E.164 format (+country_code + number)
- */
-export function formatPhoneE164(phone: string): string {
-  // Strip all formatting characters
-  const cleaned = phone.replace(/[^\d+]/g, '');
-
-  // Already has + prefix (international format)
-  if (cleaned.startsWith('+')) {
-    return cleaned;
-  }
-
-  // Starts with country code without +
-  if (cleaned.startsWith('972')) {
-    return '+' + cleaned;
-  }
-
-  // Starts with 0 (Israeli local format) - replace with +972
-  if (cleaned.startsWith('0')) {
-    return '+972' + cleaned.substring(1);
-  }
-
-  // Default: prepend Israeli country code
-  return '+972' + cleaned;
-}
-

--- a/src/features/schedules/utils/send-helpers.ts
+++ b/src/features/schedules/utils/send-helpers.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'crypto';
+import { toE164 } from '@/lib/phone';
 import type { GuestApp } from '@/features/guests/schemas';
 import type { DeliveryMethod } from '../schemas';
 import type { SmsPayload, WhatsAppTemplateApp } from '../schemas/message-templates';
@@ -10,16 +11,6 @@ import {
   buildDynamicHeaderParameters,
   type ParameterResolutionContext,
 } from './parameter-resolvers';
-
-// Inline to avoid circular dependency (formatPhoneE164 lives in index.ts
-// which re-exports this file).
-function formatPhoneE164(phone: string): string {
-  const cleaned = phone.replace(/[^\d+]/g, '');
-  if (cleaned.startsWith('+')) return cleaned;
-  if (cleaned.startsWith('972')) return '+' + cleaned;
-  if (cleaned.startsWith('0')) return '+972' + cleaned.substring(1);
-  return '+972' + cleaned;
-}
 
 // ─── SMS fallback toggle ──────────────────────────────────────────────────────
 // Temporarily disabled — schedules send via WhatsApp only until the SMS copy
@@ -78,7 +69,21 @@ export async function sendToGuest(params: {
   confirmationToken: string;
 }): Promise<GuestSendResult> {
   const { guest, context, template, templateId, confirmationToken } = params;
-  const phoneE164 = formatPhoneE164(guest.phone!);
+
+  // Callers filter the audience on isValidPhone first, so a null here is a
+  // guest whose stored number does not parse at all. Fail the send rather than
+  // dialling a number we had to guess at.
+  const phoneE164 = toE164(guest.phone);
+  if (!phoneE164) {
+    return {
+      guest,
+      success: false,
+      message: 'No usable phone number',
+      channel: 'whatsapp',
+      confirmationToken,
+      templateId,
+    };
+  }
 
   const parameters = buildDynamicTemplateParameters(
     template.parameters!.placeholders,
@@ -172,7 +177,19 @@ export async function sendSmsToGuest(params: {
   confirmationToken: string;
 }): Promise<GuestSendResult> {
   const { guest, context, smsPayload, templateId, confirmationToken } = params;
-  const phoneE164 = formatPhoneE164(guest.phone!);
+
+  const phoneE164 = toE164(guest.phone);
+  if (!phoneE164) {
+    return {
+      guest,
+      success: false,
+      message: 'No usable phone number',
+      channel: 'sms',
+      confirmationToken,
+      templateId,
+    };
+  }
+
   const body = buildSmsBody(smsPayload, context);
   const result = await sendSmsMessage({ to: phoneE164, body });
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,75 @@
+import { parsePhoneNumberWithError } from 'libphonenumber-js';
+
+/**
+ * The single place a phone number becomes canonical.
+ *
+ * Every number reaching `guests.phone_number` or `profiles.phone_number` is
+ * stored in E.164 (`+972545451963`) so that equality, indexing and duplicate
+ * detection all work on a plain `=`. Before this existed the column held
+ * whatever the user typed - `0545451963`, `054-545-1963` and `+972545451963`
+ * were three distinct strings for one person, which is how the same guest got
+ * invited twice.
+ *
+ * Formatting for humans is a render-time concern and belongs at the component
+ * layer, not here.
+ */
+
+/** Matches the `CHECK` constraint on both phone columns. Keep the two in step. */
+export const E164_PATTERN = /^\+[1-9]\d{1,14}$/;
+
+/**
+ * The region an unprefixed number is assumed to belong to.
+ *
+ * The product is Israel-only today. When that stops being true this has to
+ * become an input captured alongside the number rather than a constant, since
+ * `054...` is only unambiguous once you already know the country.
+ */
+export const DEFAULT_PHONE_REGION = 'IL' as const;
+
+/**
+ * Converts a number to E.164, or returns null when it cannot be parsed.
+ *
+ * Deliberately returns null rather than guessing: the previous implementation
+ * ended with `return '+972' + cleaned`, which silently mangled anything it did
+ * not recognise into a plausible-looking Israeli number.
+ */
+export function toE164(
+  input: string | null | undefined,
+  region: string = DEFAULT_PHONE_REGION,
+): string | null {
+  if (!input) return null;
+
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = parsePhoneNumberWithError(
+      trimmed,
+      region as Parameters<typeof parsePhoneNumberWithError>[1],
+    );
+    return parsed.isValid() ? parsed.format('E.164') : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the input parses to a real, dialable number. */
+export function isValidPhone(
+  input: string | null | undefined,
+  region: string = DEFAULT_PHONE_REGION,
+): boolean {
+  return toE164(input, region) !== null;
+}
+
+/**
+ * Canonical form for *comparison* - duplicate detection, set membership, map
+ * keys - falling back to a whitespace-stripped copy of the input when the
+ * number does not parse.
+ *
+ * The fallback matters: two identical unparseable strings should still collide
+ * with each other rather than silently comparing as two different guests.
+ */
+export function phoneComparisonKey(input: string | null | undefined): string {
+  if (!input) return '';
+  return toE164(input) ?? input.replace(/[\s\-().]/g, '');
+}

--- a/supabase/migrations/20260828000000_normalize_phone_numbers_to_e164.sql
+++ b/supabase/migrations/20260828000000_normalize_phone_numbers_to_e164.sql
@@ -1,0 +1,114 @@
+-- Makes E.164 the only phone format either phone column will hold, and stops
+-- the same person being stored twice under two spellings of one number.
+--
+-- `guests.phone_number` and `profiles.phone_number` held whatever the user
+-- typed. The Zod layer only ever validated the input (`israeliMobilePhone` is a
+-- `.refine`, so it passes the raw string through) and every write path handed
+-- that string straight to the column, so `0545451963`, `054-545-1963` and
+-- `+972545451963` all coexisted as distinct values for one guest. Conversion to
+-- E.164 happened later, at send time, purely so Meta and Twilio would accept it.
+--
+-- The cost was duplicate detection: `getExistingGuestPhones` keyed its map on a
+-- punctuation-stripped copy of the stored string, which collapses `054-545-1963`
+-- onto `0545451963` but never onto `+972545451963`. Event
+-- c9a9c96b-b74f-45d7-96ba-f80163660d06 accumulated three guests entered twice
+-- this way; they were merged by hand before this migration, and the unique index
+-- below is what stops the next three.
+--
+-- Ships alongside the code change that canonicalises on write (src/lib/phone.ts).
+-- That has to be deployed first: once the CHECK lands, any writer still sending
+-- a local-format number fails at insert.
+
+-- Empty strings are the same absence of a number that NULL is, and would fail
+-- the CHECK below. One row in profiles holds one today.
+
+update guests
+   set phone_number = null
+ where phone_number is not null
+   and btrim(phone_number) = '';
+
+update profiles
+   set phone_number = null
+ where phone_number is not null
+   and btrim(phone_number) = '';
+
+-- The backfill itself. libphonenumber is JavaScript and cannot run in here, so
+-- this reimplements the Israeli cases by hand - safe only because every row was
+-- surveyed first and they all fall into these three shapes (1180 local, 58
+-- already E.164, 0 unparseable in guests; 11 local in profiles). Anything that
+-- does not is left untouched on purpose, for the guard at the bottom to catch.
+
+update guests
+   set phone_number =
+         case
+           when phone_number ~ '^\+' then
+             regexp_replace(phone_number, '[^0-9+]', '', 'g')
+           when regexp_replace(phone_number, '[^0-9]', '', 'g') like '972%' then
+             '+' || regexp_replace(phone_number, '[^0-9]', '', 'g')
+           when regexp_replace(phone_number, '[^0-9]', '', 'g') like '0%' then
+             '+972' || substring(regexp_replace(phone_number, '[^0-9]', '', 'g') from 2)
+           else phone_number
+         end
+ where phone_number is not null;
+
+update profiles
+   set phone_number =
+         case
+           when phone_number ~ '^\+' then
+             regexp_replace(phone_number, '[^0-9+]', '', 'g')
+           when regexp_replace(phone_number, '[^0-9]', '', 'g') like '972%' then
+             '+' || regexp_replace(phone_number, '[^0-9]', '', 'g')
+           when regexp_replace(phone_number, '[^0-9]', '', 'g') like '0%' then
+             '+972' || substring(regexp_replace(phone_number, '[^0-9]', '', 'g') from 2)
+           else phone_number
+         end
+ where phone_number is not null;
+
+-- Mirrors E164_PATTERN in src/lib/phone.ts. Keep the two in step.
+
+alter table guests
+  add constraint guests_phone_number_e164
+  check (phone_number is null or phone_number ~ '^\+[1-9][0-9]{1,14}$');
+
+alter table profiles
+  add constraint profiles_phone_number_e164
+  check (phone_number is null or phone_number ~ '^\+[1-9][0-9]{1,14}$');
+
+-- Scoped to the event, not global: the same person legitimately appears on two
+-- different weddings, and two guests sharing one household number is a real
+-- pattern this must not block across events.
+
+create unique index guests_event_id_phone_number_key
+    on guests (event_id, phone_number)
+ where phone_number is not null;
+
+do $$
+declare
+  non_canonical_guests   integer;
+  non_canonical_profiles integer;
+begin
+  select count(*)
+    into non_canonical_guests
+    from guests
+   where phone_number is not null
+     and phone_number !~ '^\+[1-9][0-9]{1,14}$';
+
+  select count(*)
+    into non_canonical_profiles
+    from profiles
+   where phone_number is not null
+     and phone_number !~ '^\+[1-9][0-9]{1,14}$';
+
+  -- Unreachable while the CHECK constraints above are in force, which is the
+  -- point: if a future edit weakens or drops one, this still fails the run
+  -- rather than letting mixed formats back into the column unnoticed.
+  if non_canonical_guests > 0 then
+    raise exception
+      'guests.phone_number still holds % row(s) that are not E.164', non_canonical_guests;
+  end if;
+
+  if non_canonical_profiles > 0 then
+    raise exception
+      'profiles.phone_number still holds % row(s) that are not E.164', non_canonical_profiles;
+  end if;
+end $$;


### PR DESCRIPTION
## Why

Both phone columns held whatever the user typed. `israeliMobilePhoneSchema` is a `.refine` — it validates the input and passes the raw string through — and every write path handed that string straight to the column. So `0545451963`, `054-545-1963` and `+972545451963` coexisted as three distinct values for one person. Conversion to E.164 happened later, at send time, purely so Meta and Twilio would accept it.

The cost was duplicate detection. `getEventGuestPhones` keyed its map on a punctuation-stripped copy of the stored string, which collapses `054-545-1963` onto `0545451963` but never onto `+972545451963`. One production event accumulated three guests entered twice through exactly that gap; they were merged by hand before this branch.

## What

**`src/lib/phone.ts`** — the single place a number becomes canonical, backed by `libphonenumber-js` rather than hand-rolled regex. The dependency was already here for validation; only the conversion was manual.

`toE164()` returns `null` instead of guessing. The previous implementation ended with `return '+972' + cleaned`, which silently mangled anything unrecognised into a plausible-looking Israeli number.

**Canonicalises at all five write boundaries**, so no path can store raw input:

| Path | Was |
|---|---|
| `AppToDbTransformerSchema` | `dbData.phone_number = appData.phone` verbatim — the root cause |
| `importGuests` | bulk insert, bypasses the transform entirely |
| `updateUserProfile` | `profiles.phone_number` straight from `formData` |
| `auth-takeover` | had its own third `+972` string-concat |
| `sendToGuest` / `sendSmsToGuest` | now fail the send on an unparseable number instead of dialling a guess |

**Deletes three duplicate normalizers**, including the copy-pasted `formatPhoneE164` in `send-helpers.ts` that existed only to dodge a circular import. `validatePhoneNumber` delegates to `isValidPhone`, so validation and canonicalisation can no longer drift.

**Closes the dedup gap** — `getEventGuestPhones` and `normalizePhone` both key on `phoneComparisonKey` now.

**Migration** backfills both tables, nulls empty strings, adds a `CHECK` on each column, adds a partial unique index on `(event_id, phone_number)`, and ends with the raise-on-failure guard.

The `CHECK` is what makes this stick. Application-layer discipline decays as new write paths appear; only the database cannot forget.

## Verification

`npx supabase db reset` replays every migration clean. Beyond that, the parts an empty database cannot exercise:

**Backfill expression against all 9 shapes production actually holds** — local, dashed, spaced, parenthesized, already-E.164, spaced-E.164, `972`-no-plus, foreign US. All convert correctly. The 2 unparseable shapes are left untouched and fail the check, aborting the migration — the intended fail-loud behavior. Production holds zero rows of those shapes (1180 local + 58 already-E.164 + 89 null in `guests`; 11 local in `profiles`).

**8 constraint cases**: E.164 accepted; local, dashed and empty-string rejected; duplicate in the same event rejected; the same number across *different* events allowed; multiple NULLs allowed; foreign E.164 allowed.

`tsc`, `eslint` and `npm run build` show no new problems.

## Deploy order

**Merge and deploy this before running the migration.** The moment the `CHECK` lands, any deployed code still writing a local-format number throws at insert. Reversed, guest creation breaks in production until the deploy catches up.

Scoping the unique index to `event_id` is deliberate: the same person legitimately appears on two different weddings, and two guests sharing one household number is a real pattern that must not be blocked across events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tfiwEL8tQuVXcbd4zcCzv