### PR TITLE
Read the Operator's profile row once per request

### DIFF
--- a/src/features/admin/queries/operator.ts
+++ b/src/features/admin/queries/operator.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { assertAdmin } from '@/lib/supabase/admin';
-import { createServiceClient } from '@/lib/supabase/service';
+import { assertAdmin, getOperatorEmail } from '@/lib/supabase/admin';
 
 export type OperatorIdentity = {
   email: string;
@@ -10,14 +9,12 @@ export type OperatorIdentity = {
 };
 
 export async function getOperatorIdentity(): Promise<OperatorIdentity> {
-  const userId = await assertAdmin();
-  const supabase = createServiceClient();
+  await assertAdmin();
 
-  const { data } = await supabase
-    .from('profiles')
-    .select('email')
-    .eq('id', userId)
-    .single();
+  // The email comes off the row assertAdmin has already read on this request,
+  // so this adds no round trip of its own. It used to be a second read of the
+  // same row through the service client.
+  const email = await getOperatorEmail();
 
   // A Back Office that does not say which database it is reading is one
   // mis-click away from an Operator acting on the wrong data.
@@ -26,5 +23,5 @@ export async function getOperatorIdentity(): Promise<OperatorIdentity> {
     ? 'Local'
     : 'Production';
 
-  return { email: data?.email ?? 'Unknown operator', environment };
+  return { email: email ?? 'Unknown operator', environment };
 }

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -34,7 +34,28 @@ export async function getEffectiveClient() {
   return { supabase, impersonation };
 }
 
-export const assertAdmin = cache(async function assertAdmin(): Promise<string> {
+type OperatorProfile = {
+  /** null when the request carries no valid session at all. */
+  userId: string | null;
+  email: string | null;
+  isAdmin: boolean;
+};
+
+/**
+ * The Operator's own profile row, read once per request.
+ *
+ * Every Back Office render used to read this one row twice - assertAdmin for
+ * is_admin, getOperatorIdentity for email - for the same user, on the same
+ * request, and updateSession reads it a third time before either of them runs.
+ * That is fixed cost ahead of anything a page can stream: measured against
+ * production, /admin/configuration, which is seven lines of static JSX and
+ * makes no queries of its own, is as slow as /admin/users. The queries a page
+ * runs are not what makes the Back Office feel slow; this chain is.
+ *
+ * Both callers now share one query through cache(), so asking for is_admin and
+ * asking for the email together cost what asking for either used to.
+ */
+const readOperator = cache(async function readOperator(): Promise<OperatorProfile> {
   const supabase = await createClient();
 
   // getClaims rather than getUser, for the reason updateSession already spells
@@ -44,25 +65,47 @@ export const assertAdmin = cache(async function assertAdmin(): Promise<string> {
   // locally against a cached JWKS and only reaches the network to refresh.
   //
   // The weaker guarantee - a verified signature rather than a live server check
-  // - costs nothing here, because the is_admin read below is a real query
-  // against the row. A token whose user has been deleted finds no profile and
-  // redirects; an account whose admin flag was revoked reads false and
-  // redirects. Only the token's own expiry is taken on trust.
+  // - costs nothing here, because the read below is a real query against the
+  // row. A token whose user has been deleted finds no profile and redirects; an
+  // account whose admin flag was revoked reads false and redirects. Only the
+  // token's own expiry is taken on trust.
   const { data } = await supabase.auth.getClaims();
   const userId = data?.claims.sub ?? null;
+  if (!userId) return { userId: null, email: null, isAdmin: false };
 
-  if (!userId) redirect('/login');
-
+  // Read through the user's own client rather than the service client: the
+  // profiles_select_own_or_shared_event policy already covers `id = auth.uid()`
+  // for the whole row, so nothing here needs RLS bypassed.
   const { data: profile } = await supabase
     .from('profiles')
-    .select('is_admin')
+    .select('email, is_admin')
     .eq('id', userId)
     .single();
 
-  if (!profile?.is_admin) redirect('/app');
+  return { userId, email: profile?.email ?? null, isAdmin: !!profile?.is_admin };
+});
+
+export const assertAdmin = cache(async function assertAdmin(): Promise<string> {
+  const { userId, isAdmin } = await readOperator();
+
+  // The two failures stay distinct: no session means "sign in", a session
+  // without the flag means "you are not an Operator", and they land in
+  // different places. A missing profile row reads as the second, which is what
+  // it was before this shared a query with getOperatorIdentity.
+  if (!userId) redirect('/login');
+  if (!isAdmin) redirect('/app');
 
   return userId;
 });
+
+/**
+ * The Operator's email address, free to whoever has already called assertAdmin
+ * on this request - it comes off the same cached row.
+ */
+export async function getOperatorEmail(): Promise<string | null> {
+  const { email } = await readOperator();
+  return email;
+}
 
 export async function assertNotImpersonating(): Promise<string | null> {
   const impersonation = await getImpersonation();


### PR DESCRIPTION
assertAdmin read profiles for is_admin and getOperatorIdentity read the same row, for the same user, on the same request, for email. Both are on the Back Office's fixed path - the layout calls getOperatorIdentity and every query calls assertAdmin - so both land before a page can stream.

Measured against production rather than guessed at. /admin/configuration is seven lines of static JSX and makes no queries at all; it costs TTFB 0.40s and 0.85-1.83s total, which is what /admin/users costs with four queries behind it. The queries are not what makes the Back Office slow: profiles holds 13 rows, events 11, event_collaborators 13, and the index query this was going to be blamed on runs in 0.216ms. The fixed auth chain ahead of them is the cost.

readOperator() is one cache()d read returning email and is_admin together, and the two callers share it. getOperatorIdentity also drops the service client on the way past: profiles_select_own_or_shared_event already covers `id = auth.uid()` for the whole row, so nothing here needs RLS bypassed to read one's own email.

Behaviour is unchanged, including which redirect fires. No session still means /login and a session without the flag still means /app, and a missing profile row still reads as the second of those.

Leaves the third read of that row, in updateSession, alone. Dropping it is an auth-posture change rather than a refactor, and it wants a decision rather than a commit - it is also the largest remaining piece, since runtime logs show it is paid once per prefetched link.

Verified: tsc --noEmit, eslint, next build all clean. Not exercised against a live session; this is on the auth path, so it wants one login and one /admin load on a preview before it merges.


Claude-Session: https://claude.ai/code/session_01GT15rsiL95snNhT7rxzAB7