### PR TITLE
Split the Back Office event page before it grows

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,9 @@ a family of five arriving as one entry is one Guest Record with an amount of fiv
 Kululu is priced per Guest Record, not per Guest. Say "guest record" whenever the
 quantity being counted is billable; say "guest" when talking about human beings attending.
 
+Both the Owner and an **Operator** can create and delete Guest Records. Because the row
+is the billing unit, either act changes what the Owner pays.
+
 ## Seating Plan
 
 An Event's arrangement of Guest Records among Tables and of those Tables relative to one
@@ -97,8 +100,10 @@ The Owner watches a Call Round; they never run one.
 How one Guest's call ended: no answer, confirmed, or declined. Confirmed and declined
 carry straight through to the Guest's RSVP.
 
-Distinct from the RSVP itself: a Guest can be confirmed without any Call Outcome, having
-answered on their own after the round began.
+Distinct from the RSVP itself: a Guest can be confirmed without any Call Outcome - by
+answering on their own, by the Owner recording it, or by an Operator setting it directly
+in the Back Office. A Call Outcome is one of several ways an RSVP arrives, not the
+definition of one.
 
 ## Round Completion
 
@@ -137,7 +142,11 @@ and should not appear in routes, code, or copy.
 ## Operator
 
 A member of Kululu staff working in the Back Office. The Operator runs Call Rounds, sends
-messages by hand, and watches for things going wrong.
+messages by hand, watches for things going wrong, and maintains the guest list - correcting
+a Guest Record, and adding or deleting one.
+
+An Operator changing a guest is Kululu acting as itself. An Operator who needs the *Owner*
+to be the author of a change impersonates instead.
 
 Distinct from an **Owner**: an Owner plans their own Event, an Operator works across every
 Event. An Operator may impersonate an Owner to see exactly what they see, but the two roles

--- a/docs/adr/0006-back-office-event-page-is-tabbed-with-no-overview-tab.md
+++ b/docs/adr/0006-back-office-event-page-is-tabbed-with-no-overview-tab.md
@@ -1,0 +1,125 @@
+# 6. The Back Office event page is tabbed, and has no Overview tab
+
+Date: 2026-08-28
+
+## Status
+
+Accepted
+
+## Context
+
+`/admin/events/[eventId]` renders five bands down one page: Signals, Identity,
+then either a draft explanation or Guest list, Outreach timeline and Event
+details. That is tolerable today. Only one band, the outreach timeline, grows
+without bound, and nobody has complained about scrolling.
+
+The page is being split anyway, for two reasons that have nothing to do with its
+current length.
+
+**Room to grow.** Two surfaces are coming that cannot be bands. A per-guest
+table is the larger one: the Back Office holds counts but no guest rows, so an
+Operator answering an Owner's question about one guest has to impersonate to see
+it. Payment data is the other. Neither fits under a heading in a stack.
+
+**Task separation.** The jobs an Operator does on one Event are genuinely
+different work, and mixing them means every job pays the cost of the others
+being on screen.
+
+Load time is explicitly *not* a reason. Each band already streams behind its own
+Suspense boundary and the queries are small.
+
+There is also a mismatch worth naming, because it is what shapes the answer. The
+page was built triage-first: Signals lead, and a Signal link scrolls to the row
+that needs work. But the most frequent reason an Operator opens an Event is none
+of that. It is to check on an account, with no specific fix in mind. The page
+answers the rarer question first.
+
+## Decision
+
+Signals and Identity are **pinned above a tab bar** and are the health check.
+Below the bar are three tabs, each a work surface: **Guests**, **Outreach**,
+**Billing**. Guests is the default.
+
+**There is no Overview tab.** Once Signals and Identity are pinned, an Overview
+tab has nothing left of its own. Anything put in it would be a digest of the
+other three, which means two places to change when one number changes, and two
+places to disagree while data streams in. The pinned header is the overview.
+
+The tab bar carries **counts and no severity**: `Guests 240`, `Outreach 6`, in
+muted type. Facts, not judgements. Signals remain the only element on the page
+permitted to say something is wrong, which preserves the existing rule that
+destructive styling means overdue work or failed delivery and nothing else. An
+Operator reads account health off the bar in one glance and clicks only to act,
+which is what the most common job actually needs.
+
+### The tab lives in the URL, as a route segment
+
+```
+admin/events/[eventId]/
+  (workspace)/
+    layout.tsx        pinned header + tab bar
+    page.tsx          Guests, the default
+    loading.tsx
+    outreach/page.tsx
+    billing/page.tsx
+  rounds/[roundId]/   outside the group: no tab chrome
+```
+
+`/admin/events/[eventId]` **is** the Guests tab. There is no redirect to
+`/guests` and no `/guests` segment, so one view never has two URLs.
+
+Segments rather than `?tab=`, even though the events index sets the house
+convention for URL state with plain `searchParams`. A search param would put the
+whole page behind one `loading.tsx`, re-render the pinned header on every tab
+change, and forfeit per-tab code splitting. Segments give each tab its own
+loading boundary, so switching tabs paints the frame immediately and streams the
+contents, and they let a Signal deep-link name its destination exactly:
+`/outreach#schedule-123` switches tab and then anchors.
+
+The `(workspace)` group exists so the call round at `rounds/[roundId]` escapes
+the tab chrome. Somebody is on the phone looking at that page; it stays focused.
+
+### A Draft Event has no tab bar
+
+A Draft renders the compact identity and the incomplete-onboarding explanation,
+and nothing else. `/outreach` and `/billing` on a draft call `notFound()`.
+
+This is deliberately an *absent* view rather than an empty one. ADR-0003 says
+Events exist before they are complete, and `CONTEXT.md` says a Draft "is not yet
+a workspace". Three tabs that each say "nothing here" would contradict that in
+the one place an Operator would read it.
+
+## Consequences
+
+**The `@topbar` slot has to learn the new segments.** `resolveAdminTopBar` falls
+through to `{ kind: 'search' }` on anything it does not recognise, so without a
+change every tab silently loses its breadcrumb and shows the operator search
+instead. The breadcrumb deliberately stays `Events / event` and does not name
+the tab: the tab bar is directly below it, already saying where you are.
+
+**The layout must not await anything before returning.** The pinned header and
+the tab labels paint on the first frame; the identity, the signals and the tab
+*counts* each stream in behind their own boundary. This is the same constraint
+the `@topbar` route already documents at length, and for the same reason. A
+count that blocks the bar would make every tab change feel slower than the page
+it replaced.
+
+**The "Event details" band is dissolved rather than moved.** Short code and
+collaborators are already in the pinned header, "Created" becomes a line there,
+and sending state belongs to Billing. No band survives merely to have somewhere
+to live.
+
+**Signal links change kind.** They were same-page scrolls; they are now
+navigations. A Signal on the Guests tab pointing at a failed delivery moves the
+Operator to another route before anchoring.
+
+**Billing ships nearly empty.** It holds the sending gate and the Enable sending
+action that exist today, and waits for real payment data. That is accepted: the
+slot is the point, and a tab holding one true fact is honest, where an Overview
+tab holding four restated ones would not be.
+
+**If we change our mind.** Collapsing back to one page means deleting three route
+files and re-stacking the bands. Nothing about the data or the queries changes,
+so the reversal is a day's work. The part that does not reverse cheaply is the
+URLs: `/outreach` and `/billing` will be in Operators' history, in bookmarks and
+in Signal links, and would need redirects rather than deletion.

--- a/docs/adr/0007-the-back-office-is-a-second-writer-of-the-guest-list.md
+++ b/docs/adr/0007-the-back-office-is-a-second-writer-of-the-guest-list.md
@@ -1,0 +1,107 @@
+# 7. The Back Office is a second writer of the guest list
+
+Date: 2026-08-28
+
+## Status
+
+Accepted
+
+## Context
+
+The guest list has always belonged to the Owner. Three things write an RSVP
+today, and `guests.rsvp_change_source` names each of them:
+
+- `guest` - the Guest answered the link themselves
+- `manual` - the Owner typed it in
+- `admin_call` - a Kululu Operator recorded a Call Outcome during a Call Round
+
+The Back Office appears in that list exactly once, and only through a Call
+Round. That was not an accident of implementation. It meant every
+Operator-set RSVP was attributable to a specific call, on a specific date, to a
+specific Guest, and the "where the answers came from" table on the Event page
+could be trusted because each row named a real writer.
+
+Membership of the list - which Guest Records exist at all - had only one writer.
+That matters more than it looks, because `CONTEXT.md` defines the Guest Record
+as **the unit of billing**. Kululu is priced per Guest Record. A row is money.
+
+The Back Office is now getting a per-guest table, and the question is what an
+Operator may do from it.
+
+The pull toward writing is real. An Operator on the phone with an Owner, or
+looking at a guest whose number is malformed and whose sends will therefore all
+fail, currently has one option: impersonate the Owner and fix it in the
+product. That works, but it is a lens designed for seeing, being used for
+doing.
+
+## Decision
+
+The Back Office guest table is a **full second writer of the guest list**.
+An Operator may edit any field on a Guest Record, and may add and delete Guest
+Records.
+
+Editing happens in a **`?guest=<id>` sheet**, not in table cells. The table
+stays a plain fast read surface. The sheet is where the fields, the notes, and
+that Guest's call history across every round sit together, and its URL is
+shareable between Operators. This reuses the `?user=` sheet pattern already
+tuned on the Users index, including its Suspense shape.
+
+Deletion is a hard delete mirroring the Owner's own `deleteGuest`, behind a
+confirm that states the billing consequence in words.
+
+### `rsvp_change_source` gains a fourth value
+
+An Operator setting an RSVP with no call behind it is none of the three existing
+writers. Writing `manual` would make the page report "Owner typed it in" about
+something the Owner did not do. Writing `admin_call` would claim a call that
+never happened, and would leave an `admin_call` RSVP with no `call_log` behind
+it.
+
+So the CHECK constraint on `guests.rsvp_change_source` widens to admit
+`admin_edit`, rendered as **"Operator typed it in"**. This is the same shape of
+change as `20260530000002_add_admin_call_rsvp_source.sql`, which added
+`admin_call` for the same kind of reason.
+
+The provenance table therefore keeps telling the truth, and gains an honest
+fourth row.
+
+## Consequences
+
+**The billing unit has two writers and no reconciliation between them.** This is
+the real cost and it is accepted rather than solved. If an Owner disputes their
+guest record count, there is no record of whether an Operator added or removed
+rows. The mitigations are weak on purpose, because the alternative was to keep
+the Back Office read-only and lose the capability:
+
+- Provenance makes RSVP writes visible in aggregate, so bypassing a Call Round
+  is at least *measurable* on the page itself
+- Add and delete are not visible anywhere, in aggregate or otherwise
+
+If that becomes a support problem, the fix is an activity log, deliberately
+deferred here. A narrower `rsvp_changed_by` actor column was considered and
+rejected as a half-measure: it would answer "who" for RSVP only, and only for
+the most recent change, while saying nothing about the rows that stopped
+existing.
+
+**"Operator typed it in" is the number to watch.** If it grows relative to
+"Operator on the phone", the Call Round has stopped being how Kululu touches
+guests, and this decision is quietly changing what the service is. Today's
+distribution is 170 answers from calls against 62 from the Owner, out of 1,324
+Guest Records, so the new row starts at zero and any movement is legible.
+
+**Impersonation stops being the only doing-path.** It remains available and
+remains the honest way to act *as the Owner*. The distinction sharpens: an
+Operator impersonates when the Owner should be the author of the change, and
+uses the Back Office when Kululu is.
+
+**Three glossary entries were wrong and are amended.** `Operator` listed the
+work an Operator does and no longer covered it. `Call Outcome` said a Guest could
+be confirmed without a Call Outcome only by answering themselves, and there is
+now a second way. `Guest Record` defined the billing unit without saying who may
+create and destroy one.
+
+**If we change our mind.** Narrowing back to read-only is cheap in code: remove
+the mutations, keep the sheet as a detail view. The `admin_edit` rows already
+written stay as accurate history of a period when the rule was different, which
+is exactly why the fourth provenance value is worth the migration even if the
+capability is later withdrawn.

--- a/docs/design/back-office-event-workspace-brief.md
+++ b/docs/design/back-office-event-workspace-brief.md
@@ -1,0 +1,249 @@
+# Back Office Event Workspace - Design Brief
+
+**For:** Claude Design
+**Date:** 2026-08-28
+**Product:** Kululu - event guest management for the Israeli market
+
+This is an **internal staff tool**, not the product. Nothing from
+[`onboarding-flow-brief.md`](./onboarding-flow-brief.md) carries over: no Hebrew,
+no RTL, no marketing brand, no emotional payoff.
+
+Read [`back-office-overview-brief.md`](./back-office-overview-brief.md) first.
+Its art direction, its density, and its rule about severity colour are binding
+here and are not restated in full. This page lives inside the shell that brief
+designed.
+
+Vocabulary is binding and defined in [`CONTEXT.md`](../../CONTEXT.md) - in
+particular **Operator**, **Signal**, **Guest** vs **Guest Record**, **Call
+Round**, **Call Outcome**, and **Free to Plan, Pay to Send**. The structural
+decisions behind this brief are
+[ADR-0006](../adr/0006-back-office-event-page-is-tabbed-with-no-overview-tab.md)
+and
+[ADR-0007](../adr/0007-the-back-office-is-a-second-writer-of-the-guest-list.md);
+this brief does not overrule them.
+
+---
+
+## 1. What we are designing
+
+The Back Office page for a single Event, at `/admin/events/[eventId]`. It is
+being restructured from one long stack of bands into a pinned header plus three
+tabs.
+
+Design:
+
+1. **The workspace shell** - pinned Signals, pinned Identity, the tab bar
+2. **The Guests tab** - the summary rollup and, new, a per-guest table
+3. **The guest sheet** - the detail and edit surface behind a table row
+4. **The Billing tab** - the commercial state of the Event
+5. **The Draft Event** state, which has no tabs at all
+
+The **Outreach tab inherits** its contents. See section 8.
+
+## 2. Who this is for
+
+Three or four Kululu staff, on a laptop. They know the product intimately.
+
+The most common reason one of them opens an Event is **to check on an account** -
+is this event healthy, did they pay, are they actually using it - with no
+specific fix in mind. The second most common is to answer a question an Owner
+just asked on the phone, usually about one guest.
+
+Both of those are lookups. Design for reading first and acting second. That is a
+change of emphasis from the Overview, which is a queue.
+
+## 3. The thesis
+
+**The header answers "how is this event", the tabs answer "show me".**
+
+Everything needed to judge the account at a glance is pinned above the tab bar
+and never moves: what the event is, when it is, who owns it, and whether
+anything is broken. The tabs below are where an Operator goes to look something
+up or do something.
+
+This is why **there is no Overview tab**. Once the header carries the health
+check, an Overview tab could only restate the other three, and two places that
+say the same number will eventually say different numbers. Do not add one back.
+
+The tab bar carries counts, and counts only: `Guests 240`, `Outreach 6`. Muted,
+tabular, no dots and no colour. The counts exist so the account check finishes
+without a click. **Signals are the only element on this page allowed to say
+something is wrong** - the Overview brief's severity rule applies unchanged, and
+a badge on a tab would be a second, competing vocabulary for trouble.
+
+## 4. The pinned header
+
+Two things, in this order, above the tab bar.
+
+**Signals**, when there are any. Omitted entirely when there are none - this is
+the common case and it should read as good news, not as a missing element. There
+are exactly three kinds and they are defined in `CONTEXT.md`: Overdue Schedule,
+Failed Delivery, Stale Call Round. Each links to the row that needs work, which
+is now a navigation to another tab rather than a scroll.
+
+**Identity.** Event title, event type, hosts, event date with countdown, venue,
+ceremony and reception times, the `/r/{shortCode}` copy and open actions, the
+Owner with email and phone, collaborators, and a quiet "Created" line.
+
+Identity is doing more work than before: the dissolved "Event details" band has
+moved into it. Resist letting it become a form. It is a masthead, and an
+Operator reads it in about three seconds.
+
+The header stays put while tabs change. It is the one stable thing on the page.
+
+## 5. The Guests tab (default)
+
+Two parts, top to bottom.
+
+**The rollup**, which exists today and is good: guest records against actual
+guests, the RSVP distribution bar, the phone-quality warning, and the "where the
+answers came from" provenance table. Keep the Guest Record versus Guest
+distinction rigorous - it is the billing unit and the brief that muddles it
+causes real support cost.
+
+Provenance gains a **fourth row, "Operator typed it in"**, which will read as
+zero for a while. Design the table so a new row does not look like an error.
+
+**The table**, which is new and is the reason for the whole restructure. One row
+per Guest Record: name, phone, RSVP, amount, group. Search by name or phone and
+a filter by RSVP status, both URL-backed, paginated at 50 to match the events
+index.
+
+The table is **read-only**. No interactive cells, no inline editing, no row
+actions. It is a fast surface for scanning and it should feel like one.
+
+## 6. The guest sheet
+
+A row click opens a sheet at `?guest=<id>`. It is the only place a Guest Record
+is edited, and the only place notes and call history appear.
+
+It holds: the editable fields (RSVP, phone, amount, notes, group), this Guest's
+call history across every Call Round, and a delete action.
+
+Two things need real care.
+
+**Delete is destructive on a billable row.** A Guest Record is the unit Kululu
+charges for. Deleting one reduces what the Owner is billed, and there is no
+audit trail behind it. The confirm has to say that in plain words rather than
+asking "are you sure".
+
+**An Operator editing an RSVP here is not the same act as a Call Outcome.** It
+is recorded as a distinct provenance source precisely because it bypasses the
+Call Round. The sheet should not make the two feel interchangeable, and the call
+history sitting right there is part of how it does that.
+
+Reuse the `?user=` sheet on the Users index as the pattern. It is already tuned
+so the table behind it does not flash on row click.
+
+## 7. The Billing tab
+
+The commercial state of the Event, and today that is nearly empty: whether
+sending is enabled, and the action to enable it.
+
+`CONTEXT.md` calls this boundary **Free to Plan, Pay to Send** - planning is
+free, payment unlocks outbound reach. That is what this tab is about, and the
+copy should sound like it rather than like an admin settings screen.
+
+Design it honestly at its current size. A tab holding one true fact and one
+action is fine. Do not pad it with placeholder metrics for payment data that
+does not exist yet, but do leave it obvious where that data will sit.
+
+An Event without sending enabled is not broken and must not look it. Five of the
+ten published events are in that state right now. It is the normal condition of
+an event that has not paid yet.
+
+## 8. Outreach: inherit, do not redesign
+
+The outreach timeline works and is staying as it is. Design **one artboard**
+showing it correctly framed by the new shell, and no more.
+
+It encodes rules that took real work and that a fresh design would quietly lose:
+cancelled rows stay at their original planned date and say only "Cancelled by
+owner"; a failure summary counts persisted delivery rows rather than today's
+guest list; a row with mixed origins is labelled "Includes manual resends"; Add
+call round is hidden until sending is enabled and an eligible audience exists.
+The full contract is in
+[`back-office-events-brief.md`](./back-office-events-brief.md).
+
+If the new shell makes something in the timeline sit badly, say so. Do not fix
+it by redrawing it.
+
+## 9. The Draft Event
+
+A Draft Event has **no tab bar**. It gets the compact identity and one
+explanation that onboarding was never finished, and that is the whole page.
+
+This is an absent workspace, not an empty one. A Draft has no guest list and no
+schedules, and `CONTEXT.md` is explicit that it is not yet a workspace. Three
+tabs each saying "nothing here" would contradict that.
+
+The Operator's question on this page is only ever "is this worth a call", so the
+Owner's phone number and the step onboarding stopped at are the two things that
+matter.
+
+## 10. States to design
+
+- Guests tab, populated, healthy event
+- Guests tab, no guest list yet
+- Guests tab, search or filter matching nothing (distinct from the above)
+- Guest sheet, open and editable, with call history
+- Guest sheet, delete confirm
+- Billing, sending not enabled
+- Billing, sending enabled
+- Draft Event
+- A tab whose data failed to load, with the header still intact
+- Loading: the shell painted, counts and contents still streaming
+
+That last one is not decoration. The layout paints the header and tab labels on
+the first frame and streams everything else, so the half-loaded state is a state
+an Operator sees on every navigation. It should look composed, not skeletal.
+
+## 11. The data is real and it is small
+
+Production today: 10 published Events, 1 Draft, 1,324 Guest Records, 1,956
+actual guests. The average Event has 189 Guest Records and the largest has 306.
+89 Guest Records have no usable phone number. 37 have notes. 5 of the 10
+published Events have sending enabled.
+
+RSVP provenance across all Guest Records: 747 still pending, 328 answered by the
+Guest, 170 from Operators on the phone, 62 typed by an Owner, 17 from before
+source tracking.
+
+Two consequences. A guest table has to look right at 189 rows, which is more
+than a screen and far less than a scroll problem. And the provenance table has
+to hold five rows where one of them is zero.
+
+## 12. Out of scope
+
+- The events index at `/admin/events`
+- The Call Round calling surface at `rounds/[roundId]`, which deliberately sits
+  outside this shell and keeps its own focused layout
+- The outreach timeline's interior, per section 8
+- An activity or audit log. It was considered and deferred
+- Any Signal beyond the three defined ones
+- Dark mode
+- Mobile. Laptop-first
+- Anything in the Owner-facing app
+
+## 13. Deliverable
+
+`.dc.html` artboards in the Claude Design project, matching the convention used
+by the Overview work:
+
+1. Shell - pinned Signals and Identity, tab bar with counts
+2. Guests tab, populated
+3. Guests tab, no guest list yet
+4. Guest sheet, open and editable
+5. Outreach tab - inherited, framed only
+6. Billing, sending not enabled
+7. Billing, sending enabled
+8. Draft Event, no tab bar
+9. Loading and failed states
+
+## 14. Open input
+
+**How much weight Identity carries.** It absorbed the dissolved Event details
+band and now holds event facts, owner, collaborators, guest page actions and a
+created date, all while staying pinned above every tab. It may be too heavy to
+sit on screen permanently. If it is, the interesting question is what drops out
+of it rather than what shrinks, and this brief wants that answer.


### PR DESCRIPTION
Decide the structure ahead of the per-guest table and payment data, neither of which fits in another stacked band. Records two ADRs, a Claude Design brief, and the glossary changes the decisions falsified.


Claude-Session: https://claude.ai/code/session_014tfiwEL8tQuVXcbd4zcCzv