### PR TITLE
fix(guests): skip duplicate phones on import instead of failing the batch

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -690,6 +690,8 @@
         "successHeading": "Import Successful!",
         "successMessage": "{count} guests have been added to your event.",
         "successMessageSingular": "{count} guest has been added to your event.",
+        "skippedMessage": "{count} guests were already on the event and were skipped.",
+        "skippedMessageSingular": "{count} guest was already on the event and was skipped.",
         "failedHeading": "Import Failed"
       }
     },

--- a/messages/he.json
+++ b/messages/he.json
@@ -690,6 +690,8 @@
         "successHeading": "הייבוא הצליח!",
         "successMessage": "{count} אורחים נוספו לאירוע שלך.",
         "successMessageSingular": "אורח {count} נוסף לאירוע שלך.",
+        "skippedMessage": "{count} אורחים כבר היו באירוע ולכן דולגו.",
+        "skippedMessageSingular": "אורח {count} כבר היה באירוע ולכן דולג.",
         "failedHeading": "הייבוא נכשל"
       }
     },

--- a/src/features/guests/actions/guests.ts
+++ b/src/features/guests/actions/guests.ts
@@ -11,7 +11,8 @@ import {
 } from '@/features/guests/schemas';
 import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
-import { toE164 } from '@/lib/phone';
+import { toE164, phoneComparisonKey } from '@/lib/phone';
+import { getEventGuestPhones } from '@/features/guests/queries';
 import { z } from 'zod';
 
 export type UpsertGuestState = {
@@ -187,6 +188,14 @@ export type ImportGuestsState = {
   message: string;
   importedCount?: number;
   failedCount?: number;
+  /**
+   * Rows dropped because their number already belongs to a guest on this event,
+   * or to an earlier row in the same file. Distinct from `failedCount`, which
+   * counts rows that did not survive schema validation.
+   */
+  skippedCount?: number;
+  /** Names behind `skippedCount`, for a summary the host can act on. */
+  skippedNames?: string[];
 };
 
 export async function importGuests(
@@ -246,6 +255,47 @@ export async function importGuests(
       };
     }
 
+    // Duplicate phones are flagged in the import dialog, but that check runs
+    // against a snapshot taken when the dialog opened and the dialog is not the
+    // only way into this action. Since `guests_event_id_phone_number_key` makes
+    // a duplicate fail the whole insert, one stale row would otherwise cost the
+    // host every good row in the file. Drop the duplicates and import the rest.
+    const existingPhones = await getEventGuestPhones(eventId);
+    const seenInBatch = new Set<string>();
+    const skippedNames: string[] = [];
+    const guestsToImport: ValidGuest[] = [];
+
+    for (const guest of validGuests) {
+      // The unique index is partial (`where phone_number is not null`), so
+      // guests with no number never collide with each other.
+      if (!guest.phone) {
+        guestsToImport.push(guest);
+        continue;
+      }
+
+      const phoneKey = phoneComparisonKey(guest.phone);
+      if (existingPhones.has(phoneKey) || seenInBatch.has(phoneKey)) {
+        skippedNames.push(guest.name);
+        continue;
+      }
+
+      seenInBatch.add(phoneKey);
+      guestsToImport.push(guest);
+    }
+
+    if (guestsToImport.length === 0) {
+      return {
+        success: false,
+        message:
+          skippedNames.length === 1
+            ? 'That guest is already on this event'
+            : `All ${skippedNames.length} guests are already on this event`,
+        failedCount: errors.length,
+        skippedCount: skippedNames.length,
+        skippedNames,
+      };
+    }
+
     const supabase = await createClient();
 
     // Resolve group names → group_id, auto-creating missing groups.
@@ -260,7 +310,7 @@ export async function importGuests(
       string,
       { name: string; side: 'bride' | 'groom' | null }
     >();
-    for (const g of validGuests) {
+    for (const g of guestsToImport) {
       if (g.group) {
         const k = groupKey(g.group, g.side);
         if (!desiredGroups.has(k))
@@ -336,7 +386,7 @@ export async function importGuests(
       }
     }
 
-    const guestsToInsert = validGuests.map((g) => ({
+    const guestsToInsert = guestsToImport.map((g) => ({
       name: g.name,
       // Bulk import bypasses AppToDbTransformerSchema, so it canonicalises here
       // instead - the `CHECK` constraint on the column rejects anything else.
@@ -353,19 +403,30 @@ export async function importGuests(
 
     if (error) {
       console.error('Supabase insert error:', error);
+      // 23505 is unique_violation. The filter above removes every duplicate we
+      // can see, so reaching here means one was created between that read and
+      // this insert - a concurrent import or a guest added in another tab.
+      // Name the cause rather than reporting a generic save failure.
       return {
         success: false,
-        message: 'Unable to save guests',
+        message:
+          error.code === '23505'
+            ? 'One of these guests was just added by someone else - reopen the import to try again'
+            : 'Unable to save guests',
       };
     }
 
     revalidatePath(`/app/${eventId}/guests`);
 
+    const importedCount = guestsToImport.length;
+
     return {
       success: true,
-      message: `Successfully imported ${validGuests.length} guest${validGuests.length === 1 ? '' : 's'}`,
-      importedCount: validGuests.length,
+      message: `Successfully imported ${importedCount} guest${importedCount === 1 ? '' : 's'}`,
+      importedCount,
       failedCount: errors.length,
+      skippedCount: skippedNames.length,
+      skippedNames,
     };
   } catch (error) {
     console.error('Import guests error:', error);

--- a/src/features/guests/components/groups/import-guests-dialog/summary-step.tsx
+++ b/src/features/guests/components/groups/import-guests-dialog/summary-step.tsx
@@ -69,6 +69,13 @@ export function SummaryStep({
               ? t('import.summary.successMessageSingular', { count: result.importedCount ?? 0 })
               : t('import.summary.successMessage', { count: result.importedCount ?? 0 })}
           </p>
+          {(result.skippedCount ?? 0) > 0 && (
+            <p className="text-muted-foreground mt-1 text-sm">
+              {result.skippedCount === 1
+                ? t('import.summary.skippedMessageSingular', { count: result.skippedCount })
+                : t('import.summary.skippedMessage', { count: result.skippedCount ?? 0 })}
+            </p>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
Follow-up to #343, which added `guests_event_id_phone_number_key`.

## The problem that index created

Postgres rejects the **entire** `insert()` on a unique violation. So a single duplicate phone number in a CSV cost the host every good row in the file — reported as a flat `"Unable to save guests"` with no indication which row caused it. Before the index, that same import silently succeeded and created duplicates.

Duplicate detection ran **only in the import dialog**, against an `existingPhones` map snapshotted when the dialog opened. Three ways a duplicate still reached the insert:

- The snapshot goes stale while the host maps columns and fixes rows
- The dialog is not the only way into this Server Action
- Server-side, `importGuests` ran `ImportGuestSchema.safeParse` per row — format only, never uniqueness

## The fix

Filter server-side before inserting: drop rows whose number already belongs to a guest on the event or to an earlier row in the same file, import the rest, and report what was skipped.

- **Rows without a phone always import.** The unique index is partial (`where phone_number is not null`), so they never collide with each other.
- **Keyed on `phoneComparisonKey`**, the same canonical form the dialog uses since #343, so `054-545-1963` and `+972545451963` are recognised as one guest rather than two.
- **Filtering happens before group resolution**, so a skipped guest doesn't cause an empty group to be auto-created.
- **All-duplicates gets its own message** rather than falling through to a generic failure.
- **23505 is still caught** as a backstop — a duplicate can be created between the read and the insert by a concurrent import or a guest added in another tab. That now reports what actually happened instead of a generic save failure.

`skippedCount` / `skippedNames` are added to `ImportGuestsState`, deliberately distinct from `failedCount` (rows that failed schema validation), and the summary step shows the skipped line under the success message. Copy added to both `en` and `he`.

## Verification

`phoneComparisonKey` — the linchpin, since the filter is only as good as its collision behavior:

| Case | Result |
|---|---|
| One guest, seven spellings (`0545451963`, `054-545-1963`, `054 545 1963`, `(054) 545-1963`, `+972545451963`, `+972 54 545 1963`, `972545451963`) | All collide → `+972545451963` |
| Two genuinely different numbers | Stay distinct |
| Two identical unparseable strings | Still collide |
| Two different unparseable strings | Stay distinct |

That last pair matters: the fallback path must not merge unrelated junk into one key, nor let two copies of the same junk through as separate guests.

`tsc`, `eslint` and `npm run build` all clean.

## Not covered

The underlying double-insert bug is still unfound — the שירה רובין duplicates in production had `created_at` identical to the microsecond, which is one import operation inserting the same row twice, not a stale-snapshot problem. This change means such a batch now fails loudly on 23505 rather than silently duplicating, but it doesn't explain the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tfiwEL8tQuVXcbd4zcCzv