### PR TITLE
Stop paying an auth round trip per admin render

### DIFF
--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -36,21 +36,32 @@ export async function getEffectiveClient() {
 
 export const assertAdmin = cache(async function assertAdmin(): Promise<string> {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
-  if (!user) redirect('/login');
+  // getClaims rather than getUser, for the reason updateSession already spells
+  // out in ./middleware.ts: getUser is a blocking round trip to /auth/v1/user,
+  // and this runs on every Back Office render before the page can stream a
+  // single byte. The project signs with ES256, so getClaims verifies the token
+  // locally against a cached JWKS and only reaches the network to refresh.
+  //
+  // The weaker guarantee - a verified signature rather than a live server check
+  // - costs nothing here, because the is_admin read below is a real query
+  // against the row. A token whose user has been deleted finds no profile and
+  // redirects; an account whose admin flag was revoked reads false and
+  // redirects. Only the token's own expiry is taken on trust.
+  const { data } = await supabase.auth.getClaims();
+  const userId = data?.claims.sub ?? null;
+
+  if (!userId) redirect('/login');
 
   const { data: profile } = await supabase
     .from('profiles')
     .select('is_admin')
-    .eq('id', user.id)
+    .eq('id', userId)
     .single();
 
   if (!profile?.is_admin) redirect('/app');
 
-  return user.id;
+  return userId;
 });
 
 export async function assertNotImpersonating(): Promise<string | null> {


### PR DESCRIPTION
assertAdmin called auth.getUser(), a blocking request to /auth/v1/user, and every Back Office query and layout calls assertAdmin. cache() makes it one trip per request rather than one per caller, but it is a serial one, sitting ahead of anything the page can stream - so it lands before the RSC response's first byte, which is what the client router waits on before it can commit a navigation and update the URL.

updateSession already made exactly this change, and says why: the project signs with ES256, so getClaims verifies the token locally against a cached JWKS and only reaches the network to refresh. The reasoning was never carried across to admin.ts, which is the copy on the Back Office's hot path.

getClaims gives a weaker guarantee - a verified signature rather than a live server check - and that costs nothing here, because the is_admin read below it is a real query against the row. A token whose user has been deleted finds no profile and redirects; an account whose admin flag was revoked reads false and redirects. Only the token's own expiry is taken on trust.

Does not touch the profiles read in updateSession, which is a separate call to make: runtime logs show it is paid once per prefetched link, not once per navigation - ten /admin/events/<id> prefetches inside one second, each running the full middleware - but dropping it is an auth-posture change and wants its own decision. The other 13 getUser() call sites, the [eventId] layout among them, are the same fix on the owner app's hot path and are left for their own pass.

Verified: tsc --noEmit, eslint, next build all clean. Not yet exercised against a live session - this is on the auth path, so it wants one login and one /admin load on a preview before it merges.


Claude-Session: https://claude.ai/code/session_01GT15rsiL95snNhT7rxzAB7